### PR TITLE
refactor: smart all the Things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options(-Wimplicit-fallthrough -Wmove)
 endif ()
 
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/bigobj>")
+
 # Find packages.
 find_package(OpenSSL 3.0.0 REQUIRED COMPONENTS Crypto)
 find_package(simdutf CONFIG REQUIRED)

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -7,7 +7,6 @@
 
 #include "bed.h"
 #include "configmanager.h"
-#include "container.h"
 #include "game.h"
 #include "housetile.h"
 #include "spells.h"
@@ -89,7 +88,7 @@ bool Actions::registerLuaEvent(Action* event)
 	return false;
 }
 
-ReturnValue Actions::canUse(const Player* player, const Position& pos)
+ReturnValue Actions::canUse(const std::shared_ptr<const Player>& player, const Position& pos)
 {
 	if (pos.x != 0xFFFF) {
 		const Position& playerPos = player->getPosition();
@@ -104,7 +103,8 @@ ReturnValue Actions::canUse(const Player* player, const Position& pos)
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Actions::canUse(const Player* player, const Position& pos, const Item* item)
+ReturnValue Actions::canUse(const std::shared_ptr<const Player>& player, const Position& pos,
+                            const std::shared_ptr<const Item>& item)
 {
 	Action* action = getAction(item);
 	if (action) {
@@ -113,7 +113,8 @@ ReturnValue Actions::canUse(const Player* player, const Position& pos, const Ite
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Actions::canUseFar(const Creature* creature, const Position& toPos, bool checkLineOfSight, bool checkFloor)
+ReturnValue Actions::canUseFar(const std::shared_ptr<const Creature>& creature, const Position& toPos,
+                               bool checkLineOfSight, bool checkFloor)
 {
 	if (toPos.x == 0xFFFF) {
 		return RETURNVALUE_NOERROR;
@@ -135,7 +136,7 @@ ReturnValue Actions::canUseFar(const Creature* creature, const Position& toPos, 
 	return RETURNVALUE_NOERROR;
 }
 
-Action* Actions::getAction(const Item* item)
+Action* Actions::getAction(const std::shared_ptr<const Item>& item)
 {
 	if (item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		auto it = uniqueItemMap.find(item->getUniqueId());
@@ -160,9 +161,10 @@ Action* Actions::getAction(const Item* item)
 	return g_spells->getRuneSpell(item->getID());
 }
 
-ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey)
+ReturnValue Actions::internalUseItem(const std::shared_ptr<Player>& player, const Position& pos, uint8_t index,
+                                     const std::shared_ptr<Item>& item, bool isHotkey)
 {
-	if (Door* door = item->getDoor()) {
+	if (const auto& door = item->getDoor()) {
 		if (!door->canUse(player)) {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
@@ -183,7 +185,7 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 		}
 	}
 
-	if (BedItem* bed = item->getBed()) {
+	if (const auto& bed = item->getBed()) {
 		if (!bed->canUse(player)) {
 			if (!bed->getHouse()) {
 				return RETURNVALUE_YOUCANNOTUSETHISBED;
@@ -203,17 +205,16 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 		return RETURNVALUE_NOERROR;
 	}
 
-	if (Container* container = item->getContainer()) {
+	if (auto container = item->getContainer()) {
 		uint32_t corpseOwner = container->getCorpseOwner();
 		if (corpseOwner != 0 && !player->canOpenCorpse(corpseOwner)) {
 			return RETURNVALUE_YOUARENOTTHEOWNER;
 		}
 
 		// depot container
-		if (DepotLocker* depot = container->getDepotLocker()) {
-			DepotLocker& myDepotLocker = player->getDepotLocker();
-			myDepotLocker.setParent(depot->getParent()->getTile());
-			container = &myDepotLocker;
+		if (const auto& depot = container->getDepotLocker()) {
+			container = player->getDepotLocker();
+			container->setParent(depot->getParent()->getTile());
 		}
 
 		// open/close container
@@ -245,7 +246,8 @@ ReturnValue Actions::internalUseItem(Player* player, const Position& pos, uint8_
 	return RETURNVALUE_CANNOTUSETHISOBJECT;
 }
 
-static void showUseHotkeyMessage(Player* player, const Item* item, uint32_t count)
+static void showUseHotkeyMessage(const std::shared_ptr<Player>& player, const std::shared_ptr<const Item>& item,
+                                 uint32_t count)
 {
 	const ItemType& it = Item::items[item->getID()];
 	if (!it.showCount) {
@@ -258,7 +260,8 @@ static void showUseHotkeyMessage(Player* player, const Item* item, uint32_t coun
 	}
 }
 
-bool Actions::useItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey)
+bool Actions::useItem(const std::shared_ptr<Player>& player, const Position& pos, uint8_t index,
+                      const std::shared_ptr<Item>& item, bool isHotkey)
 {
 	int32_t cooldown = getNumber(ConfigManager::ACTIONS_DELAY_INTERVAL);
 	player->setNextAction(OTSYS_TIME() + cooldown);
@@ -274,8 +277,8 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, Item* 
 	}
 
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		if (const auto tile = item->getTile()) {
-			if (const auto houseTile = tile->getHouseTile()) {
+		if (const auto& tile = item->getTile()) {
+			if (const auto& houseTile = tile->getHouseTile()) {
 				if (!item->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
 					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 					return false;
@@ -298,8 +301,9 @@ bool Actions::useItem(Player* player, const Position& pos, uint8_t index, Item* 
 	return true;
 }
 
-bool Actions::useItemEx(Player* player, const Position& fromPos, const Position& toPos, uint8_t toStackPos, Item* item,
-                        bool isHotkey, Creature* creature /* = nullptr*/)
+bool Actions::useItemEx(const std::shared_ptr<Player>& player, const Position& fromPos, const Position& toPos,
+                        uint8_t toStackPos, const std::shared_ptr<Item>& item, bool isHotkey,
+                        const std::shared_ptr<Creature>& creature /* = nullptr*/)
 {
 	int32_t cooldown = getNumber(ConfigManager::EX_ACTIONS_DELAY_INTERVAL);
 	player->setNextAction(OTSYS_TIME() + cooldown);
@@ -324,8 +328,8 @@ bool Actions::useItemEx(Player* player, const Position& fromPos, const Position&
 	}
 
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		if (const auto tile = item->getTile()) {
-			if (const auto houseTile = tile->getHouseTile()) {
+		if (const auto& tile = item->getTile()) {
+			if (const auto& houseTile = tile->getHouseTile()) {
 				if (!item->getTopParent()->getCreature() && !houseTile->getHouse()->isInvited(player)) {
 					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 					return false;
@@ -350,7 +354,7 @@ Action::Action(LuaScriptInterface* interface) :
     Event(interface), function(nullptr), allowFarUse(false), checkFloor(true), checkLineOfSight(true)
 {}
 
-ReturnValue Action::canExecuteAction(const Player* player, const Position& toPos)
+ReturnValue Action::canExecuteAction(const std::shared_ptr<const Player>& player, const Position& toPos)
 {
 	if (allowFarUse) {
 		return g_actions->canUseFar(player, toPos, checkLineOfSight, checkFloor);
@@ -358,7 +362,9 @@ ReturnValue Action::canExecuteAction(const Player* player, const Position& toPos
 	return g_actions->canUse(player, toPos);
 }
 
-Thing* Action::getTarget(Player* player, Creature* targetCreature, const Position& toPosition, uint8_t toStackPos) const
+std::shared_ptr<Thing> Action::getTarget(const std::shared_ptr<Player>& player,
+                                         const std::shared_ptr<Creature>& targetCreature, const Position& toPosition,
+                                         uint8_t toStackPos) const
 {
 	if (targetCreature) {
 		return targetCreature;
@@ -366,8 +372,9 @@ Thing* Action::getTarget(Player* player, Creature* targetCreature, const Positio
 	return g_game.internalGetThing(player, toPosition, toStackPos, 0, STACKPOS_USETARGET);
 }
 
-bool Action::executeUse(Player* player, Item* item, const Position& fromPosition, Thing* target,
-                        const Position& toPosition, bool isHotkey)
+bool Action::executeUse(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+                        const Position& fromPosition, const std::shared_ptr<Thing>& target, const Position& toPosition,
+                        bool isHotkey)
 {
 	// onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -382,7 +389,7 @@ bool Action::executeUse(Player* player, Item* item, const Position& fromPosition
 
 	scriptInterface->pushFunction(scriptId);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushThing(L, item);

--- a/src/actions.h
+++ b/src/actions.h
@@ -10,7 +10,8 @@
 
 class Action;
 using Action_ptr = std::unique_ptr<Action>;
-using ActionFunction = std::function<bool(Player* player, Item* item, const Position& fromPosition, Thing* target,
+using ActionFunction = std::function<bool(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+                                          const Position& fromPosition, const std::shared_ptr<Thing>& target,
                                           const Position& toPosition, bool isHotkey)>;
 
 class Action : public Event
@@ -21,7 +22,8 @@ public:
 	bool configureEvent(const pugi::xml_node&) override { return false; }
 
 	// scripting
-	virtual bool executeUse(Player* player, Item* item, const Position& fromPosition, Thing* target,
+	virtual bool executeUse(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                        const Position& fromPosition, const std::shared_ptr<Thing>& target,
 	                        const Position& toPosition, bool isHotkey);
 
 	bool getAllowFarUse() const { return allowFarUse; }
@@ -33,10 +35,11 @@ public:
 	bool getCheckFloor() const { return checkFloor; }
 	void setCheckFloor(bool v) { checkFloor = v; }
 
-	virtual ReturnValue canExecuteAction(const Player* player, const Position& toPos);
+	virtual ReturnValue canExecuteAction(const std::shared_ptr<const Player>& player, const Position& toPos);
 	virtual bool hasOwnErrorHandler() { return false; }
-	virtual Thing* getTarget(Player* player, Creature* targetCreature, const Position& toPosition,
-	                         uint8_t toStackPos) const;
+	virtual std::shared_ptr<Thing> getTarget(const std::shared_ptr<Player>& player,
+	                                         const std::shared_ptr<Creature>& targetCreature,
+	                                         const Position& toPosition, uint8_t toStackPos) const;
 
 	ActionFunction function;
 
@@ -58,13 +61,17 @@ public:
 	Actions(const Actions&) = delete;
 	Actions& operator=(const Actions&) = delete;
 
-	bool useItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
-	bool useItemEx(Player* player, const Position& fromPos, const Position& toPos, uint8_t toStackPos, Item* item,
-	               bool isHotkey, Creature* creature = nullptr);
+	bool useItem(const std::shared_ptr<Player>& player, const Position& pos, uint8_t index,
+	             const std::shared_ptr<Item>& item, bool isHotkey);
+	bool useItemEx(const std::shared_ptr<Player>& player, const Position& fromPos, const Position& toPos,
+	               uint8_t toStackPos, const std::shared_ptr<Item>& item, bool isHotkey,
+	               const std::shared_ptr<Creature>& creature = nullptr);
 
-	ReturnValue canUse(const Player* player, const Position& pos);
-	ReturnValue canUse(const Player* player, const Position& pos, const Item* item);
-	ReturnValue canUseFar(const Creature* creature, const Position& toPos, bool checkLineOfSight, bool checkFloor);
+	ReturnValue canUse(const std::shared_ptr<const Player>& player, const Position& pos);
+	ReturnValue canUse(const std::shared_ptr<const Player>& player, const Position& pos,
+	                   const std::shared_ptr<const Item>& item);
+	ReturnValue canUseFar(const std::shared_ptr<const Creature>& creature, const Position& toPos, bool checkLineOfSight,
+	                      bool checkFloor);
 
 	bool registerLuaEvent(Action* event);
 	void clear(bool fromLua) override final;
@@ -83,7 +90,8 @@ public:
 	void addActionId(Action* action, uint16_t id) { aids[action].emplace_back(id); }
 
 private:
-	ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
+	ReturnValue internalUseItem(const std::shared_ptr<Player>& player, const Position& pos, uint8_t index,
+	                            const std::shared_ptr<Item>& item, bool isHotkey);
 
 	LuaScriptInterface& getScriptInterface() override;
 	std::string_view getScriptBaseName() const override { return "actions"; }
@@ -98,7 +106,7 @@ private:
 	std::map<Action*, std::vector<uint16_t>> uids;
 	std::map<Action*, std::vector<uint16_t>> aids;
 
-	Action* getAction(const Item* item);
+	Action* getAction(const std::shared_ptr<const Item>& item);
 	void clearMap(ActionUseMap& map, bool fromLua);
 
 	LuaScriptInterface scriptInterface;

--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -27,7 +27,7 @@ Attr_ReadValue BedItem::readAttr(AttrTypes_t attr, PropStream& propStream)
 				std::string name = IOLoginData::getNameByGuid(guid);
 				if (!name.empty()) {
 					setSpecialDescription(name + " is sleeping there.");
-					g_game.setBedSleeper(this, guid);
+					g_game.setBedSleeper(getBed(), guid);
 					sleeperGUID = guid;
 				}
 			}
@@ -64,19 +64,19 @@ void BedItem::serializeAttr(PropWriteStream& propWriteStream) const
 	}
 }
 
-BedItem* BedItem::getNextBedItem() const
+std::shared_ptr<BedItem> BedItem::getNextBedItem() const
 {
 	Direction dir = Item::items[id].bedPartnerDir;
 	Position targetPos = getNextPosition(dir, getPosition());
 
-	Tile* tile = g_game.map.getTile(targetPos);
+	const auto& tile = g_game.map.getTile(targetPos);
 	if (!tile) {
 		return nullptr;
 	}
 	return tile->getBedItem();
 }
 
-bool BedItem::canUse(Player* player)
+bool BedItem::canUse(const std::shared_ptr<Player>& player)
 {
 	if (!player || !house || !player->isPremium() || player->getZone() != ZONE_PROTECTION) {
 		return false;
@@ -90,18 +90,18 @@ bool BedItem::canUse(Player* player)
 		return true;
 	}
 
-	Player sleeper(nullptr);
-	if (!IOLoginData::loadPlayerById(&sleeper, sleeperGUID)) {
+	auto sleeper = std::make_shared<Player>(nullptr);
+	if (!IOLoginData::loadPlayerById(sleeper, sleeperGUID)) {
 		return false;
 	}
 
-	if (house->getHouseAccessLevel(&sleeper) > house->getHouseAccessLevel(player)) {
+	if (house->getHouseAccessLevel(sleeper) > house->getHouseAccessLevel(player)) {
 		return false;
 	}
 	return true;
 }
 
-bool BedItem::trySleep(Player* player)
+bool BedItem::trySleep(const std::shared_ptr<Player>& player)
 {
 	if (!house || player->isRemoved()) {
 		return false;
@@ -118,7 +118,7 @@ bool BedItem::trySleep(Player* player)
 	return true;
 }
 
-bool BedItem::sleep(Player* player)
+bool BedItem::sleep(const std::shared_ptr<Player>& player)
 {
 	if (!house) {
 		return false;
@@ -128,7 +128,7 @@ bool BedItem::sleep(Player* player)
 		return false;
 	}
 
-	BedItem* nextBedItem = getNextBedItem();
+	const auto& nextBedItem = getNextBedItem();
 
 	internalSetSleeper(player);
 
@@ -137,10 +137,10 @@ bool BedItem::sleep(Player* player)
 	}
 
 	// update the bedSleepersMap
-	g_game.setBedSleeper(this, player->getGUID());
+	g_game.setBedSleeper(getBed(), player->getGUID());
 
 	// make the player walk onto the bed
-	g_game.map.moveCreature(*player, *getTile());
+	g_game.map.moveCreature(player, getTile());
 
 	// display 'Zzzz'/sleep effect
 	g_game.addMagicEffect(player->getPosition(), CONST_ME_SLEEP);
@@ -159,7 +159,7 @@ bool BedItem::sleep(Player* player)
 	return true;
 }
 
-void BedItem::wakeUp(Player* player)
+void BedItem::wakeUp(const std::shared_ptr<Player>& player)
 {
 	if (!house) {
 		return;
@@ -167,10 +167,10 @@ void BedItem::wakeUp(Player* player)
 
 	if (sleeperGUID != 0) {
 		if (!player) {
-			Player regenPlayer(nullptr);
-			if (IOLoginData::loadPlayerById(&regenPlayer, sleeperGUID)) {
-				regeneratePlayer(&regenPlayer);
-				IOLoginData::savePlayer(&regenPlayer);
+			auto regenPlayer = std::make_shared<Player>(nullptr);
+			if (IOLoginData::loadPlayerById(regenPlayer, sleeperGUID)) {
+				regeneratePlayer(regenPlayer);
+				IOLoginData::savePlayer(regenPlayer);
 			}
 		} else {
 			regeneratePlayer(player);
@@ -181,7 +181,7 @@ void BedItem::wakeUp(Player* player)
 	// update the bedSleepersMap
 	g_game.removeBedSleeper(sleeperGUID);
 
-	BedItem* nextBedItem = getNextBedItem();
+	const auto& nextBedItem = getNextBedItem();
 
 	// unset sleep info
 	internalRemoveSleeper();
@@ -198,7 +198,7 @@ void BedItem::wakeUp(Player* player)
 	}
 }
 
-void BedItem::regeneratePlayer(Player* player) const
+void BedItem::regeneratePlayer(const std::shared_ptr<Player>& player) const
 {
 	const uint32_t sleptTime = time(nullptr) - sleepStart;
 
@@ -225,25 +225,25 @@ void BedItem::regeneratePlayer(Player* player) const
 	player->changeSoul(soulRegen);
 }
 
-void BedItem::updateAppearance(const Player* player)
+void BedItem::updateAppearance(const std::shared_ptr<const Player>& player)
 {
 	const ItemType& it = Item::items[id];
 	if (it.type == ITEM_TYPE_BED) {
 		if (player && it.transformToOnUse[player->getSex()] != 0) {
 			const ItemType& newType = Item::items[it.transformToOnUse[player->getSex()]];
 			if (newType.type == ITEM_TYPE_BED) {
-				g_game.transformItem(this, it.transformToOnUse[player->getSex()]);
+				g_game.transformItem(getBed(), it.transformToOnUse[player->getSex()]);
 			}
 		} else if (it.transformToFree != 0) {
 			const ItemType& newType = Item::items[it.transformToFree];
 			if (newType.type == ITEM_TYPE_BED) {
-				g_game.transformItem(this, it.transformToFree);
+				g_game.transformItem(getBed(), it.transformToFree);
 			}
 		}
 	}
 }
 
-void BedItem::internalSetSleeper(const Player* player)
+void BedItem::internalSetSleeper(const std::shared_ptr<const Player>& player)
 {
 	std::string desc_str = player->getName() + " is sleeping there.";
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -14,8 +14,11 @@ class BedItem final : public Item
 public:
 	explicit BedItem(uint16_t id);
 
-	BedItem* getBed() override { return this; }
-	const BedItem* getBed() const override { return this; }
+	std::shared_ptr<BedItem> getBed() override { return std::static_pointer_cast<BedItem>(shared_from_this()); }
+	std::shared_ptr<const BedItem> getBed() const override
+	{
+		return std::static_pointer_cast<const BedItem>(shared_from_this());
+	}
 
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 	void serializeAttr(PropWriteStream& propWriteStream) const override;
@@ -27,18 +30,18 @@ public:
 	House* getHouse() const { return house; }
 	void setHouse(House* h) { house = h; }
 
-	bool canUse(Player* player);
+	bool canUse(const std::shared_ptr<Player>& player);
 
-	bool trySleep(Player* player);
-	bool sleep(Player* player);
-	void wakeUp(Player* player);
+	bool trySleep(const std::shared_ptr<Player>& player);
+	bool sleep(const std::shared_ptr<Player>& player);
+	void wakeUp(const std::shared_ptr<Player>& player);
 
-	BedItem* getNextBedItem() const;
+	std::shared_ptr<BedItem> getNextBedItem() const;
 
 private:
-	void updateAppearance(const Player* player);
-	void regeneratePlayer(Player* player) const;
-	void internalSetSleeper(const Player* player);
+	void updateAppearance(const std::shared_ptr<const Player>& player);
+	void regeneratePlayer(const std::shared_ptr<Player>& player) const;
+	void internalSetSleeper(const std::shared_ptr<const Player>& player);
 	void internalRemoveSleeper();
 
 	House* house = nullptr;

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -22,51 +22,53 @@ bool PrivateChatChannel::isInvited(uint32_t guid) const
 
 bool PrivateChatChannel::removeInvite(uint32_t guid) { return invites.erase(guid) != 0; }
 
-void PrivateChatChannel::invitePlayer(const Player& player, Player& invitePlayer)
+void PrivateChatChannel::invitePlayer(const std::shared_ptr<const Player>& player,
+                                      const std::shared_ptr<Player>& invitePlayer)
 {
-	auto result = invites.emplace(invitePlayer.getGUID(), &invitePlayer);
+	auto result = invites.emplace(invitePlayer->getGUID(), invitePlayer);
 	if (!result.second) {
 		return;
 	}
 
-	invitePlayer.sendTextMessage(MESSAGE_INFO_DESCR,
-	                             std::format("{:s} invites you to {:s} private chat channel.", player.getName(),
-	                                         player.getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
+	invitePlayer->sendTextMessage(MESSAGE_INFO_DESCR,
+	                              std::format("{:s} invites you to {:s} private chat channel->", player->getName(),
+	                                          player->getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
 
-	player.sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been invited.", invitePlayer.getName()));
+	player->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been invited.", invitePlayer->getName()));
 
-	for (auto&& user : users | std::views::values | std::views::as_const) {
-		user->sendChannelEvent(id, invitePlayer.getName(), CHANNELEVENT_INVITE);
+	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		user->sendChannelEvent(id, invitePlayer->getName(), CHANNELEVENT_INVITE);
 	}
 }
 
-void PrivateChatChannel::excludePlayer(const Player& player, Player& excludePlayer)
+void PrivateChatChannel::excludePlayer(const std::shared_ptr<const Player>& player,
+                                       const std::shared_ptr<Player>& excludePlayer)
 {
-	if (!removeInvite(excludePlayer.getGUID())) {
+	if (!removeInvite(excludePlayer->getGUID())) {
 		return;
 	}
 
 	removeUser(excludePlayer);
 
-	player.sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been excluded.", excludePlayer.getName()));
+	player->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been excluded.", excludePlayer->getName()));
 
-	excludePlayer.sendClosePrivate(id);
+	excludePlayer->sendClosePrivate(id);
 
-	for (auto&& user : users | std::views::values | std::views::as_const) {
-		user->sendChannelEvent(id, excludePlayer.getName(), CHANNELEVENT_EXCLUDE);
+	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		user->sendChannelEvent(id, excludePlayer->getName(), CHANNELEVENT_EXCLUDE);
 	}
 }
 
 void PrivateChatChannel::closeChannel() const
 {
-	for (auto&& user : users | std::views::values | std::views::as_const) {
+	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
 		user->sendClosePrivate(id);
 	}
 }
 
-bool ChatChannel::addUser(Player& player)
+bool ChatChannel::addUser(const std::shared_ptr<Player>& player)
 {
-	if (users.find(player.getID()) != users.end()) {
+	if (users.find(player->getID()) != users.end()) {
 		return false;
 	}
 
@@ -76,25 +78,25 @@ bool ChatChannel::addUser(Player& player)
 
 	// TODO: Move to script when guild channels can be scripted
 	if (id == CHANNEL_GUILD) {
-		if (const auto& guild = player.getGuild(); !guild->getMotd().empty()) {
+		if (const auto& guild = player->getGuild(); !guild->getMotd().empty()) {
 			g_scheduler.addEvent(
-			    createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
+			    createSchedulerTask(150, [playerID = player->getID()]() { g_game.sendGuildMotd(playerID); }));
 		}
 	}
 
 	if (!publicChannel) {
-		for (auto&& user : users | std::views::values | std::views::as_const) {
-			user->sendChannelEvent(id, player.getName(), CHANNELEVENT_JOIN);
+		for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+			user->sendChannelEvent(id, player->getName(), CHANNELEVENT_JOIN);
 		}
 	}
 
-	users[player.getID()] = &player;
+	users[player->getID()] = player;
 	return true;
 }
 
-bool ChatChannel::removeUser(const Player& player)
+bool ChatChannel::removeUser(const std::shared_ptr<const Player>& player)
 {
-	auto iter = users.find(player.getID());
+	auto iter = users.find(player->getID());
 	if (iter == users.end()) {
 		return false;
 	}
@@ -102,8 +104,8 @@ bool ChatChannel::removeUser(const Player& player)
 	users.erase(iter);
 
 	if (!publicChannel) {
-		for (auto&& user : users | std::views::values | std::views::as_const) {
-			user->sendChannelEvent(id, player.getName(), CHANNELEVENT_LEAVE);
+		for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+			user->sendChannelEvent(id, player->getName(), CHANNELEVENT_LEAVE);
 		}
 	}
 
@@ -111,28 +113,31 @@ bool ChatChannel::removeUser(const Player& player)
 	return true;
 }
 
-bool ChatChannel::hasUser(const Player& player) { return users.find(player.getID()) != users.end(); }
+bool ChatChannel::hasUser(const std::shared_ptr<const Player>& player)
+{
+	return users.find(player->getID()) != users.end();
+}
 
 void ChatChannel::sendToAll(const std::string& message, SpeakClasses type) const
 {
-	for (auto&& user : users | std::views::values | std::views::as_const) {
+	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
 		user->sendChannelMessage("", message, type, id);
 	}
 }
 
-bool ChatChannel::talk(const Player& fromPlayer, SpeakClasses type, const std::string& text)
+bool ChatChannel::talk(const std::shared_ptr<const Player>& fromPlayer, SpeakClasses type, const std::string& text)
 {
-	if (users.find(fromPlayer.getID()) == users.end()) {
+	if (users.find(fromPlayer->getID()) == users.end()) {
 		return false;
 	}
 
-	for (auto&& user : users | std::views::values | std::views::as_const) {
-		user->sendToChannel(&fromPlayer, type, text, id);
+	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		user->sendToChannel(fromPlayer, type, text, id);
 	}
 	return true;
 }
 
-bool ChatChannel::executeCanJoinEvent(const Player& player)
+bool ChatChannel::executeCanJoinEvent(const std::shared_ptr<const Player>& player)
 {
 	if (canJoinEvent == -1) {
 		return true;
@@ -151,13 +156,13 @@ bool ChatChannel::executeCanJoinEvent(const Player& player)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(canJoinEvent);
-	tfs::lua::pushUserdata(L, &player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface->callFunction(1);
 }
 
-bool ChatChannel::executeOnJoinEvent(const Player& player)
+bool ChatChannel::executeOnJoinEvent(const std::shared_ptr<const Player>& player)
 {
 	if (onJoinEvent == -1) {
 		return true;
@@ -176,13 +181,13 @@ bool ChatChannel::executeOnJoinEvent(const Player& player)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(onJoinEvent);
-	tfs::lua::pushUserdata(L, &player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface->callFunction(1);
 }
 
-bool ChatChannel::executeOnLeaveEvent(const Player& player)
+bool ChatChannel::executeOnLeaveEvent(const std::shared_ptr<const Player>& player)
 {
 	if (onLeaveEvent == -1) {
 		return true;
@@ -201,13 +206,14 @@ bool ChatChannel::executeOnLeaveEvent(const Player& player)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(onLeaveEvent);
-	tfs::lua::pushUserdata(L, &player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface->callFunction(1);
 }
 
-bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, const std::string& message)
+bool ChatChannel::executeOnSpeakEvent(const std::shared_ptr<const Player>& player, SpeakClasses& type,
+                                      const std::string& message)
 {
 	if (onSpeakEvent == -1) {
 		return true;
@@ -226,7 +232,7 @@ bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, 
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(onSpeakEvent);
-	tfs::lua::pushUserdata(L, &player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushNumber(L, type);
@@ -294,8 +300,8 @@ bool Chat::load()
 			}
 
 			UsersMap tempUserMap = std::move(channel.users);
-			for (auto&& player : tempUserMap | std::views::values | std::views::as_const) {
-				channel.addUser(*player);
+			for (auto&& player : tempUserMap | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+				channel.addUser(player);
 			}
 			continue;
 		}
@@ -320,7 +326,7 @@ bool Chat::load()
 	return true;
 }
 
-ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
+ChatChannel* Chat::createChannel(const std::shared_ptr<const Player>& player, uint16_t channelId)
 {
 	if (getChannel(player, channelId)) {
 		return nullptr;
@@ -328,7 +334,7 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			if (const auto& guild = player.getGuild()) {
+			if (const auto& guild = player->getGuild()) {
 				auto ret =
 				    guildChannels.emplace(std::make_pair(guild->getId(), ChatChannel(channelId, guild->getName())));
 				return &ret.first->second;
@@ -337,8 +343,7 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 		}
 
 		case CHANNEL_PARTY: {
-			Party* party = player.getParty();
-			if (party) {
+			if (Party* party = player->getParty()) {
 				auto ret = partyChannels.emplace(std::make_pair(party, ChatChannel(channelId, "Party")));
 				return &ret.first->second;
 			}
@@ -347,17 +352,17 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 
 		case CHANNEL_PRIVATE: {
 			// only 1 private channel for each premium player
-			if (!player.isPremium() || getPrivateChannel(player)) {
+			if (!player->isPremium() || getPrivateChannel(player)) {
 				return nullptr;
 			}
 
 			// find a free private channel slot
 			for (uint16_t i = 100; i < 10000; ++i) {
-				auto ret =
-				    privateChannels.emplace(std::make_pair(i, PrivateChatChannel(i, player.getName() + "'s Channel")));
-				if (ret.second) { // second is a bool that indicates that a new channel has been placed in the map
-					auto& newChannel = (*ret.first).second;
-					newChannel.setOwner(player.getGUID());
+				auto [it, inserted] =
+				    privateChannels.emplace(std::make_pair(i, PrivateChatChannel(i, player->getName() + "'s Channel")));
+				if (inserted) { // second is a bool that indicates that a new channel has been placed in the map
+					auto& newChannel = it->second;
+					newChannel.setOwner(player->getGUID());
 					return &newChannel;
 				}
 			}
@@ -370,37 +375,23 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 	return nullptr;
 }
 
-bool Chat::deleteChannel(const Player& player, uint16_t channelId)
+bool Chat::deleteChannel(const std::shared_ptr<const Player>& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			const auto& guild = player.getGuild();
-			if (!guild) {
-				return false;
+			if (const auto& guild = player->getGuild()) {
+				guildChannels.erase(guild->getId());
+				return true;
 			}
-
-			auto it = guildChannels.find(guild->getId());
-			if (it == guildChannels.end()) {
-				return false;
-			}
-
-			guildChannels.erase(it);
-			break;
+			return false;
 		}
 
 		case CHANNEL_PARTY: {
-			Party* party = player.getParty();
-			if (!party) {
-				return false;
+			if (Party* party = player->getParty()) {
+				partyChannels.erase(party);
+				return true;
 			}
-
-			auto it = partyChannels.find(party);
-			if (it == partyChannels.end()) {
-				return false;
-			}
-
-			partyChannels.erase(it);
-			break;
+			return false;
 		}
 
 		default: {
@@ -418,7 +409,7 @@ bool Chat::deleteChannel(const Player& player, uint16_t channelId)
 	return true;
 }
 
-ChatChannel* Chat::addUserToChannel(Player& player, uint16_t channelId)
+ChatChannel* Chat::addUserToChannel(const std::shared_ptr<Player>& player, uint16_t channelId)
 {
 	ChatChannel* channel = getChannel(player, channelId);
 	if (channel && channel->addUser(player)) {
@@ -427,20 +418,20 @@ ChatChannel* Chat::addUserToChannel(Player& player, uint16_t channelId)
 	return nullptr;
 }
 
-bool Chat::removeUserFromChannel(const Player& player, uint16_t channelId)
+bool Chat::removeUserFromChannel(const std::shared_ptr<const Player>& player, uint16_t channelId)
 {
 	ChatChannel* channel = getChannel(player, channelId);
 	if (!channel || !channel->removeUser(player)) {
 		return false;
 	}
 
-	if (channel->getOwner() == player.getGUID()) {
+	if (channel->getOwner() == player->getGUID()) {
 		deleteChannel(player, channelId);
 	}
 	return true;
 }
 
-void Chat::removeUserFromAllChannels(const Player& player)
+void Chat::removeUserFromAllChannels(const std::shared_ptr<const Player>& player)
 {
 	for (auto&& channel : normalChannels | std::views::values) {
 		channel.removeUser(player);
@@ -457,9 +448,9 @@ void Chat::removeUserFromAllChannels(const Player& player)
 	auto it = privateChannels.begin();
 	while (it != privateChannels.end()) {
 		PrivateChatChannel* channel = &it->second;
-		channel->removeInvite(player.getGUID());
+		channel->removeInvite(player->getGUID());
 		channel->removeUser(player);
-		if (channel->getOwner() == player.getGUID()) {
+		if (channel->getOwner() == player->getGUID()) {
 			channel->closeChannel();
 			it = privateChannels.erase(it);
 		} else {
@@ -468,7 +459,8 @@ void Chat::removeUserFromAllChannels(const Player& player)
 	}
 }
 
-bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::string& text, uint16_t channelId)
+bool Chat::talkToChannel(const std::shared_ptr<const Player>& player, SpeakClasses type, const std::string& text,
+                         uint16_t channelId)
 {
 	ChatChannel* channel = getChannel(player, channelId);
 	if (!channel) {
@@ -476,7 +468,7 @@ bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::str
 	}
 
 	if (channelId == CHANNEL_GUILD) {
-		const auto& rank = player.getGuildRank();
+		const auto& rank = player->getGuildRank();
 		if (rank && rank->level > 1) {
 			type = TALKTYPE_CHANNEL_O;
 		} else if (type != TALKTYPE_CHANNEL_Y) {
@@ -493,10 +485,10 @@ bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::str
 	return channel->talk(player, type, text);
 }
 
-ChannelList Chat::getChannelList(const Player& player)
+ChannelList Chat::getChannelList(const std::shared_ptr<const Player>& player)
 {
 	ChannelList list;
-	if (player.getGuild()) {
+	if (player->getGuild()) {
 		ChatChannel* channel = getChannel(player, CHANNEL_GUILD);
 		if (channel) {
 			list.push_back(channel);
@@ -508,7 +500,7 @@ ChannelList Chat::getChannelList(const Player& player)
 		}
 	}
 
-	if (player.getParty()) {
+	if (player->getParty()) {
 		ChatChannel* channel = getChannel(player, CHANNEL_PARTY);
 		if (channel) {
 			list.push_back(channel);
@@ -529,7 +521,7 @@ ChannelList Chat::getChannelList(const Player& player)
 
 	bool hasPrivate = false;
 	for (auto&& channel : privateChannels | std::views::values) {
-		uint32_t guid = player.getGUID();
+		uint32_t guid = player->getGUID();
 		if (channel.isInvited(guid)) {
 			list.push_back(&channel);
 		}
@@ -539,17 +531,17 @@ ChannelList Chat::getChannelList(const Player& player)
 		}
 	}
 
-	if (!hasPrivate && player.isPremium()) {
+	if (!hasPrivate && player->isPremium()) {
 		list.push_front(&dummyPrivate);
 	}
 	return list;
 }
 
-ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
+ChatChannel* Chat::getChannel(const std::shared_ptr<const Player>& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			if (const auto& guild = player.getGuild()) {
+			if (const auto& guild = player->getGuild()) {
 				auto it = guildChannels.find(guild->getId());
 				if (it != guildChannels.end()) {
 					return &it->second;
@@ -559,7 +551,7 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 		}
 
 		case CHANNEL_PARTY: {
-			Party* party = player.getParty();
+			Party* party = player->getParty();
 			if (party) {
 				auto it = partyChannels.find(party);
 				if (it != partyChannels.end()) {
@@ -579,7 +571,7 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 				return &channel;
 			} else {
 				auto it2 = privateChannels.find(channelId);
-				if (it2 != privateChannels.end() && it2->second.isInvited(player.getGUID())) {
+				if (it2 != privateChannels.end() && it2->second.isInvited(player->getGUID())) {
 					return &it2->second;
 				}
 			}
@@ -607,10 +599,10 @@ ChatChannel* Chat::getChannelById(uint16_t channelId)
 	return &it->second;
 }
 
-PrivateChatChannel* Chat::getPrivateChannel(const Player& player)
+PrivateChatChannel* Chat::getPrivateChannel(const std::shared_ptr<const Player>& player)
 {
 	for (auto&& channel : privateChannels | std::views::values) {
-		if (channel.getOwner() == player.getGUID()) {
+		if (channel.getOwner() == player->getGUID()) {
 			return &channel;
 		}
 	}

--- a/src/chat.h
+++ b/src/chat.h
@@ -10,8 +10,8 @@
 class Party;
 class Player;
 
-using UsersMap = std::map<uint32_t, Player*>;
-using InvitedMap = std::map<uint32_t, const Player*>;
+using UsersMap = std::map<uint32_t, std::weak_ptr<Player>>;
+using InvitedMap = std::map<uint32_t, std::weak_ptr<const Player>>;
 
 class ChatChannel
 {
@@ -21,11 +21,11 @@ public:
 
 	virtual ~ChatChannel() = default;
 
-	bool addUser(Player& player);
-	bool removeUser(const Player& player);
-	bool hasUser(const Player& player);
+	bool addUser(const std::shared_ptr<Player>& player);
+	bool removeUser(const std::shared_ptr<const Player>& player);
+	bool hasUser(const std::shared_ptr<const Player>& player);
 
-	bool talk(const Player& fromPlayer, SpeakClasses type, const std::string& text);
+	bool talk(const std::shared_ptr<const Player>& fromPlayer, SpeakClasses type, const std::string& text);
 	void sendToAll(const std::string& message, SpeakClasses type) const;
 
 	const std::string& getName() const { return name; }
@@ -37,10 +37,11 @@ public:
 
 	bool isPublicChannel() const { return publicChannel; }
 
-	bool executeOnJoinEvent(const Player& player);
-	bool executeCanJoinEvent(const Player& player);
-	bool executeOnLeaveEvent(const Player& player);
-	bool executeOnSpeakEvent(const Player& player, SpeakClasses& type, const std::string& message);
+	bool executeOnJoinEvent(const std::shared_ptr<const Player>& player);
+	bool executeCanJoinEvent(const std::shared_ptr<const Player>& player);
+	bool executeOnLeaveEvent(const std::shared_ptr<const Player>& player);
+	bool executeOnSpeakEvent(const std::shared_ptr<const Player>& player, SpeakClasses& type,
+	                         const std::string& message);
 
 protected:
 	UsersMap users;
@@ -70,8 +71,8 @@ public:
 
 	bool isInvited(uint32_t guid) const;
 
-	void invitePlayer(const Player& player, Player& invitePlayer);
-	void excludePlayer(const Player& player, Player& excludePlayer);
+	void invitePlayer(const std::shared_ptr<const Player>& player, const std::shared_ptr<Player>& invitePlayer);
+	void excludePlayer(const std::shared_ptr<const Player>& player, const std::shared_ptr<Player>& excludePlayer);
 
 	bool removeInvite(uint32_t guid);
 
@@ -97,21 +98,22 @@ public:
 
 	bool load();
 
-	ChatChannel* createChannel(const Player& player, uint16_t channelId);
-	bool deleteChannel(const Player& player, uint16_t channelId);
+	ChatChannel* createChannel(const std::shared_ptr<const Player>& player, uint16_t channelId);
+	bool deleteChannel(const std::shared_ptr<const Player>& player, uint16_t channelId);
 
-	ChatChannel* addUserToChannel(Player& player, uint16_t channelId);
-	bool removeUserFromChannel(const Player& player, uint16_t channelId);
-	void removeUserFromAllChannels(const Player& player);
+	ChatChannel* addUserToChannel(const std::shared_ptr<Player>& player, uint16_t channelId);
+	bool removeUserFromChannel(const std::shared_ptr<const Player>& player, uint16_t channelId);
+	void removeUserFromAllChannels(const std::shared_ptr<const Player>& player);
 
-	bool talkToChannel(const Player& player, SpeakClasses type, const std::string& text, uint16_t channelId);
+	bool talkToChannel(const std::shared_ptr<const Player>& player, SpeakClasses type, const std::string& text,
+	                   uint16_t channelId);
 
-	ChannelList getChannelList(const Player& player);
+	ChannelList getChannelList(const std::shared_ptr<const Player>& player);
 
-	ChatChannel* getChannel(const Player& player, uint16_t channelId);
+	ChatChannel* getChannel(const std::shared_ptr<const Player>& player, uint16_t channelId);
 	ChatChannel* getChannelById(uint16_t channelId);
 	ChatChannel* getGuildChannelById(uint32_t guildId);
-	PrivateChatChannel* getPrivateChannel(const Player& player);
+	PrivateChatChannel* getPrivateChannel(const std::shared_ptr<const Player>& player);
 
 	LuaScriptInterface* getScriptInterface() { return &scriptInterface; }
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -14,11 +14,11 @@
 extern Game g_game;
 extern Weapons* g_weapons;
 
-std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, const Direction dir)
+std::vector<std::shared_ptr<Tile>> getList(const MatrixArea& area, const Position& targetPos, const Direction dir)
 {
 	auto casterPos = getNextPosition(dir, targetPos);
 
-	std::vector<Tile*> vec;
+	std::vector<std::shared_ptr<Tile>> vec;
 
 	auto center = area.getCenter();
 
@@ -27,9 +27,9 @@ std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, co
 		for (uint32_t col = 0; col < area.getCols(); ++col, ++tmpPos.x) {
 			if (area(row, col)) {
 				if (g_game.isSightClear(casterPos, tmpPos, true)) {
-					Tile* tile = g_game.map.getTile(tmpPos);
+					auto tile = g_game.map.getTile(tmpPos);
 					if (!tile) {
-						tile = new StaticTile(tmpPos.x, tmpPos.y, tmpPos.z);
+						tile = std::make_shared<StaticTile>(tmpPos.x, tmpPos.y, tmpPos.z);
 						g_game.map.setTile(tmpPos, tile);
 					}
 					vec.push_back(tile);
@@ -41,7 +41,8 @@ std::vector<Tile*> getList(const MatrixArea& area, const Position& targetPos, co
 	return vec;
 }
 
-std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targetPos, const AreaCombat* area)
+std::vector<std::shared_ptr<Tile>> getCombatArea(const Position& centerPos, const Position& targetPos,
+                                                 const AreaCombat* area)
 {
 	if (targetPos.z >= MAP_MAX_LAYERS) {
 		return {};
@@ -51,15 +52,16 @@ std::vector<Tile*> getCombatArea(const Position& centerPos, const Position& targ
 		return getList(area->getArea(centerPos, targetPos), targetPos, getDirectionTo(targetPos, centerPos));
 	}
 
-	Tile* tile = g_game.map.getTile(targetPos);
+	auto tile = g_game.map.getTile(targetPos);
 	if (!tile) {
-		tile = new StaticTile(targetPos.x, targetPos.y, targetPos.z);
+		tile = std::make_shared<StaticTile>(targetPos.x, targetPos.y, targetPos.z);
 		g_game.map.setTile(targetPos, tile);
 	}
 	return {tile};
 }
 
-CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
+CombatDamage Combat::getCombatDamage(const std::shared_ptr<Creature>& creature,
+                                     const std::shared_ptr<Creature>& target) const
 {
 	CombatDamage damage;
 	damage.origin = params.origin;
@@ -70,7 +72,7 @@ CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
 		int32_t min, max;
 		if (creature->getCombatValues(min, max)) {
 			damage.primary.value = normal_random(min, max);
-		} else if (Player* player = creature->getPlayer()) {
+		} else if (const auto& player = creature->getPlayer()) {
 			if (params.valueCallback) {
 				params.valueCallback->getMinMaxValues(player, damage);
 			} else if (formulaType == COMBAT_FORMULA_LEVELMAGIC) {
@@ -80,9 +82,8 @@ CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
 				damage.primary.value =
 				    normal_random(std::fma(levelFormula, mina, minb), std::fma(levelFormula, maxa, maxb));
 			} else if (formulaType == COMBAT_FORMULA_SKILL) {
-				Item* tool = player->getWeapon();
-				const Weapon* weapon = g_weapons->getWeapon(tool);
-				if (weapon) {
+				const auto& tool = player->getWeapon();
+				if (const auto& weapon = g_weapons->getWeapon(tool)) {
 					damage.primary.value =
 					    normal_random(minb, std::fma(weapon->getWeaponDamage(player, target, tool, true), maxa, maxb));
 					damage.secondary.type = weapon->getElementType();
@@ -96,7 +97,7 @@ CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
 	return damage;
 }
 
-static bool isProtected(const Player* attacker, const Player* target)
+static bool isProtected(const std::shared_ptr<const Player>& attacker, const std::shared_ptr<const Player>& target)
 {
 	uint32_t protectionLevel = getNumber(ConfigManager::PROTECTION_LEVEL);
 	if (target->getLevel() < protectionLevel || attacker->getLevel() < protectionLevel) {
@@ -114,7 +115,7 @@ static bool isProtected(const Player* attacker, const Player* target)
 	return false;
 }
 
-bool Combat::isPlayerCombat(const Creature* target)
+bool Combat::isPlayerCombat(const std::shared_ptr<const Creature>& target)
 {
 	if (target->getPlayer()) {
 		return true;
@@ -127,7 +128,7 @@ bool Combat::isPlayerCombat(const Creature* target)
 	return false;
 }
 
-ReturnValue Combat::canTargetCreature(Player* attacker, Creature* target)
+ReturnValue Combat::canTargetCreature(const std::shared_ptr<Player>& attacker, const std::shared_ptr<Creature>& target)
 {
 	if (attacker == target) {
 		return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
@@ -176,7 +177,8 @@ ReturnValue Combat::canTargetCreature(Player* attacker, Creature* target)
 	return Combat::canDoCombat(attacker, target);
 }
 
-ReturnValue Combat::canDoCombat(Creature* caster, Tile* tile, bool aggressive)
+ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& caster, const std::shared_ptr<Tile>& tile,
+                                bool aggressive)
 {
 	if (tile->hasProperty(CONST_PROP_BLOCKPROJECTILE)) {
 		return RETURNVALUE_NOTENOUGHROOM;
@@ -199,7 +201,7 @@ ReturnValue Combat::canDoCombat(Creature* caster, Tile* tile, bool aggressive)
 			return RETURNVALUE_FIRSTGOUPSTAIRS;
 		}
 
-		if (const Player* player = caster->getPlayer()) {
+		if (const auto& player = caster->getPlayer()) {
 			if (player->hasFlag(PlayerFlag_IgnoreProtectionZone)) {
 				return RETURNVALUE_NOERROR;
 			}
@@ -214,23 +216,23 @@ ReturnValue Combat::canDoCombat(Creature* caster, Tile* tile, bool aggressive)
 	return tfs::events::creature::onAreaCombat(caster, tile, aggressive);
 }
 
-bool Combat::isInPvpZone(const Creature* attacker, const Creature* target)
+bool Combat::isInPvpZone(const std::shared_ptr<const Creature>& attacker, const std::shared_ptr<const Creature>& target)
 {
 	return attacker->getZone() == ZONE_PVP && target->getZone() == ZONE_PVP;
 }
 
-ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
+ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const std::shared_ptr<Creature>& target)
 {
 	if (!attacker) {
 		return tfs::events::creature::onTargetCombat(attacker, target);
 	}
 
-	if (const Player* targetPlayer = target->getPlayer()) {
+	if (const auto& targetPlayer = target->getPlayer()) {
 		if (targetPlayer->hasFlag(PlayerFlag_CannotBeAttacked)) {
 			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 		}
 
-		if (const Player* attackerPlayer = attacker->getPlayer()) {
+		if (const auto& attackerPlayer = attacker->getPlayer()) {
 			if (attackerPlayer->hasFlag(PlayerFlag_CannotAttackPlayer)) {
 				return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 			}
@@ -240,7 +242,7 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 			}
 
 			// nopvp-zone
-			const Tile* targetPlayerTile = targetPlayer->getTile();
+			const auto& targetPlayerTile = targetPlayer->getTile();
 			if (targetPlayerTile->hasFlag(TILESTATE_NOPVPZONE)) {
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			} else if (attackerPlayer->getTile()->hasFlag(TILESTATE_NOPVPZONE) &&
@@ -250,7 +252,7 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 		}
 
 		if (attacker->isSummon()) {
-			if (const Player* masterAttackerPlayer = attacker->getMaster()->getPlayer()) {
+			if (const auto& masterAttackerPlayer = attacker->getMaster()->getPlayer()) {
 				if (masterAttackerPlayer->hasFlag(PlayerFlag_CannotAttackPlayer)) {
 					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 				}
@@ -265,7 +267,7 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 			}
 		}
 	} else if (target->getMonster()) {
-		if (const Player* attackerPlayer = attacker->getPlayer()) {
+		if (const auto& attackerPlayer = attacker->getPlayer()) {
 			if (attackerPlayer->hasFlag(PlayerFlag_CannotAttackMonster)) {
 				return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 			}
@@ -274,10 +276,10 @@ ReturnValue Combat::canDoCombat(Creature* attacker, Creature* target)
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			}
 		} else if (attacker->getMonster()) {
-			const Creature* targetMaster = target->getMaster();
+			const auto& targetMaster = target->getMaster();
 
 			if (!targetMaster || !targetMaster->getPlayer()) {
-				const Creature* attackerMaster = attacker->getMaster();
+				const auto& attackerMaster = attacker->getMaster();
 
 				if (!attackerMaster || !attackerMaster->getPlayer()) {
 					return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
@@ -454,7 +456,8 @@ CallBack* Combat::getCallback(CallBackParam_t key)
 	return nullptr;
 }
 
-static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, Tile* tile, const CombatParams& params)
+static void combatTileEffects(const SpectatorVec& spectators, const std::shared_ptr<Creature>& caster,
+                              const std::shared_ptr<Tile>& tile, const CombatParams& params)
 {
 	if (params.itemId != 0) {
 		uint16_t itemId = params.itemId;
@@ -492,7 +495,7 @@ static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, 
 		}
 
 		if (caster) {
-			Player* casterPlayer;
+			std::shared_ptr<Player> casterPlayer;
 			if (caster->isSummon()) {
 				casterPlayer = caster->getMaster()->getPlayer();
 			} else {
@@ -519,7 +522,7 @@ static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, 
 			}
 		}
 
-		Item* item = Item::CreateItem(itemId);
+		const auto item = Item::CreateItem(itemId);
 		if (caster) {
 			item->setOwner(caster->getID());
 		}
@@ -527,8 +530,6 @@ static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, 
 		ReturnValue ret = g_game.internalAddItem(tile, item);
 		if (ret == RETURNVALUE_NOERROR) {
 			g_game.startDecay(item);
-		} else {
-			delete item;
 		}
 	}
 
@@ -541,21 +542,22 @@ static void combatTileEffects(const SpectatorVec& spectators, Creature* caster, 
 	}
 }
 
-void Combat::postCombatEffects(Creature* caster, const Position& pos, const CombatParams& params)
+void Combat::postCombatEffects(const std::shared_ptr<Creature>& caster, const Position& pos, const CombatParams& params)
 {
 	if (caster && params.distanceEffect != CONST_ANI_NONE) {
 		addDistanceEffect(caster, caster->getPosition(), pos, params.distanceEffect);
 	}
 }
 
-void Combat::addDistanceEffect(Creature* caster, const Position& fromPos, const Position& toPos, uint8_t effect)
+void Combat::addDistanceEffect(const std::shared_ptr<Creature>& caster, const Position& fromPos, const Position& toPos,
+                               uint8_t effect)
 {
 	if (effect == CONST_ANI_WEAPONTYPE) {
 		if (!caster) {
 			return;
 		}
 
-		Player* player = caster->getPlayer();
+		const auto& player = caster->getPlayer();
 		if (!player) {
 			return;
 		}
@@ -581,7 +583,7 @@ void Combat::addDistanceEffect(Creature* caster, const Position& fromPos, const 
 	}
 }
 
-void Combat::doCombat(Creature* caster, Creature* target) const
+void Combat::doCombat(const std::shared_ptr<Creature>& caster, const std::shared_ptr<Creature>& target) const
 {
 	// target combat callback function
 	if (params.combatType != COMBAT_NONE) {
@@ -637,22 +639,22 @@ void Combat::doCombat(Creature* caster, Creature* target) const
 	}
 }
 
-void Combat::doCombat(Creature* caster, const Position& position) const
+void Combat::doCombat(const std::shared_ptr<Creature>& caster, const Position& position) const
 {
 	// area combat callback function
 	if (params.combatType != COMBAT_NONE) {
 		CombatDamage damage = getCombatDamage(caster, nullptr);
 		doAreaCombat(caster, position, area.get(), damage, params);
 	} else {
-		auto tiles = caster ? getCombatArea(caster->getPosition(), position, area.get())
-		                    : getCombatArea(position, position, area.get());
+		const auto& tiles = caster ? getCombatArea(caster->getPosition(), position, area.get())
+		                           : getCombatArea(position, position, area.get());
 
 		SpectatorVec spectators;
 		int32_t maxX = 0;
 		int32_t maxY = 0;
 
 		// calculate the max viewable range
-		for (Tile* tile : tiles) {
+		for (const auto& tile : tiles) {
 			const Position& tilePos = tile->getPosition();
 			maxX = std::max(maxX, tilePos.getDistanceX(position));
 			maxY = std::max(maxY, tilePos.getDistanceY(position));
@@ -664,7 +666,7 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 
 		postCombatEffects(caster, position, params);
 
-		for (Tile* tile : tiles) {
+		for (const auto& tile : tiles) {
 			if (canDoCombat(caster, tile, params.aggressive) != RETURNVALUE_NOERROR) {
 				continue;
 			}
@@ -672,8 +674,8 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 			combatTileEffects(spectators, caster, tile, params);
 
 			if (CreatureVector* creatures = tile->getCreatures()) {
-				const Creature* topCreature = tile->getTopCreature();
-				for (Creature* creature : *creatures) {
+				const auto& topCreature = tile->getTopCreature();
+				for (const auto& creature : *creatures) {
 					if (params.targetCasterOrTopMost) {
 						if (caster && caster->getTile() == tile) {
 							if (creature != caster) {
@@ -718,13 +720,14 @@ void Combat::doCombat(Creature* caster, const Position& position) const
 	}
 }
 
-void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& damage, const CombatParams& params)
+void Combat::doTargetCombat(const std::shared_ptr<Creature>& caster, const std::shared_ptr<Creature>& target,
+                            CombatDamage& damage, const CombatParams& params)
 {
 	if (caster && target && params.distanceEffect != CONST_ANI_NONE) {
 		addDistanceEffect(caster, caster->getPosition(), target->getPosition(), params.distanceEffect);
 	}
 
-	Player* casterPlayer = caster ? caster->getPlayer() : nullptr;
+	const auto& casterPlayer = caster ? caster->getPlayer() : nullptr;
 
 	bool success = false;
 	if (damage.primary.type != COMBAT_MANADRAIN) {
@@ -734,7 +737,7 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 		}
 
 		if (casterPlayer) {
-			Player* targetPlayer = target ? target->getPlayer() : nullptr;
+			const auto& targetPlayer = target ? target->getPlayer() : nullptr;
 			if (targetPlayer && casterPlayer != targetPlayer && targetPlayer->getSkull() != SKULL_BLACK &&
 			    damage.primary.type != COMBAT_HEALING) {
 				damage.primary.value /= 2;
@@ -817,13 +820,13 @@ void Combat::doTargetCombat(Creature* caster, Creature* target, CombatDamage& da
 	}
 }
 
-void Combat::doAreaCombat(Creature* caster, const Position& position, const AreaCombat* area, CombatDamage& damage,
-                          const CombatParams& params)
+void Combat::doAreaCombat(const std::shared_ptr<Creature>& caster, const Position& position, const AreaCombat* area,
+                          CombatDamage& damage, const CombatParams& params)
 {
-	auto tiles =
+	const auto& tiles =
 	    caster ? getCombatArea(caster->getPosition(), position, area) : getCombatArea(position, position, area);
 
-	Player* casterPlayer = caster ? caster->getPlayer() : nullptr;
+	const auto& casterPlayer = caster ? caster->getPlayer() : nullptr;
 	int32_t criticalPrimary = 0;
 	int32_t criticalSecondary = 0;
 	if (!damage.critical && damage.primary.type != COMBAT_HEALING && casterPlayer &&
@@ -841,7 +844,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 	int32_t maxY = 0;
 
 	// calculate the max viewable range
-	for (Tile* tile : tiles) {
+	for (const auto& tile : tiles) {
 		const Position& tilePos = tile->getPosition();
 		maxX = std::max(maxX, tilePos.getDistanceX(position));
 		maxY = std::max(maxY, tilePos.getDistanceY(position));
@@ -855,10 +858,10 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 	postCombatEffects(caster, position, params);
 
-	std::vector<Creature*> toDamageCreatures;
+	std::vector<std::shared_ptr<Creature>> toDamageCreatures;
 	toDamageCreatures.reserve(100);
 
-	for (Tile* tile : tiles) {
+	for (const auto& tile : tiles) {
 		if (canDoCombat(caster, tile, params.aggressive) != RETURNVALUE_NOERROR) {
 			continue;
 		}
@@ -866,8 +869,8 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 		combatTileEffects(spectators, caster, tile, params);
 
 		if (CreatureVector* creatures = tile->getCreatures()) {
-			const Creature* topCreature = tile->getTopCreature();
-			for (Creature* creature : *creatures) {
+			const auto& topCreature = tile->getTopCreature();
+			for (const auto& creature : *creatures) {
 				if (params.targetCasterOrTopMost) {
 					if (caster && caster->getTile() == tile) {
 						if (creature != caster) {
@@ -894,12 +897,12 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 	leechCombat.origin = ORIGIN_NONE;
 	leechCombat.leeched = true;
 
-	for (Creature* creature : toDamageCreatures) {
+	for (const auto& creature : toDamageCreatures) {
 		CombatDamage damageCopy = damage; // we cannot avoid copying here, because we don't know if it's player combat
 		                                  // or not, so we can't modify the initial damage.
 		bool playerCombatReduced = false;
 		if ((damageCopy.primary.value < 0 || damageCopy.secondary.value < 0) && caster) {
-			Player* targetPlayer = creature->getPlayer();
+			const auto& targetPlayer = creature->getPlayer();
 			if (casterPlayer && targetPlayer && casterPlayer != targetPlayer &&
 			    targetPlayer->getSkull() != SKULL_BLACK) {
 				damageCopy.primary.value /= 2;
@@ -986,7 +989,7 @@ void Combat::doAreaCombat(Creature* caster, const Position& position, const Area
 
 //**********************************************************//
 
-void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage) const
+void ValueCallback::getMinMaxValues(const std::shared_ptr<Player>& player, CombatDamage& damage) const
 {
 	// onGetPlayerMinMaxValues(...)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -1004,7 +1007,7 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage) const
 
 	scriptInterface->pushFunction(scriptId);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	int parameters = 1;
@@ -1019,12 +1022,11 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage) const
 
 		case COMBAT_FORMULA_SKILL: {
 			// onGetPlayerMinMaxValues(player, attackSkill, attackValue, attackFactor)
-			Item* tool = player->getWeapon();
-			const Weapon* weapon = g_weapons->getWeapon(tool);
-			Item* item = nullptr;
+			const auto& tool = player->getWeapon();
+			std::shared_ptr<Item> item = nullptr;
 
 			int32_t attackValue = 7;
-			if (weapon) {
+			if (const auto& weapon = g_weapons->getWeapon(tool)) {
 				attackValue = tool->getAttack();
 				if (tool->getWeaponType() == WEAPON_AMMO) {
 					item = player->getWeapon(true);
@@ -1068,7 +1070,7 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage) const
 
 //**********************************************************//
 
-void TileCallback::onTileCombat(Creature* creature, Tile* tile) const
+void TileCallback::onTileCombat(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Tile>& tile) const
 {
 	// onTileCombat(creature, pos)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -1086,7 +1088,7 @@ void TileCallback::onTileCombat(Creature* creature, Tile* tile) const
 
 	scriptInterface->pushFunction(scriptId);
 	if (creature) {
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
@@ -1098,7 +1100,8 @@ void TileCallback::onTileCombat(Creature* creature, Tile* tile) const
 
 //**********************************************************//
 
-void TargetCallback::onTargetCombat(Creature* creature, Creature* target) const
+void TargetCallback::onTargetCombat(const std::shared_ptr<Creature>& creature,
+                                    const std::shared_ptr<Creature>& target) const
 {
 	// onTargetCombat(creature, target)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -1117,14 +1120,14 @@ void TargetCallback::onTargetCombat(Creature* creature, Creature* target) const
 	scriptInterface->pushFunction(scriptId);
 
 	if (creature) {
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
 	}
 
 	if (target) {
-		tfs::lua::pushUserdata(L, target);
+		tfs::lua::pushSharedPtr(L, target);
 		tfs::lua::setCreatureMetatable(L, -1, target);
 	} else {
 		lua_pushnil(L);
@@ -1298,12 +1301,12 @@ void AreaCombat::setupExtArea(const std::vector<uint32_t>& vec, uint32_t rows)
 
 //**********************************************************//
 
-void MagicField::onStepInField(Creature* creature)
+void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 {
 	// remove magic walls/wild growth
 	if (id == ITEM_MAGICWALL_SAFE || id == ITEM_WILDGROWTH_SAFE || isBlocking()) {
 		if (!creature->isInGhostMode()) {
-			g_game.internalRemoveItem(this, 1);
+			g_game.internalRemoveItem(getMagicField(), 1);
 		}
 
 		return;
@@ -1312,7 +1315,7 @@ void MagicField::onStepInField(Creature* creature)
 	// remove magic walls/wild growth (only nopvp tiles/world)
 	if (id == ITEM_MAGICWALL_NOPVP || id == ITEM_WILDGROWTH_NOPVP) {
 		if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
-			g_game.internalRemoveItem(this, 1);
+			g_game.internalRemoveItem(getMagicField(), 1);
 		}
 		return;
 	}
@@ -1327,26 +1330,22 @@ void MagicField::onStepInField(Creature* creature)
 		return;
 	}
 
-	const ItemType& it = items[getID()];
-	if (it.conditionDamage) {
+	if (const ItemType& it = items[getID()]; it.conditionDamage) {
 		Condition* conditionCopy = it.conditionDamage->clone();
-		uint32_t ownerId = getOwner();
-		if (ownerId) {
+
+		if (uint32_t ownerId = getOwner()) {
 			bool harmfulField = true;
 
 			if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
-				Creature* owner = g_game.getCreatureByID(ownerId);
-				if (owner) {
+				if (const auto& owner = g_game.getCreatureByID(ownerId)) {
 					if (owner->getPlayer() || (owner->isSummon() && owner->getMaster()->getPlayer())) {
 						harmfulField = false;
 					}
 				}
 			}
 
-			Player* targetPlayer = creature->getPlayer();
-			if (!harmfulField && targetPlayer) {
-				Player* attackerPlayer = g_game.getPlayerByID(ownerId);
-				if (attackerPlayer) {
+			if (const auto& targetPlayer = creature->getPlayer(); !harmfulField && targetPlayer) {
+				if (const auto& attackerPlayer = g_game.getPlayerByID(ownerId)) {
 					if (isProtected(attackerPlayer, targetPlayer)) {
 						harmfulField = false;
 					}

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -153,7 +153,7 @@ void Condition::setTicks(int32_t newTicks)
 	endTime = ticks + OTSYS_TIME();
 }
 
-bool Condition::executeCondition(Creature*, int32_t interval)
+bool Condition::executeCondition(const std::shared_ptr<Creature>&, int32_t interval)
 {
 	if (ticks == -1) {
 		return true;
@@ -290,7 +290,7 @@ Condition* Condition::createCondition(PropStream& propStream)
 	                       subId, aggressive);
 }
 
-bool Condition::startCondition(Creature*)
+bool Condition::startCondition(const std::shared_ptr<Creature>&)
 {
 	if (ticks > 0) {
 		endTime = ticks + OTSYS_TIME();
@@ -330,19 +330,22 @@ bool Condition::updateCondition(const Condition* addCondition)
 	return true;
 }
 
-bool ConditionGeneric::startCondition(Creature* creature) { return Condition::startCondition(creature); }
+bool ConditionGeneric::startCondition(const std::shared_ptr<Creature>& creature)
+{
+	return Condition::startCondition(creature);
+}
 
-bool ConditionGeneric::executeCondition(Creature* creature, int32_t interval)
+bool ConditionGeneric::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	return Condition::executeCondition(creature, interval);
 }
 
-void ConditionGeneric::endCondition(Creature*)
+void ConditionGeneric::endCondition(const std::shared_ptr<Creature>&)
 {
 	//
 }
 
-void ConditionGeneric::addCondition(Creature*, const Condition* condition)
+void ConditionGeneric::addCondition(const std::shared_ptr<Creature>&, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
@@ -373,7 +376,7 @@ uint32_t ConditionGeneric::getIcons() const
 	return icons;
 }
 
-void ConditionAttributes::addCondition(Creature* creature, const Condition* condition)
+void ConditionAttributes::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
@@ -390,7 +393,7 @@ void ConditionAttributes::addCondition(Creature* creature, const Condition* cond
 		memcpy(statsPercent, conditionAttrs.statsPercent, sizeof(statsPercent));
 		disableDefense = conditionAttrs.disableDefense;
 
-		if (Player* player = creature->getPlayer()) {
+		if (const auto& player = creature->getPlayer()) {
 			updatePercentSkills(player);
 			updateSkills(player);
 			updatePercentStats(player);
@@ -436,7 +439,7 @@ void ConditionAttributes::serialize(PropWriteStream& propWriteStream)
 	}
 }
 
-bool ConditionAttributes::startCondition(Creature* creature)
+bool ConditionAttributes::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -444,7 +447,7 @@ bool ConditionAttributes::startCondition(Creature* creature)
 
 	creature->setUseDefense(!disableDefense);
 
-	if (Player* player = creature->getPlayer()) {
+	if (const auto& player = creature->getPlayer()) {
 		updatePercentSkills(player);
 		updateSkills(player);
 		updatePercentStats(player);
@@ -454,7 +457,7 @@ bool ConditionAttributes::startCondition(Creature* creature)
 	return true;
 }
 
-void ConditionAttributes::updatePercentStats(Player* player)
+void ConditionAttributes::updatePercentStats(const std::shared_ptr<Player>& player)
 {
 	for (int32_t i = STAT_FIRST; i <= STAT_LAST; ++i) {
 		if (statsPercent[i] == 0) {
@@ -477,7 +480,7 @@ void ConditionAttributes::updatePercentStats(Player* player)
 	}
 }
 
-void ConditionAttributes::updateStats(Player* player)
+void ConditionAttributes::updateStats(const std::shared_ptr<Player>& player)
 {
 	bool needUpdateStats = false;
 
@@ -494,7 +497,7 @@ void ConditionAttributes::updateStats(Player* player)
 	}
 }
 
-void ConditionAttributes::updatePercentSkills(Player* player)
+void ConditionAttributes::updatePercentSkills(const std::shared_ptr<Player>& player)
 {
 	for (uint8_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
 		if (skillsPercent[i] == 0) {
@@ -506,7 +509,7 @@ void ConditionAttributes::updatePercentSkills(Player* player)
 	}
 }
 
-void ConditionAttributes::updateSkills(Player* player)
+void ConditionAttributes::updateSkills(const std::shared_ptr<Player>& player)
 {
 	bool needUpdateSkills = false;
 
@@ -529,15 +532,14 @@ void ConditionAttributes::updateSkills(Player* player)
 	}
 }
 
-bool ConditionAttributes::executeCondition(Creature* creature, int32_t interval)
+bool ConditionAttributes::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	return ConditionGeneric::executeCondition(creature, interval);
 }
 
-void ConditionAttributes::endCondition(Creature* creature)
+void ConditionAttributes::endCondition(const std::shared_ptr<Creature>& creature)
 {
-	Player* player = creature->getPlayer();
-	if (player) {
+	if (const auto& player = creature->getPlayer()) {
 		bool needUpdateSkills = false;
 
 		for (int32_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
@@ -831,7 +833,7 @@ int32_t ConditionAttributes::getParam(ConditionParam_t param)
 	}
 }
 
-void ConditionRegeneration::addCondition(Creature*, const Condition* condition)
+void ConditionRegeneration::addCondition(const std::shared_ptr<Creature>&, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
@@ -877,7 +879,7 @@ void ConditionRegeneration::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<uint32_t>(manaGain);
 }
 
-bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interval)
+bool ConditionRegeneration::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	if (!creature) {
 		return false;
@@ -898,8 +900,7 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 		realHealthGain = creature->getHealth() - realHealthGain;
 
 		if (isBuff && realHealthGain > 0) {
-			Player* player = creature->getPlayer();
-			if (player) {
+			if (const auto& player = creature->getPlayer()) {
 				std::string healString =
 				    std::to_string(realHealthGain) + (realHealthGain != 1 ? " hitpoints." : " hitpoint.");
 
@@ -915,9 +916,9 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 				if (!spectators.empty()) {
 					message.type = MESSAGE_HEALED_OTHERS;
 					message.text = player->getName() + " was healed for " + healString;
-					for (Creature* spectator : spectators) {
-						assert(dynamic_cast<Player*>(spectator) != nullptr);
-						static_cast<Player*>(spectator)->sendTextMessage(message);
+					for (const auto& spectator : spectators) {
+						assert(spectator->getPlayer() != nullptr);
+						std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 					}
 				}
 			}
@@ -927,7 +928,7 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 	if (internalManaTicks >= manaTicks) {
 		internalManaTicks = 0;
 
-		if (Player* player = creature->getPlayer()) {
+		if (const auto& player = creature->getPlayer()) {
 			int32_t realManaGain = player->getMana();
 			player->changeMana(manaGain);
 			realManaGain = player->getMana() - realManaGain;
@@ -947,9 +948,9 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 				if (!spectators.empty()) {
 					message.type = MESSAGE_HEALED_OTHERS;
 					message.text = player->getName() + " gained " + manaGainString + " mana.";
-					for (Creature* spectator : spectators) {
-						assert(dynamic_cast<Player*>(spectator) != nullptr);
-						static_cast<Player*>(spectator)->sendTextMessage(message);
+					for (const auto& spectator : spectators) {
+						assert(spectator->getPlayer() != nullptr);
+						std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 					}
 				}
 			}
@@ -1005,7 +1006,7 @@ int32_t ConditionRegeneration::getParam(ConditionParam_t param)
 	}
 }
 
-void ConditionSoul::addCondition(Creature*, const Condition* condition)
+void ConditionSoul::addCondition(const std::shared_ptr<Creature>&, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
@@ -1038,7 +1039,7 @@ void ConditionSoul::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<uint32_t>(soulTicks);
 }
 
-bool ConditionSoul::executeCondition(Creature* creature, int32_t interval)
+bool ConditionSoul::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	if (!creature) {
 		return false;
@@ -1046,7 +1047,7 @@ bool ConditionSoul::executeCondition(Creature* creature, int32_t interval)
 
 	internalSoulTicks += interval;
 
-	if (Player* player = creature->getPlayer()) {
+	if (const auto& player = creature->getPlayer()) {
 		if (player->getZone() != ZONE_PROTECTION) {
 			if (internalSoulTicks >= soulTicks) {
 				internalSoulTicks = 0;
@@ -1292,7 +1293,7 @@ bool ConditionDamage::init()
 	return !damageList.empty();
 }
 
-bool ConditionDamage::startCondition(Creature* creature)
+bool ConditionDamage::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -1311,7 +1312,7 @@ bool ConditionDamage::startCondition(Creature* creature)
 	return true;
 }
 
-bool ConditionDamage::executeCondition(Creature* creature, int32_t interval)
+bool ConditionDamage::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	if (periodDamage != 0) {
 		periodDamageTick += interval;
@@ -1401,7 +1402,7 @@ constexpr CombatType_t ConditionToDamageType(ConditionType_t type)
 	return COMBAT_NONE;
 }
 
-bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange)
+bool ConditionDamage::doDamage(const std::shared_ptr<Creature>& creature, int32_t healthChange)
 {
 	if (!creature) {
 		return false;
@@ -1416,7 +1417,7 @@ bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange)
 	damage.primary.value = healthChange;
 	damage.primary.type = ConditionToDamageType(conditionType);
 
-	Creature* attacker = g_game.getCreatureByID(owner);
+	const auto& attacker = g_game.getCreatureByID(owner);
 	if (field && creature->getPlayer() && attacker && attacker->getPlayer()) {
 		damage.primary.value = static_cast<int32_t>(std::round(damage.primary.value / 2.));
 	}
@@ -1435,12 +1436,12 @@ bool ConditionDamage::doDamage(Creature* creature, int32_t healthChange)
 	return g_game.combatChangeHealth(attacker, creature, damage);
 }
 
-void ConditionDamage::endCondition(Creature*)
+void ConditionDamage::endCondition(const std::shared_ptr<Creature>&)
 {
 	//
 }
 
-void ConditionDamage::addCondition(Creature* creature, const Condition* condition)
+void ConditionDamage::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (condition->getType() != conditionType) {
 		return;
@@ -1639,7 +1640,7 @@ static std::pair<int32_t, int32_t> getFormulaValues(int32_t var, float mina, flo
 	return {std::fma(var, mina, minb), std::fma(var, maxa, maxb)};
 }
 
-bool ConditionSpeed::startCondition(Creature* creature)
+bool ConditionSpeed::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -1654,14 +1655,17 @@ bool ConditionSpeed::startCondition(Creature* creature)
 	return true;
 }
 
-bool ConditionSpeed::executeCondition(Creature* creature, int32_t interval)
+bool ConditionSpeed::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	return Condition::executeCondition(creature, interval);
 }
 
-void ConditionSpeed::endCondition(Creature* creature) { g_game.changeSpeed(creature, -speedDelta); }
+void ConditionSpeed::endCondition(const std::shared_ptr<Creature>& creature)
+{
+	g_game.changeSpeed(creature, -speedDelta);
+}
 
-void ConditionSpeed::addCondition(Creature* creature, const Condition* condition)
+void ConditionSpeed::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (conditionType != condition->getType()) {
 		return;
@@ -1710,7 +1714,7 @@ uint32_t ConditionSpeed::getIcons() const
 	return icons;
 }
 
-bool ConditionInvisible::startCondition(Creature* creature)
+bool ConditionInvisible::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -1722,7 +1726,7 @@ bool ConditionInvisible::startCondition(Creature* creature)
 	return true;
 }
 
-void ConditionInvisible::endCondition(Creature* creature)
+void ConditionInvisible::endCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!creature->isInGhostMode() && !creature->isInvisible()) {
 		g_game.internalCreatureChangeVisible(creature, true);
@@ -1747,7 +1751,7 @@ void ConditionOutfit::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<Outfit_t>(outfit);
 }
 
-bool ConditionOutfit::startCondition(Creature* creature)
+bool ConditionOutfit::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -1757,17 +1761,17 @@ bool ConditionOutfit::startCondition(Creature* creature)
 	return true;
 }
 
-bool ConditionOutfit::executeCondition(Creature* creature, int32_t interval)
+bool ConditionOutfit::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	return Condition::executeCondition(creature, interval);
 }
 
-void ConditionOutfit::endCondition(Creature* creature)
+void ConditionOutfit::endCondition(const std::shared_ptr<Creature>& creature)
 {
 	g_game.internalCreatureChangeOutfit(creature, creature->getDefaultOutfit());
 }
 
-void ConditionOutfit::addCondition(Creature* creature, const Condition* condition)
+void ConditionOutfit::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
@@ -1779,7 +1783,7 @@ void ConditionOutfit::addCondition(Creature* creature, const Condition* conditio
 	}
 }
 
-bool ConditionLight::startCondition(Creature* creature)
+bool ConditionLight::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -1792,7 +1796,7 @@ bool ConditionLight::startCondition(Creature* creature)
 	return true;
 }
 
-bool ConditionLight::executeCondition(Creature* creature, int32_t interval)
+bool ConditionLight::executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval)
 {
 	if (!creature) {
 		return false;
@@ -1814,13 +1818,13 @@ bool ConditionLight::executeCondition(Creature* creature, int32_t interval)
 	return Condition::executeCondition(creature, interval);
 }
 
-void ConditionLight::endCondition(Creature* creature)
+void ConditionLight::endCondition(const std::shared_ptr<Creature>& creature)
 {
 	creature->setNormalCreatureLight();
 	g_game.changeLight(creature);
 }
 
-void ConditionLight::addCondition(Creature* creature, const Condition* condition)
+void ConditionLight::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
@@ -1920,65 +1924,61 @@ void ConditionLight::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<uint32_t>(lightChangeInterval);
 }
 
-void ConditionSpellCooldown::addCondition(Creature* creature, const Condition* condition)
+void ConditionSpellCooldown::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
 
 		if (subId != 0 && ticks > 0) {
-			Player* player = creature->getPlayer();
-			if (player) {
+			if (const auto& player = creature->getPlayer()) {
 				player->sendSpellCooldown(subId, ticks);
 			}
 		}
 	}
 }
 
-bool ConditionSpellCooldown::startCondition(Creature* creature)
+bool ConditionSpellCooldown::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
 	}
 
 	if (subId != 0 && ticks > 0) {
-		Player* player = creature->getPlayer();
-		if (player) {
+		if (const auto& player = creature->getPlayer()) {
 			player->sendSpellCooldown(subId, ticks);
 		}
 	}
 	return true;
 }
 
-void ConditionSpellGroupCooldown::addCondition(Creature* creature, const Condition* condition)
+void ConditionSpellGroupCooldown::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (updateCondition(condition)) {
 		setTicks(condition->getTicks());
 
 		if (subId != 0 && ticks > 0) {
-			Player* player = creature->getPlayer();
-			if (player) {
+			if (const auto& player = creature->getPlayer()) {
 				player->sendSpellGroupCooldown(static_cast<SpellGroup_t>(subId), ticks);
 			}
 		}
 	}
 }
 
-bool ConditionSpellGroupCooldown::startCondition(Creature* creature)
+bool ConditionSpellGroupCooldown::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
 	}
 
 	if (subId != 0 && ticks > 0) {
-		Player* player = creature->getPlayer();
-		if (player) {
+		if (const auto& player = creature->getPlayer()) {
 			player->sendSpellGroupCooldown(static_cast<SpellGroup_t>(subId), ticks);
 		}
 	}
 	return true;
 }
 
-bool ConditionDrunk::startCondition(Creature* creature)
+bool ConditionDrunk::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!Condition::startCondition(creature)) {
 		return false;
@@ -1994,7 +1994,7 @@ bool ConditionDrunk::updateCondition(const Condition* addCondition)
 	return conditionDrunk->drunkenness > drunkenness;
 }
 
-void ConditionDrunk::addCondition(Creature* creature, const Condition* condition)
+void ConditionDrunk::addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition)
 {
 	if (!updateCondition(condition)) {
 		return;
@@ -2005,7 +2005,7 @@ void ConditionDrunk::addCondition(Creature* creature, const Condition* condition
 	creature->setDrunkenness(conditionDrunk->drunkenness);
 }
 
-void ConditionDrunk::endCondition(Creature* creature) { creature->setDrunkenness(0); }
+void ConditionDrunk::endCondition(const std::shared_ptr<Creature>& creature) { creature->setDrunkenness(0); }
 
 uint32_t ConditionDrunk::getIcons() const { return ICON_DRUNK; }
 
@@ -2025,7 +2025,7 @@ bool ConditionDrunk::setParam(ConditionParam_t param, int32_t value)
 	}
 }
 
-bool ConditionManaShield::startCondition(Creature* creature)
+bool ConditionManaShield::startCondition(const std::shared_ptr<Creature>& creature)
 {
 	if (!creature) {
 		return false;
@@ -2035,7 +2035,7 @@ bool ConditionManaShield::startCondition(Creature* creature)
 		return false;
 	}
 
-	if (Player* player = creature->getPlayer()) {
+	if (const auto& player = creature->getPlayer()) {
 		const auto& conditionManaShield = static_cast<const ConditionManaShield&>(*this);
 		manaShield = conditionManaShield.manaShield;
 		maxManaShield = conditionManaShield.manaShield;
@@ -2045,16 +2045,16 @@ bool ConditionManaShield::startCondition(Creature* creature)
 	return false;
 }
 
-void ConditionManaShield::endCondition(Creature* creature)
+void ConditionManaShield::endCondition(const std::shared_ptr<Creature>& creature)
 {
-	if (Player* player = creature->getPlayer()) {
+	if (const auto& player = creature->getPlayer()) {
 		player->sendStats();
 	}
 }
 
-void ConditionManaShield::addCondition(Creature* creature, const Condition* addCondition)
+void ConditionManaShield::addCondition(const std::shared_ptr<Creature>& creature, const Condition* addCondition)
 {
-	if (Player* player = creature->getPlayer()) {
+	if (const auto& player = creature->getPlayer()) {
 		endCondition(player);
 		setTicks(addCondition->getTicks());
 
@@ -2077,7 +2077,7 @@ bool ConditionManaShield::unserializeProp(ConditionAttr_t attr, PropStream& prop
 	return Condition::unserializeProp(attr, propStream);
 }
 
-int32_t ConditionManaShield::onDamageTaken(Player* player, int32_t manaChange)
+int32_t ConditionManaShield::onDamageTaken(const std::shared_ptr<Player>& player, int32_t manaChange)
 {
 	if (!player) {
 		return 0;

--- a/src/condition.h
+++ b/src/condition.h
@@ -73,10 +73,10 @@ public:
 	{}
 	virtual ~Condition() = default;
 
-	virtual bool startCondition(Creature* creature);
-	virtual bool executeCondition(Creature* creature, int32_t interval);
-	virtual void endCondition(Creature* creature) = 0;
-	virtual void addCondition(Creature* creature, const Condition* condition) = 0;
+	virtual bool startCondition(const std::shared_ptr<Creature>& creature);
+	virtual bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval);
+	virtual void endCondition(const std::shared_ptr<Creature>& creature) = 0;
+	virtual void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) = 0;
 	virtual uint32_t getIcons() const;
 	ConditionId_t getId() const { return id; }
 	uint32_t getSubId() const { return subId; }
@@ -125,10 +125,10 @@ public:
 	    Condition(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 	uint32_t getIcons() const override;
 
 	ConditionGeneric* clone() const override { return new ConditionGeneric(*this); }
@@ -142,10 +142,10 @@ public:
 	    ConditionGeneric(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
@@ -168,10 +168,10 @@ private:
 
 	bool disableDefense = false;
 
-	void updatePercentStats(Player* player);
-	void updateStats(Player* player);
-	void updatePercentSkills(Player* player);
-	void updateSkills(Player* player);
+	void updatePercentStats(const std::shared_ptr<Player>& player);
+	void updateStats(const std::shared_ptr<Player>& player);
+	void updatePercentSkills(const std::shared_ptr<Player>& player);
+	void updateSkills(const std::shared_ptr<Player>& player);
 };
 
 class ConditionRegeneration final : public ConditionGeneric
@@ -182,8 +182,8 @@ public:
 	    ConditionGeneric(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	void addCondition(Creature* creature, const Condition* condition) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
@@ -212,8 +212,8 @@ public:
 	    ConditionGeneric(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	void addCondition(Creature* creature, const Condition* condition) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
@@ -238,8 +238,8 @@ public:
 	    ConditionGeneric(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	void endCondition(Creature* creature) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
 
 	ConditionInvisible* clone() const override { return new ConditionInvisible(*this); }
 };
@@ -255,10 +255,10 @@ public:
 
 	static void generateDamageList(int32_t amount, int32_t start, std::list<int32_t>& list);
 
-	bool startCondition(Creature* creature) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 	uint32_t getIcons() const override;
 
 	ConditionDamage* clone() const override { return new ConditionDamage(*this); }
@@ -295,7 +295,7 @@ private:
 	std::list<IntervalInfo> damageList;
 
 	bool getNextDamage(int32_t& damage);
-	bool doDamage(Creature* creature, int32_t healthChange);
+	bool doDamage(const std::shared_ptr<Creature>& creature, int32_t healthChange);
 
 	bool updateCondition(const Condition* addCondition) override;
 };
@@ -308,10 +308,10 @@ public:
 	    Condition(id, type, ticks, buff, subId, aggressive), speedDelta(changeSpeed)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 	uint32_t getIcons() const override;
 
 	ConditionSpeed* clone() const override { return new ConditionSpeed(*this); }
@@ -343,10 +343,10 @@ public:
 	    Condition(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
 	ConditionOutfit* clone() const override { return new ConditionOutfit(*this); }
 
@@ -368,10 +368,10 @@ public:
 	    Condition{id, type, ticks, buff, subId, aggressive}, lightInfo{.level = lightlevel, .color = lightcolor}
 	{}
 
-	bool startCondition(Creature* creature) override;
-	bool executeCondition(Creature* creature, int32_t interval) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	bool executeCondition(const std::shared_ptr<Creature>& creature, int32_t interval) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
 	ConditionLight* clone() const override { return new ConditionLight(*this); }
 
@@ -396,8 +396,8 @@ public:
 	    ConditionGeneric(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
 	ConditionSpellCooldown* clone() const override { return new ConditionSpellCooldown(*this); }
 };
@@ -410,8 +410,8 @@ public:
 	    ConditionGeneric(id, type, ticks, buff, subId, aggressive)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
 	ConditionSpellGroupCooldown* clone() const override { return new ConditionSpellGroupCooldown(*this); }
 };
@@ -429,10 +429,10 @@ public:
 	}
 
 	uint32_t getIcons() const override;
-	void endCondition(Creature* creature) override;
-	bool startCondition(Creature* creature) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
 	bool setParam(ConditionParam_t param, int32_t value) override;
-	void addCondition(Creature* creature, const Condition* condition) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
 	ConditionDrunk* clone() const override { return new ConditionDrunk(*this); }
 
@@ -450,9 +450,9 @@ public:
 	    Condition(initId, initType, iniTicks, initBuff, initSubId)
 	{}
 
-	bool startCondition(Creature* creature) override;
-	void endCondition(Creature* creature) override;
-	void addCondition(Creature* creature, const Condition* addCondition) override;
+	bool startCondition(const std::shared_ptr<Creature>& creature) override;
+	void endCondition(const std::shared_ptr<Creature>& creature) override;
+	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* addCondition) override;
 	uint32_t getIcons() const override;
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
@@ -462,7 +462,7 @@ public:
 	// serialization
 	void serialize(PropWriteStream& propWriteStream) override;
 	bool unserializeProp(ConditionAttr_t attr, PropStream& propStream) override;
-	int32_t onDamageTaken(Player* player, int32_t manaChange);
+	int32_t onDamageTaken(const std::shared_ptr<Player>& player, int32_t manaChange);
 
 	uint16_t getManaShield() { return manaShield; }
 	uint16_t getMaxManaShield() { return maxManaShield; }

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -7,7 +7,6 @@
 #include "configmanager.h"
 
 #include "game.h"
-#include "monster.h"
 #include "pugicast.h"
 
 #if LUA_VERSION_NUM >= 502

--- a/src/container.h
+++ b/src/container.h
@@ -16,10 +16,10 @@ public:
 	bool hasNext() const { return !over.empty(); }
 
 	void advance();
-	Item* operator*();
+	std::shared_ptr<Item> operator*() { return *cur; }
 
 private:
-	std::list<const Container*> over;
+	std::list<std::shared_ptr<const Container>> over;
 	ItemDeque::const_iterator cur;
 
 	friend class Container;
@@ -28,51 +28,60 @@ private:
 class Container : public Item
 {
 public:
-	explicit Container(uint16_t type);
-	Container(uint16_t type, uint16_t size, bool unlocked = true, bool pagination = false);
-	explicit Container(Tile* tile);
-	~Container();
+	explicit Container(uint16_t type) : Container{type, items[type].maxItems} {}
+
+	Container(uint16_t type, uint16_t size, bool unlocked = true, bool pagination = false) :
+	    Item{type}, maxSize{size}, unlocked{unlocked}, pagination{pagination}
+	{}
+
+	virtual ~Container();
 
 	// non-copyable
 	Container(const Container&) = delete;
 	Container& operator=(const Container&) = delete;
 
-	Item* clone() const override final;
+	std::shared_ptr<Item> clone() const override final;
 
-	Thing* getReceiver() override final { return this; }
-	const Thing* getReceiver() const override final { return this; }
+	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	Container* getContainer() override final { return this; }
-	const Container* getContainer() const override final { return this; }
+	std::shared_ptr<Container> getContainer() override final
+	{
+		return std::static_pointer_cast<Container>(shared_from_this());
+	}
+	std::shared_ptr<const Container> getContainer() const override final
+	{
+		return std::static_pointer_cast<const Container>(shared_from_this());
+	}
 
-	virtual DepotLocker* getDepotLocker() { return nullptr; }
-	virtual const DepotLocker* getDepotLocker() const { return nullptr; }
+	virtual std::shared_ptr<DepotLocker> getDepotLocker() { return nullptr; }
+	virtual std::shared_ptr<const DepotLocker> getDepotLocker() const { return nullptr; }
 
-	virtual StoreInbox* getStoreInbox() { return nullptr; }
-	virtual const StoreInbox* getStoreInbox() const { return nullptr; }
+	virtual std::shared_ptr<StoreInbox> getStoreInbox() { return nullptr; }
+	virtual std::shared_ptr<const StoreInbox> getStoreInbox() const { return nullptr; }
 
 	bool hasContainerParent() const;
 
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 	bool unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, PropStream& propStream) override;
 
-	size_t size() const { return itemlist.size(); }
-	bool empty() const { return itemlist.empty(); }
+	size_t size() const { return itemList.size(); }
+	bool empty() const { return itemList.empty(); }
 	uint32_t capacity() const { return maxSize; }
 	uint32_t getAmmoCount() const { return ammoCount; }
 
 	ContainerIterator iterator() const;
 
-	const ItemDeque& getItemList() const { return itemlist; }
+	const ItemDeque& getItemList() const { return itemList; }
 
-	ItemDeque::const_reverse_iterator getReversedItems() const { return itemlist.rbegin(); }
-	ItemDeque::const_reverse_iterator getReversedEnd() const { return itemlist.rend(); }
+	ItemDeque::const_reverse_iterator getReversedItems() const { return itemList.rbegin(); }
+	ItemDeque::const_reverse_iterator getReversedEnd() const { return itemList.rend(); }
 
 	std::string getName(bool addArticle = false) const;
 
-	void addItem(Item* item);
-	Item* getItemByIndex(size_t index) const;
-	bool isHoldingItem(const Item* item) const;
+	void addItem(std::shared_ptr<Item> item);
+	std::shared_ptr<Item> getItemByIndex(size_t index) const;
+	bool isHoldingItem(const std::shared_ptr<const Item>& item) const;
 
 	uint32_t getItemHoldingCount() const;
 	uint32_t getWeight() const override final;
@@ -80,44 +89,44 @@ public:
 	bool isUnlocked() const { return unlocked; }
 	bool hasPagination() const { return pagination; }
 
-	virtual ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                             Creature* actor = nullptr) const override;
-	ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-	                          uint32_t flags) const override final;
-	ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags,
-	                        Creature* actor = nullptr) const override final;
-	Thing* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override final;
+	virtual ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+	                             uint32_t flags, const std::shared_ptr<Creature>& actor = nullptr) const override;
+	ReturnValue queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+	                          uint32_t& maxQueryCount, uint32_t flags) const override final;
+	ReturnValue queryRemove(const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                        const std::shared_ptr<Creature>& actor = nullptr) const override final;
+	std::shared_ptr<Thing> queryDestination(int32_t& index, const std::shared_ptr<const Thing>& thing,
+	                                        std::shared_ptr<Item>& destItem, uint32_t& flags) override final;
 
-	void addThing(Thing* thing) override final { return addThing(0, thing); }
-	void addThing(int32_t index, Thing* thing) override final;
-	void addItemBack(Item* item);
+	void addThing(const std::shared_ptr<Thing>& thing) override final { return addThing(0, thing); }
+	void addThing(int32_t index, const std::shared_ptr<Thing>& thing) override final;
+	void addItemBack(const std::shared_ptr<Item>& item);
 
-	void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override final;
-	void replaceThing(uint32_t index, Thing* thing) override final;
+	void updateThing(const std::shared_ptr<Thing>& thing, uint16_t itemId, uint32_t count) override final;
+	void replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing) override final;
 
-	void removeThing(Thing* thing, uint32_t count) override final;
+	void removeThing(const std::shared_ptr<Thing>& thing, uint32_t count) override final;
 
-	int32_t getThingIndex(const Thing* thing) const override final;
-	size_t getFirstIndex() const override final { return 0; }
+	int32_t getThingIndex(const std::shared_ptr<const Thing>& thing) const override final;
 	size_t getLastIndex() const override final { return size(); }
 	uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override final;
 	std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const override final;
-	Thing* getThing(size_t index) const override final { return getItemByIndex(index); }
+	std::shared_ptr<Thing> getThing(size_t index) const override final { return getItemByIndex(index); }
 
-	std::vector<Item*> getItems(bool recursive = false);
+	std::vector<std::shared_ptr<Item>> getItems(bool recursive = false);
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 
-	void internalRemoveThing(Thing* thing) override final;
-	void internalAddThing(Thing* thing) override final { internalAddThing(0, thing); }
-	void internalAddThing(uint32_t index, Thing* thing) override final;
+	void internalRemoveThing(const std::shared_ptr<Thing>& thing) override final;
+	void internalAddThing(const std::shared_ptr<Thing>& thing) override final { internalAddThing(0, thing); }
+	void internalAddThing(uint32_t index, const std::shared_ptr<Thing>& thing) override final;
 	void startDecaying() override final;
 
 protected:
-	ItemDeque itemlist;
+	ItemDeque itemList;
 
 private:
 	uint32_t maxSize;
@@ -128,9 +137,10 @@ private:
 	bool unlocked;
 	bool pagination;
 
-	void onAddContainerItem(Item* item);
-	void onUpdateContainerItem(uint32_t index, Item* oldItem, Item* newItem);
-	void onRemoveContainerItem(uint32_t index, Item* item);
+	void onAddContainerItem(const std::shared_ptr<Item>& item);
+	void onUpdateContainerItem(uint32_t index, const std::shared_ptr<Item>& oldItem,
+	                           const std::shared_ptr<Item>& newItem);
+	void onRemoveContainerItem(uint32_t index, const std::shared_ptr<Item>& item);
 
 	void updateItemWeight(int32_t diff);
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -17,7 +17,6 @@ class Monster;
 class Npc;
 class Player;
 
-using ConditionList = std::list<Condition*>;
 using CreatureEventList = std::list<CreatureEvent*>;
 using CreatureIconHashMap = std::unordered_map<CreatureIcon_t, uint16_t>;
 
@@ -77,7 +76,7 @@ private:
 // Defines the Base class for all creatures and base functions which
 // every creature has
 
-class Creature : virtual public Thing
+class Creature : public Thing
 {
 protected:
 	Creature();
@@ -91,14 +90,21 @@ public:
 	Creature(const Creature&) = delete;
 	Creature& operator=(const Creature&) = delete;
 
-	Creature* getCreature() override final { return this; }
-	const Creature* getCreature() const override final { return this; }
-	virtual Player* getPlayer() { return nullptr; }
-	virtual const Player* getPlayer() const { return nullptr; }
-	virtual Npc* getNpc() { return nullptr; }
-	virtual const Npc* getNpc() const { return nullptr; }
-	virtual Monster* getMonster() { return nullptr; }
-	virtual const Monster* getMonster() const { return nullptr; }
+	std::shared_ptr<Creature> getCreature() override final
+	{
+		return std::static_pointer_cast<Creature>(shared_from_this());
+	}
+	std::shared_ptr<const Creature> getCreature() const override final
+	{
+		return std::static_pointer_cast<const Creature>(shared_from_this());
+	}
+
+	virtual std::shared_ptr<Player> getPlayer() { return nullptr; }
+	virtual std::shared_ptr<const Player> getPlayer() const { return nullptr; }
+	virtual std::shared_ptr<Npc> getNpc() { return nullptr; }
+	virtual std::shared_ptr<const Npc> getNpc() const { return nullptr; }
+	virtual std::shared_ptr<Monster> getMonster() { return nullptr; }
+	virtual std::shared_ptr<const Monster> getMonster() const { return nullptr; }
 
 	virtual const std::string& getName() const = 0;
 	virtual const std::string& getNameDescription() const = 0;
@@ -114,11 +120,14 @@ public:
 	virtual void addList() = 0;
 
 	virtual bool canSee(const Position& pos) const;
-	virtual bool canSeeCreature(const Creature* creature) const;
+	virtual bool canSeeCreature(const std::shared_ptr<const Creature>& creature) const;
 
 	virtual RaceType_t getRace() const { return RACE_NONE; }
 	virtual Skulls_t getSkull() const { return skull; }
-	virtual Skulls_t getSkullClient(const Creature* creature) const { return creature->getSkull(); }
+	virtual Skulls_t getSkullClient(const std::shared_ptr<const Creature>& creature) const
+	{
+		return creature->getSkull();
+	}
 	void setSkull(Skulls_t newSkull);
 	Direction getDirection() const { return direction; }
 	void setDirection(Direction dir) { direction = dir; }
@@ -131,7 +140,7 @@ public:
 	bool isRemoved() const override final { return isInternalRemoved; }
 	virtual bool canSeeInvisibility() const { return false; }
 	virtual bool isInGhostMode() const { return false; }
-	virtual bool canSeeGhostMode(const Creature*) const { return false; }
+	virtual bool canSeeGhostMode(const std::shared_ptr<const Creature>&) const { return false; }
 
 	int32_t getWalkDelay(Direction dir) const;
 	int32_t getWalkDelay() const;
@@ -159,7 +168,9 @@ public:
 	uint32_t getBaseSpeed() const { return baseSpeed; }
 
 	int32_t getHealth() const { return health; }
+	void setHealth(int32_t newHealth) { health = std::clamp(newHealth, 0, healthMax); }
 	virtual int32_t getMaxHealth() const { return healthMax; }
+	virtual void setMaxHealth(int32_t newMaxHealth) { healthMax = newMaxHealth; }
 	bool isDead() const { return health <= 0; }
 
 	void setDrunkenness(uint8_t newDrunkenness) { drunkenness = newDrunkenness; }
@@ -168,10 +179,11 @@ public:
 	const Outfit_t getCurrentOutfit() const { return currentOutfit; }
 	void setCurrentOutfit(Outfit_t outfit) { currentOutfit = outfit; }
 	const Outfit_t getDefaultOutfit() const { return defaultOutfit; }
+	void setDefaultOutfit(Outfit_t outfit) { defaultOutfit = outfit; }
 	bool isInvisible() const;
 	ZoneType_t getZone() const
 	{
-		const Tile* tile = getTile();
+		const auto& tile = getTile();
 		if (!tile) {
 			return ZONE_NORMAL;
 		}
@@ -198,51 +210,58 @@ public:
 	virtual void onWalkComplete() {}
 
 	// follow functions
-	Creature* getFollowCreature() const { return followCreature; }
-	virtual void setFollowCreature(Creature* creature);
+	std::shared_ptr<Creature> getFollowCreature() const { return followCreature.lock(); }
+	virtual void setFollowCreature(const std::shared_ptr<Creature>& creature);
 	virtual void removeFollowCreature();
-	virtual bool canFollowCreature(Creature* creature);
-	virtual bool isFollowingCreature(Creature* creature) { return followCreature == creature; }
+	bool canFollowCreature(const std::shared_ptr<Creature>& creature);
+	bool isFollowingCreature(const std::shared_ptr<Creature>& creature)
+	{
+		return tfs::owner_equal(followCreature, creature);
+	}
 
 	// follow events
-	virtual void onFollowCreature(const Creature*);
+	virtual void onFollowCreature(const std::shared_ptr<const Creature>&);
 	virtual void onUnfollowCreature();
 
 	// Pathfinding functions
-	bool isFollower(const Creature* creature);
-	void addFollower(Creature* creature);
-	void removeFollower(Creature* creature);
+	void addFollower(const std::shared_ptr<Creature>& creature) { followers.insert(creature); }
+	void removeFollower(const std::shared_ptr<Creature>& creature) { followers.erase(creature); }
 	void removeFollowers();
-	void releaseFollowers();
 
 	// Pathfinding events
 	void updateFollowersPaths();
 
 	// combat functions
-	Creature* getAttackedCreature() { return attackedCreature; }
-	virtual void setAttackedCreature(Creature* creature);
+	std::shared_ptr<Creature> getAttackedCreature() { return attackedCreature.lock(); }
+	virtual void setAttackedCreature(const std::shared_ptr<Creature>& creature);
 	virtual void removeAttackedCreature();
-	virtual bool canAttackCreature(Creature* creature);
-	virtual bool isAttackingCreature(Creature* creature) { return attackedCreature == creature; }
+	bool canAttackCreature(const std::shared_ptr<Creature>& creature);
+	bool isAttackingCreature(const std::shared_ptr<Creature>& creature)
+	{
+		return tfs::owner_equal(creature, attackedCreature);
+	}
 
-	virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
+	virtual BlockType_t blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,
 	                             bool checkDefense = false, bool checkArmor = false, bool field = false,
 	                             bool ignoreResistances = false);
 
-	bool setMaster(Creature* newMaster);
+	bool setMaster(const std::shared_ptr<Creature>& newMaster);
+	void removeMaster() { master.reset(); }
 
-	void removeMaster()
+	bool isSummon() const { return !master.expired(); }
+	std::shared_ptr<Creature> getMaster() const { return master.lock(); }
+
+	const auto& getDamageMap() const { return damageMap; }
+
+	void removeSummon(const std::shared_ptr<Creature>& summon)
 	{
-		if (master) {
-			master = nullptr;
-			decrementReferenceCounter();
+		auto it = std::ranges::find_if(summons, [&summon](const auto& wp) { return summon == wp.lock(); });
+		if (it != summons.end()) {
+			summons.erase(it);
 		}
 	}
-
-	bool isSummon() const { return master != nullptr; }
-	Creature* getMaster() const { return master; }
-
-	const std::list<Creature*>& getSummons() const { return summons; }
+	const auto& getSummons() const { return summons; }
+	void clearSummons() { summons.clear(); }
 
 	virtual int32_t getArmor() const { return 0; }
 	virtual int32_t getDefense() const { return 0; }
@@ -257,6 +276,7 @@ public:
 	void removeCombatCondition(ConditionType_t type);
 	Condition* getCondition(ConditionType_t type) const;
 	Condition* getCondition(ConditionType_t type, ConditionId_t conditionId, uint32_t subId = 0) const;
+	const auto& getConditions() const { return conditions; }
 	void executeConditions(uint32_t interval);
 	bool hasCondition(ConditionType_t type, uint32_t subId = 0) const;
 	virtual bool isImmune(ConditionType_t type) const;
@@ -269,14 +289,14 @@ public:
 
 	virtual void changeHealth(int32_t healthChange, bool sendHealthChange = true);
 
-	void gainHealth(Creature* healer, int32_t healthGain);
-	virtual void drainHealth(Creature* attacker, int32_t damage);
+	void gainHealth(const std::shared_ptr<Creature>& healer, int32_t healthGain);
+	virtual void drainHealth(const std::shared_ptr<Creature>& attacker, int32_t damage);
 
-	virtual bool challengeCreature(Creature*, bool) { return false; }
+	virtual bool challengeCreature(const std::shared_ptr<Creature>&, bool) { return false; }
 
 	void onDeath();
-	virtual uint64_t getGainedExperience(Creature* attacker) const;
-	void addDamagePoints(Creature* attacker, int32_t damagePoints);
+	virtual uint64_t getGainedExperience(const std::shared_ptr<Creature>& attacker) const;
+	void addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_t damagePoints);
 	bool hasBeenAttacked(uint32_t attackerId);
 
 	// combat event functions
@@ -285,12 +305,12 @@ public:
 	virtual void onEndCondition(ConditionType_t type);
 	void onTickCondition(ConditionType_t type, bool& bRemove);
 	virtual void onCombatRemoveCondition(Condition* condition);
-	virtual void onAttackedCreature(Creature*, bool = true) {}
+	virtual void onAttackedCreature(const std::shared_ptr<Creature>&, bool = true) {}
 	virtual void onAttacked();
-	virtual void onAttackedCreatureDrainHealth(Creature* target, int32_t points);
-	virtual void onTargetCreatureGainHealth(Creature*, int32_t) {}
-	virtual bool onKilledCreature(Creature* target, bool lastHit = true);
-	virtual void onGainExperience(uint64_t gainExp, Creature* target);
+	virtual void onAttackedCreatureDrainHealth(const std::shared_ptr<Creature>& target, int32_t points);
+	virtual void onTargetCreatureGainHealth(const std::shared_ptr<Creature>&, int32_t) {}
+	virtual bool onKilledCreature(const std::shared_ptr<Creature>& target, bool lastHit = true);
+	virtual void onGainExperience(uint64_t gainExp, const std::shared_ptr<Creature>& target);
 	virtual void onAttackedCreatureBlockHit(BlockType_t) {}
 	virtual void onBlockHit() {}
 	virtual void onChangeZone(ZoneType_t zone);
@@ -307,24 +327,27 @@ public:
 	virtual void onWalk();
 	virtual bool getNextStep(Direction& dir, uint32_t& flags);
 
-	virtual void onUpdateTileItem(const Tile*, const Position&, const Item*, const ItemType&, const Item*,
-	                              const ItemType&)
+	virtual void onUpdateTileItem(const std::shared_ptr<const Tile>&, const Position&,
+	                              const std::shared_ptr<const Item>&, const ItemType&,
+	                              const std::shared_ptr<const Item>&, const ItemType&)
 	{}
-	virtual void onRemoveTileItem(const Tile*, const Position&, const ItemType&, const Item*) {}
+	virtual void onRemoveTileItem(const std::shared_ptr<const Tile>&, const Position&, const ItemType&,
+	                              const std::shared_ptr<const Item>&)
+	{}
 
-	virtual void onCreatureAppear(Creature*, bool, MagicEffectClasses) {}
-	virtual void onRemoveCreature(Creature* creature, bool isLogout);
-	virtual void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
+	virtual void onCreatureAppear(const std::shared_ptr<Creature>&, bool, MagicEffectClasses) {}
+	virtual void onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout);
+	virtual void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+	                            const Position& newPos, const std::shared_ptr<const Tile>& oldTile,
 	                            const Position& oldPos, bool teleport);
 
 	virtual void onAttackedCreatureDisappear(bool) {}
 	virtual void onFollowCreatureDisappear(bool) {}
 
-	virtual void onCreatureSay(Creature*, SpeakClasses, const std::string&) {}
+	virtual void onCreatureSay(const std::shared_ptr<Creature>&, SpeakClasses, const std::string&) {}
 
 	virtual bool getCombatValues(int32_t&, int32_t&) { return false; }
 
-	size_t getSummonCount() const { return summons.size(); }
 	void setDropLoot(bool lootDrop) { this->lootDrop = lootDrop; }
 	void setSkillLoss(bool skillLoss) { this->skillLoss = skillLoss; }
 	void setUseDefense(bool useDefense) { canUseDefense = useDefense; }
@@ -339,41 +362,35 @@ public:
 	bool registerCreatureEvent(const std::string& name);
 	bool unregisterCreatureEvent(const std::string& name);
 
-	Thing* getParent() const override final { return tile; }
-	void setParent(Thing* thing) override final
+	std::shared_ptr<Thing> getParent() const override final { return tile.lock(); }
+	void setParent(const std::shared_ptr<Thing>& thing) override final
 	{
 		tile = thing->getTile();
-		position = tile->getPosition();
+		position = thing->getTile()->getPosition();
 	}
 
 	const Position& getPosition() const override final { return position; }
 
-	Tile* getTile() override final { return tile; }
-	const Tile* getTile() const override final { return tile; }
+	std::shared_ptr<Tile> getTile() override final { return tile.lock(); }
+	std::shared_ptr<const Tile> getTile() const override final { return tile.lock(); }
 
 	const Position& getLastPosition() const { return lastPosition; }
 	void setLastPosition(Position newLastPos) { lastPosition = newLastPos; }
 
 	static bool canSee(const Position& myPos, const Position& pos, int32_t viewRangeX, int32_t viewRangeY);
 
-	double getDamageRatio(Creature* attacker) const;
+	double getDamageRatio(const std::shared_ptr<Creature>& attacker) const;
 
 	bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const FindPathParams& fpp) const;
 	bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, int32_t minTargetDist,
 	               int32_t maxTargetDist, bool fullPathSearch = true, bool clearSight = true,
 	               int32_t maxSearchDist = 0) const;
 
-	void incrementReferenceCounter() { ++referenceCounter; }
-	void decrementReferenceCounter()
-	{
-		if (--referenceCounter == 0) {
-			delete this;
-		}
-	}
-
 	virtual void setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn = false);
 	virtual std::optional<int32_t> getStorageValue(uint32_t key) const;
-	decltype(auto) getStorageMap() const { return storageMap; }
+	const auto& getStorageMap() const { return storageMap; }
+
+	CreatureEventList getCreatureEvents(CreatureEventType_t type);
 
 protected:
 	struct CountBlock_t
@@ -384,25 +401,14 @@ protected:
 
 	Position position;
 
-	using CountMap = std::map<uint32_t, CountBlock_t>;
-	CountMap damageMap;
-
-	std::list<Creature*> summons;
 	CreatureEventList eventsList;
-	ConditionList conditions;
+	std::vector<Condition*> conditions;
 	CreatureIconHashMap creatureIcons;
 
 	std::vector<Direction> listWalkDir;
 
-	Tile* tile = nullptr;
-	Creature* attackedCreature = nullptr;
-	Creature* master = nullptr;
-	Creature* followCreature = nullptr;
-	boost::container::flat_set<Creature*> followers;
-
 	uint64_t lastStep = 0;
 	int64_t lastPathUpdate = 0;
-	uint32_t referenceCounter = 0;
 	uint32_t id = 0;
 	uint32_t scriptEventsBitField = 0;
 	uint32_t eventWalk = 0;
@@ -443,26 +449,35 @@ protected:
 	{
 		return (0 != (scriptEventsBitField & (static_cast<uint32_t>(1) << event)));
 	}
-	CreatureEventList getCreatureEvents(CreatureEventType_t type);
 
-	void onCreatureDisappear(const Creature* creature, bool isLogout);
+	void onCreatureDisappear(const std::shared_ptr<const Creature>& creature, bool isLogout);
 	virtual void doAttacking(uint32_t) {}
 	virtual bool hasExtraSwing() { return false; }
 
 	virtual uint64_t getLostExperience() const { return 0; }
-	virtual void dropLoot(Container*, Creature*) {}
+	virtual void dropLoot(const std::shared_ptr<Container>&, const std::shared_ptr<Creature>&) {}
 	virtual uint16_t getLookCorpse() const { return 0; }
-	virtual void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const;
-	virtual void death(Creature*) {}
-	virtual bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified,
+	virtual void getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const;
+	virtual void death(const std::shared_ptr<Creature>&) {}
+	virtual bool dropCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+	                        const std::shared_ptr<Creature>& mostDamageCreature, bool lastHitUnjustified,
 	                        bool mostDamageUnjustified);
-	virtual Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature);
+	virtual std::shared_ptr<Item> getCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+	                                        const std::shared_ptr<Creature>& mostDamageCreature);
 
 	friend class Game;
 	friend class Map;
-	friend class LuaScriptInterface;
 
 private:
+	std::weak_ptr<Tile> tile;
+	std::weak_ptr<Creature> attackedCreature;
+	std::weak_ptr<Creature> master;
+	std::weak_ptr<Creature> followCreature;
+	boost::container::flat_set<std::weak_ptr<Creature>, std::owner_less<std::weak_ptr<Creature>>> followers;
+
+	std::vector<std::weak_ptr<Creature>> summons;
+
+	std::map<uint32_t, CountBlock_t> damageMap;
 	std::map<uint32_t, int32_t> storageMap;
 };
 

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -46,20 +46,25 @@ public:
 	void copyEvent(CreatureEvent* creatureEvent);
 
 	// scripting
-	bool executeOnLogin(Player* player) const;
-	bool executeOnLogout(Player* player) const;
-	void executeOnReconnect(Player* player) const;
-	bool executeOnThink(Creature* creature, uint32_t interval);
-	bool executeOnPrepareDeath(Creature* creature, Creature* killer);
-	bool executeOnDeath(Creature* creature, Item* corpse, Creature* killer, Creature* mostDamageKiller,
+	bool executeOnLogin(const std::shared_ptr<Player>& player) const;
+	bool executeOnLogout(const std::shared_ptr<Player>& player) const;
+	void executeOnReconnect(const std::shared_ptr<Player>& player) const;
+	bool executeOnThink(const std::shared_ptr<Creature>& creature, uint32_t interval);
+	bool executeOnPrepareDeath(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& killer);
+	bool executeOnDeath(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& corpse,
+	                    const std::shared_ptr<Creature>& killer, const std::shared_ptr<Creature>& mostDamageKiller,
 	                    bool lastHitUnjustified, bool mostDamageUnjustified);
-	void executeOnKill(Creature* creature, Creature* target);
-	bool executeAdvance(Player* player, skills_t, uint32_t, uint32_t);
-	void executeModalWindow(Player* player, uint32_t modalWindowId, uint8_t buttonId, uint8_t choiceId);
-	bool executeTextEdit(Player* player, Item* item, std::string_view text, const uint32_t windowTextId);
-	void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
-	void executeManaChange(Creature* creature, Creature* attacker, CombatDamage& damage);
-	void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);
+	void executeOnKill(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target);
+	bool executeAdvance(const std::shared_ptr<Player>& player, skills_t, uint32_t, uint32_t);
+	void executeModalWindow(const std::shared_ptr<Player>& player, uint32_t modalWindowId, uint8_t buttonId,
+	                        uint8_t choiceId);
+	bool executeTextEdit(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                     std::string_view text, const uint32_t windowTextId);
+	void executeHealthChange(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& attacker,
+	                         CombatDamage& damage);
+	void executeManaChange(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& attacker,
+	                       CombatDamage& damage);
+	void executeExtendedOpcode(const std::shared_ptr<Player>& player, uint8_t opcode, const std::string& buffer);
 	//
 
 private:
@@ -80,10 +85,10 @@ public:
 	CreatureEvents& operator=(const CreatureEvents&) = delete;
 
 	// global events
-	bool playerLogin(Player* player) const;
-	bool playerLogout(Player* player) const;
-	void playerReconnect(Player* player) const;
-	bool playerAdvance(Player* player, skills_t, uint32_t, uint32_t);
+	bool playerLogin(const std::shared_ptr<Player>& player) const;
+	bool playerLogout(const std::shared_ptr<Player>& player) const;
+	void playerReconnect(const std::shared_ptr<Player>& player) const;
+	bool playerAdvance(const std::shared_ptr<Player>& player, skills_t, uint32_t, uint32_t);
 
 	CreatureEvent* getEventByName(const std::string& name, bool forceLoaded = true);
 

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -7,14 +7,10 @@
 
 #include "tools.h"
 
-DepotChest::DepotChest(uint16_t type, bool paginated /*= true*/) :
-    Container{type, items[type].maxItems, true, paginated}
-{}
-
-ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-                                 Creature* actor /* = nullptr*/) const
+ReturnValue DepotChest::queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+                                 uint32_t flags, const std::shared_ptr<Creature>& actor /* = nullptr*/) const
 {
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -27,8 +23,8 @@ ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t cou
 			addCount = 1;
 		}
 
-		if (item->getTopParent() != this) {
-			if (const Container* container = item->getContainer()) {
+		if (item->getTopParent().get() != this) {
+			if (const auto& container = item->getContainer()) {
 				addCount = container->getItemHoldingCount() + 1;
 			} else {
 				addCount = 1;
@@ -43,22 +39,24 @@ ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t cou
 	return Container::queryAdd(index, thing, count, flags, actor);
 }
 
-void DepotChest::postAddNotification(Thing* thing, const Thing* oldParent, int32_t index, ReceiverLink_t)
+void DepotChest::postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+                                     int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void DepotChest::postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index, ReceiverLink_t)
+void DepotChest::postRemoveNotification(const std::shared_ptr<Thing>& thing,
+                                        const std::shared_ptr<const Thing>& newParent, int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }
 
-Thing* DepotChest::getParent() const
+std::shared_ptr<Thing> DepotChest::getParent() const
 {
-	const auto parent = Container::getParent();
+	const auto& parent = Container::getParent();
 	return parent ? parent->getParent() : nullptr;
 }

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -6,26 +6,24 @@
 
 #include "container.h"
 
-class DepotChest;
-using DepotChest_ptr = std::shared_ptr<DepotChest>;
-
 class DepotChest final : public Container
 {
 public:
-	explicit DepotChest(uint16_t type, bool paginated = true);
+	explicit DepotChest(uint16_t type, bool paginated = true) : Container{type, items[type].maxItems, true, paginated}
+	{}
 
 	void setMaxDepotItems(uint32_t maxitems) { maxDepotItems = maxitems; }
 
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                     Creature* actor = nullptr) const override;
+	ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                     const std::shared_ptr<Creature>& actor = nullptr) const override;
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 
 	bool canRemove() const override { return false; }
-	Thing* getParent() const override;
+	std::shared_ptr<Thing> getParent() const override;
 
 private:
 	uint32_t maxDepotItems = 0;

--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -7,8 +7,6 @@
 
 #include "inbox.h"
 
-DepotLocker::DepotLocker(uint16_t type) : Container(type), depotId(0) {}
-
 Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	if (attr == ATTR_DEPOT_ID) {
@@ -20,25 +18,27 @@ Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 	return Item::readAttr(attr, propStream);
 }
 
-void DepotLocker::postAddNotification(Thing* thing, const Thing* oldParent, int32_t index, ReceiverLink_t)
+void DepotLocker::postAddNotification(const std::shared_ptr<Thing>& thing,
+                                      const std::shared_ptr<const Thing>& oldParent, int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void DepotLocker::postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index, ReceiverLink_t)
+void DepotLocker::postRemoveNotification(const std::shared_ptr<Thing>& thing,
+                                         const std::shared_ptr<const Thing>& newParent, int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }
 
-void DepotLocker::removeInbox(Inbox* inbox)
+void DepotLocker::removeInbox(const std::shared_ptr<Inbox>& inbox)
 {
-	auto cit = std::find(itemlist.begin(), itemlist.end(), inbox);
-	if (cit == itemlist.end()) {
+	auto cit = std::find(itemList.begin(), itemList.end(), inbox);
+	if (cit == itemList.end()) {
 		return;
 	}
-	itemlist.erase(cit);
+	itemList.erase(cit);
 }

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -8,31 +8,36 @@
 
 class Inbox;
 
-using DepotLocker_ptr = std::shared_ptr<DepotLocker>;
-
 class DepotLocker final : public Container
 {
 public:
-	explicit DepotLocker(uint16_t type);
+	explicit DepotLocker(uint16_t type) : Container{type}, depotId{0} {}
 
-	void removeInbox(Inbox* inbox);
+	void removeInbox(const std::shared_ptr<Inbox>& inbox);
 	uint16_t getDepotId() const { return depotId; }
 	void setDepotId(uint16_t depotId) { this->depotId = depotId; }
 
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 
-	DepotLocker* getDepotLocker() override { return this; }
-	const DepotLocker* getDepotLocker() const override { return this; }
+	std::shared_ptr<DepotLocker> getDepotLocker() override
+	{
+		return std::static_pointer_cast<DepotLocker>(shared_from_this());
+	}
+	std::shared_ptr<const DepotLocker> getDepotLocker() const override
+	{
+		return std::static_pointer_cast<const DepotLocker>(shared_from_this());
+	}
 
-	ReturnValue queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature* = nullptr) const override
+	ReturnValue queryAdd(int32_t, const std::shared_ptr<const Thing>&, uint32_t, uint32_t,
+	                     const std::shared_ptr<Creature>& = nullptr) const override
 	{
 		return RETURNVALUE_NOTENOUGHROOM;
 	}
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 
 	bool canRemove() const override { return false; }
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -240,7 +240,7 @@ bool reload()
 
 namespace tfs::events::creature {
 
-bool onChangeOutfit(Creature* creature, const Outfit_t& outfit)
+bool onChangeOutfit(const std::shared_ptr<Creature>& creature, const Outfit_t& outfit)
 {
 	// Creature:onChangeOutfit(outfit) or Creature.onChangeOutfit(self, outfit)
 	if (creatureHandlers.onChangeOutfit == -1) {
@@ -258,7 +258,7 @@ bool onChangeOutfit(Creature* creature, const Outfit_t& outfit)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(creatureHandlers.onChangeOutfit);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushOutfit(L, outfit);
@@ -266,7 +266,7 @@ bool onChangeOutfit(Creature* creature, const Outfit_t& outfit)
 	return scriptInterface.callFunction(2);
 }
 
-ReturnValue onAreaCombat(Creature* creature, Tile* tile, bool aggressive)
+ReturnValue onAreaCombat(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Tile>& tile, bool aggressive)
 {
 	// Creature:onAreaCombat(tile, aggressive) or Creature.onAreaCombat(self, tile, aggressive)
 	if (creatureHandlers.onAreaCombat == -1) {
@@ -285,13 +285,13 @@ ReturnValue onAreaCombat(Creature* creature, Tile* tile, bool aggressive)
 	scriptInterface.pushFunction(creatureHandlers.onAreaCombat);
 
 	if (creature) {
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
 	}
 
-	tfs::lua::pushUserdata(L, tile);
+	tfs::lua::pushSharedPtr(L, tile);
 	tfs::lua::setMetatable(L, -1, "Tile");
 
 	tfs::lua::pushBoolean(L, aggressive);
@@ -309,7 +309,7 @@ ReturnValue onAreaCombat(Creature* creature, Tile* tile, bool aggressive)
 	return returnValue;
 }
 
-ReturnValue onTargetCombat(Creature* creature, Creature* target)
+ReturnValue onTargetCombat(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target)
 {
 	// Creature:onTargetCombat(target) or Creature.onTargetCombat(self, target)
 	if (creatureHandlers.onTargetCombat == -1) {
@@ -328,13 +328,13 @@ ReturnValue onTargetCombat(Creature* creature, Creature* target)
 	scriptInterface.pushFunction(creatureHandlers.onTargetCombat);
 
 	if (creature) {
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
 	}
 
-	tfs::lua::pushUserdata(L, target);
+	tfs::lua::pushSharedPtr(L, target);
 	tfs::lua::setCreatureMetatable(L, -1, target);
 
 	ReturnValue returnValue;
@@ -350,7 +350,8 @@ ReturnValue onTargetCombat(Creature* creature, Creature* target)
 	return returnValue;
 }
 
-void onHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type)
+void onHear(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& speaker,
+            const std::string& words, SpeakClasses type)
 {
 	// Creature:onHear(speaker, words, type)
 	if (creatureHandlers.onHear == -1) {
@@ -368,10 +369,10 @@ void onHear(Creature* creature, Creature* speaker, const std::string& words, Spe
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(creatureHandlers.onHear);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
-	tfs::lua::pushUserdata(L, speaker);
+	tfs::lua::pushSharedPtr(L, speaker);
 	tfs::lua::setCreatureMetatable(L, -1, speaker);
 
 	tfs::lua::pushString(L, words);
@@ -380,7 +381,7 @@ void onHear(Creature* creature, Creature* speaker, const std::string& words, Spe
 	scriptInterface.callVoidFunction(4);
 }
 
-void onChangeZone(Creature* creature, ZoneType_t fromZone, ZoneType_t toZone)
+void onChangeZone(const std::shared_ptr<Creature>& creature, ZoneType_t fromZone, ZoneType_t toZone)
 {
 	// Creature:onChangeZone(fromZone, toZone)
 	if (creatureHandlers.onChangeZone == -1) {
@@ -398,7 +399,7 @@ void onChangeZone(Creature* creature, ZoneType_t fromZone, ZoneType_t toZone)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(creatureHandlers.onChangeZone);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushNumber(L, fromZone);
@@ -407,8 +408,8 @@ void onChangeZone(Creature* creature, ZoneType_t fromZone, ZoneType_t toZone)
 	scriptInterface.callVoidFunction(3);
 }
 
-void onUpdateStorage(Creature* creature, uint32_t key, std::optional<int32_t> value, std::optional<int32_t> oldValue,
-                     bool isSpawn)
+void onUpdateStorage(const std::shared_ptr<Creature>& creature, uint32_t key, std::optional<int32_t> value,
+                     std::optional<int32_t> oldValue, bool isSpawn)
 {
 	// Creature:onUpdateStorage(key, value, oldValue, isSpawn)
 	if (creatureHandlers.onUpdateStorage == -1) {
@@ -426,7 +427,7 @@ void onUpdateStorage(Creature* creature, uint32_t key, std::optional<int32_t> va
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(creatureHandlers.onUpdateStorage);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setMetatable(L, -1, "Creature");
 
 	tfs::lua::pushNumber(L, key);
@@ -452,7 +453,7 @@ void onUpdateStorage(Creature* creature, uint32_t key, std::optional<int32_t> va
 
 namespace tfs::events::party {
 
-bool onJoin(Party* party, Player* player)
+bool onJoin(Party* party, const std::shared_ptr<Player>& player)
 {
 	// Party:onJoin(player) or Party.onJoin(self, player)
 	if (partyHandlers.onJoin == -1) {
@@ -473,13 +474,13 @@ bool onJoin(Party* party, Player* player)
 	tfs::lua::pushUserdata(L, party);
 	tfs::lua::setMetatable(L, -1, "Party");
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
-bool onLeave(Party* party, Player* player)
+bool onLeave(Party* party, const std::shared_ptr<Player>& player)
 {
 	// Party:onLeave(player) or Party.onLeave(self, player)
 	if (partyHandlers.onLeave == -1) {
@@ -500,7 +501,7 @@ bool onLeave(Party* party, Player* player)
 	tfs::lua::pushUserdata(L, party);
 	tfs::lua::setMetatable(L, -1, "Party");
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
@@ -530,7 +531,7 @@ bool onDisband(Party* party)
 	return scriptInterface.callFunction(1);
 }
 
-bool onInvite(Party* party, Player* player)
+bool onInvite(Party* party, const std::shared_ptr<Player>& player)
 {
 	// Party:onInvite(player) or Party.onInvite(self, player)
 	if (partyHandlers.onInvite == -1) {
@@ -551,13 +552,13 @@ bool onInvite(Party* party, Player* player)
 	tfs::lua::pushUserdata(L, party);
 	tfs::lua::setMetatable(L, -1, "Party");
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
-bool onRevokeInvitation(Party* party, Player* player)
+bool onRevokeInvitation(Party* party, const std::shared_ptr<Player>& player)
 {
 	// Party:onRevokeInvitation(player) or Party.onRevokeInvitation(self, player)
 	if (partyHandlers.onRevokeInvitation == -1) {
@@ -578,13 +579,13 @@ bool onRevokeInvitation(Party* party, Player* player)
 	tfs::lua::pushUserdata(L, party);
 	tfs::lua::setMetatable(L, -1, "Party");
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
-bool onPassLeadership(Party* party, Player* player)
+bool onPassLeadership(Party* party, const std::shared_ptr<Player>& player)
 {
 	// Party:onPassLeadership(player) or Party.onPassLeadership(self, player)
 	if (partyHandlers.onPassLeadership == -1) {
@@ -605,7 +606,7 @@ bool onPassLeadership(Party* party, Player* player)
 	tfs::lua::pushUserdata(L, party);
 	tfs::lua::setMetatable(L, -1, "Party");
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
@@ -648,7 +649,7 @@ void onShareExperience(Party* party, uint64_t& exp)
 
 namespace tfs::events::player {
 
-bool onBrowseField(Player* player, const Position& position)
+bool onBrowseField(const std::shared_ptr<Player>& player, const Position& position)
 {
 	// Player:onBrowseField(position) or Player.onBrowseField(self, position)
 	if (playerHandlers.onBrowseField == -1) {
@@ -666,7 +667,7 @@ bool onBrowseField(Player* player, const Position& position)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onBrowseField);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushPosition(L, position);
@@ -674,7 +675,8 @@ bool onBrowseField(Player* player, const Position& position)
 	return scriptInterface.callFunction(2);
 }
 
-void onLook(Player* player, const Position& position, Thing* thing, uint8_t stackpos, int32_t lookDistance)
+void onLook(const std::shared_ptr<Player>& player, const Position& position, const std::shared_ptr<Thing>& thing,
+            uint8_t stackpos, int32_t lookDistance)
 {
 	// Player:onLook(thing, position, distance) or Player.onLook(self, thing, position, distance)
 	if (playerHandlers.onLook == -1) {
@@ -692,14 +694,14 @@ void onLook(Player* player, const Position& position, Thing* thing, uint8_t stac
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onLook);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	if (Creature* creature = thing->getCreature()) {
-		tfs::lua::pushUserdata(L, creature);
+	if (const auto& creature = thing->getCreature()) {
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
-	} else if (Item* item = thing->getItem()) {
-		tfs::lua::pushUserdata(L, item);
+	} else if (const auto& item = thing->getItem()) {
+		tfs::lua::pushSharedPtr(L, item);
 		tfs::lua::setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -711,7 +713,8 @@ void onLook(Player* player, const Position& position, Thing* thing, uint8_t stac
 	scriptInterface.callVoidFunction(4);
 }
 
-void onLookInBattleList(Player* player, Creature* creature, int32_t lookDistance)
+void onLookInBattleList(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& creature,
+                        int32_t lookDistance)
 {
 	// Player:onLookInBattleList(creature, position, distance) or Player.onLookInBattleList(self, creature, position,
 	// distance)
@@ -730,10 +733,10 @@ void onLookInBattleList(Player* player, Creature* creature, int32_t lookDistance
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onLookInBattleList);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushNumber(L, lookDistance);
@@ -741,7 +744,8 @@ void onLookInBattleList(Player* player, Creature* creature, int32_t lookDistance
 	scriptInterface.callVoidFunction(3);
 }
 
-void onLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDistance)
+void onLookInTrade(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& partner,
+                   const std::shared_ptr<Item>& item, int32_t lookDistance)
 {
 	// Player:onLookInTrade(partner, item, distance) or Player.onLookInTrade(self, partner, item, distance)
 	if (playerHandlers.onLookInTrade == -1) {
@@ -759,13 +763,13 @@ void onLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDist
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onLookInTrade);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, partner);
+	tfs::lua::pushSharedPtr(L, partner);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	tfs::lua::pushNumber(L, lookDistance);
@@ -773,7 +777,7 @@ void onLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDist
 	scriptInterface.callVoidFunction(4);
 }
 
-bool onLookInShop(Player* player, const ItemType* itemType, uint8_t count)
+bool onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemType, uint8_t count)
 {
 	// Player:onLookInShop(itemType, count) or Player.onLookInShop(self, itemType, count)
 	if (playerHandlers.onLookInShop == -1) {
@@ -791,7 +795,7 @@ bool onLookInShop(Player* player, const ItemType* itemType, uint8_t count)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onLookInShop);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushUserdata(L, itemType);
@@ -802,7 +806,7 @@ bool onLookInShop(Player* player, const ItemType* itemType, uint8_t count)
 	return scriptInterface.callFunction(3);
 }
 
-bool onLookInMarket(Player* player, const ItemType* itemType)
+bool onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemType)
 {
 	// Player:onLookInMarket(itemType) or Player.onLookInMarket(self, itemType)
 	if (playerHandlers.onLookInMarket == -1) {
@@ -820,7 +824,7 @@ bool onLookInMarket(Player* player, const ItemType* itemType)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onLookInMarket);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushUserdata(L, itemType);
@@ -829,8 +833,9 @@ bool onLookInMarket(Player* player, const ItemType* itemType)
 	return scriptInterface.callFunction(2);
 }
 
-ReturnValue onMoveItem(Player* player, Item* item, uint16_t count, const Position& fromPosition,
-                       const Position& toPosition, Thing* fromThing, Thing* toThing)
+ReturnValue onMoveItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, uint16_t count,
+                       const Position& fromPosition, const Position& toPosition,
+                       const std::shared_ptr<Thing>& fromThing, const std::shared_ptr<Thing>& toThing)
 {
 	// Player:onMoveItem(item, count, fromPosition, toPosition) or Player.onMoveItem(self, item, count, fromPosition,
 	// toPosition, fromThing, toThing)
@@ -849,10 +854,10 @@ ReturnValue onMoveItem(Player* player, Item* item, uint16_t count, const Positio
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onMoveItem);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	tfs::lua::pushNumber(L, count);
@@ -875,8 +880,9 @@ ReturnValue onMoveItem(Player* player, Item* item, uint16_t count, const Positio
 	return returnValue;
 }
 
-void onItemMoved(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition,
-                 Thing* fromThing, Thing* toThing)
+void onItemMoved(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, uint16_t count,
+                 const Position& fromPosition, const Position& toPosition, const std::shared_ptr<Thing>& fromThing,
+                 const std::shared_ptr<Thing>& toThing)
 {
 	// Player:onItemMoved(item, count, fromPosition, toPosition) or Player.onItemMoved(self, item, count, fromPosition,
 	// toPosition, fromThing, toThing)
@@ -895,10 +901,10 @@ void onItemMoved(Player* player, Item* item, uint16_t count, const Position& fro
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onItemMoved);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	tfs::lua::pushNumber(L, count);
@@ -911,7 +917,8 @@ void onItemMoved(Player* player, Item* item, uint16_t count, const Position& fro
 	scriptInterface.callVoidFunction(7);
 }
 
-bool onMoveCreature(Player* player, Creature* creature, const Position& fromPosition, const Position& toPosition)
+bool onMoveCreature(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& creature,
+                    const Position& fromPosition, const Position& toPosition)
 {
 	// Player:onMoveCreature(creature, fromPosition, toPosition) or Player.onMoveCreature(self, creature, fromPosition,
 	// toPosition)
@@ -930,10 +937,10 @@ bool onMoveCreature(Player* player, Creature* creature, const Position& fromPosi
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onMoveCreature);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushPosition(L, fromPosition);
@@ -942,8 +949,8 @@ bool onMoveCreature(Player* player, Creature* creature, const Position& fromPosi
 	return scriptInterface.callFunction(4);
 }
 
-void onReportRuleViolation(Player* player, const std::string& targetName, uint8_t reportType, uint8_t reportReason,
-                           const std::string& comment, const std::string& translation)
+void onReportRuleViolation(const std::shared_ptr<Player>& player, const std::string& targetName, uint8_t reportType,
+                           uint8_t reportReason, const std::string& comment, const std::string& translation)
 {
 	// Player:onReportRuleViolation(targetName, reportType, reportReason, comment, translation)
 	if (playerHandlers.onReportRuleViolation == -1) {
@@ -961,7 +968,7 @@ void onReportRuleViolation(Player* player, const std::string& targetName, uint8_
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onReportRuleViolation);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushString(L, targetName);
@@ -975,7 +982,8 @@ void onReportRuleViolation(Player* player, const std::string& targetName, uint8_
 	scriptInterface.callVoidFunction(6);
 }
 
-bool onReportBug(Player* player, const std::string& message, const Position& position, uint8_t category)
+bool onReportBug(const std::shared_ptr<Player>& player, const std::string& message, const Position& position,
+                 uint8_t category)
 {
 	// Player:onReportBug(message, position, category)
 	if (playerHandlers.onReportBug == -1) {
@@ -993,7 +1001,7 @@ bool onReportBug(Player* player, const std::string& message, const Position& pos
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onReportBug);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushString(L, message);
@@ -1003,7 +1011,7 @@ bool onReportBug(Player* player, const std::string& message, const Position& pos
 	return scriptInterface.callFunction(4);
 }
 
-void onRotateItem(Player* player, Item* item)
+void onRotateItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item)
 {
 	// Player:onRotateItem(item)
 	if (playerHandlers.onRotateItem == -1) {
@@ -1021,16 +1029,16 @@ void onRotateItem(Player* player, Item* item)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onRotateItem);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	scriptInterface.callFunction(2);
 }
 
-bool onTurn(Player* player, Direction direction)
+bool onTurn(const std::shared_ptr<Player>& player, Direction direction)
 {
 	// Player:onTurn(direction) or Player.onTurn(self, direction)
 	if (playerHandlers.onTurn == -1) {
@@ -1048,7 +1056,7 @@ bool onTurn(Player* player, Direction direction)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onTurn);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushNumber(L, direction);
@@ -1056,7 +1064,8 @@ bool onTurn(Player* player, Direction direction)
 	return scriptInterface.callFunction(2);
 }
 
-bool onTradeRequest(Player* player, Player* target, Item* item)
+bool onTradeRequest(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target,
+                    const std::shared_ptr<Item>& item)
 {
 	// Player:onTradeRequest(target, item)
 	if (playerHandlers.onTradeRequest == -1) {
@@ -1074,19 +1083,20 @@ bool onTradeRequest(Player* player, Player* target, Item* item)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onTradeRequest);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, target);
+	tfs::lua::pushSharedPtr(L, target);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	return scriptInterface.callFunction(3);
 }
 
-bool onTradeAccept(Player* player, Player* target, Item* item, Item* targetItem)
+bool onTradeAccept(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target,
+                   const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& targetItem)
 {
 	// Player:onTradeAccept(target, item, targetItem)
 	if (playerHandlers.onTradeAccept == -1) {
@@ -1104,22 +1114,23 @@ bool onTradeAccept(Player* player, Player* target, Item* item, Item* targetItem)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onTradeAccept);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, target);
+	tfs::lua::pushSharedPtr(L, target);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
-	tfs::lua::pushUserdata(L, targetItem);
+	tfs::lua::pushSharedPtr(L, targetItem);
 	tfs::lua::setItemMetatable(L, -1, targetItem);
 
 	return scriptInterface.callFunction(4);
 }
 
-void onTradeCompleted(Player* player, Player* target, Item* item, Item* targetItem, bool isSuccess)
+void onTradeCompleted(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target,
+                      const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& targetItem, bool isSuccess)
 {
 	// Player:onTradeCompleted(target, item, targetItem, isSuccess)
 	if (playerHandlers.onTradeCompleted == -1) {
@@ -1137,16 +1148,16 @@ void onTradeCompleted(Player* player, Player* target, Item* item, Item* targetIt
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onTradeCompleted);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, target);
+	tfs::lua::pushSharedPtr(L, target);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
-	tfs::lua::pushUserdata(L, targetItem);
+	tfs::lua::pushSharedPtr(L, targetItem);
 	tfs::lua::setItemMetatable(L, -1, targetItem);
 
 	tfs::lua::pushBoolean(L, isSuccess);
@@ -1154,7 +1165,7 @@ void onTradeCompleted(Player* player, Player* target, Item* item, Item* targetIt
 	return scriptInterface.callVoidFunction(5);
 }
 
-void onPodiumRequest(Player* player, Item* item)
+void onPodiumRequest(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item)
 {
 	// Player:onPodiumRequest(item) or Player.onPodiumRequest(self, item)
 	if (playerHandlers.onPodiumRequest == -1) {
@@ -1172,16 +1183,17 @@ void onPodiumRequest(Player* player, Item* item)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onPodiumRequest);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	scriptInterface.callFunction(2);
 }
 
-void onPodiumEdit(Player* player, Item* item, const Outfit_t& outfit, bool podiumVisible, Direction direction)
+void onPodiumEdit(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, const Outfit_t& outfit,
+                  bool podiumVisible, Direction direction)
 {
 	// Player:onPodiumEdit(item, outfit, direction, isVisible) or Player.onPodiumEdit(self, item, outfit, direction,
 	// isVisible)
@@ -1200,10 +1212,10 @@ void onPodiumEdit(Player* player, Item* item, const Outfit_t& outfit, bool podiu
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onPodiumEdit);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	tfs::lua::pushOutfit(L, outfit);
@@ -1214,7 +1226,8 @@ void onPodiumEdit(Player* player, Item* item, const Outfit_t& outfit, bool podiu
 	scriptInterface.callFunction(5);
 }
 
-void onGainExperience(Player* player, Creature* source, uint64_t& exp, uint64_t rawExp, bool sendText)
+void onGainExperience(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& source, uint64_t& exp,
+                      uint64_t rawExp, bool sendText)
 {
 	// Player:onGainExperience(source, exp, rawExp, sendText) rawExp gives the original exp which is not multiplied
 	if (playerHandlers.onGainExperience == -1) {
@@ -1232,11 +1245,11 @@ void onGainExperience(Player* player, Creature* source, uint64_t& exp, uint64_t 
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onGainExperience);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	if (source) {
-		tfs::lua::pushUserdata(L, source);
+		tfs::lua::pushSharedPtr(L, source);
 		tfs::lua::setCreatureMetatable(L, -1, source);
 	} else {
 		lua_pushnil(L);
@@ -1256,7 +1269,7 @@ void onGainExperience(Player* player, Creature* source, uint64_t& exp, uint64_t 
 	tfs::lua::resetScriptEnv();
 }
 
-void onLoseExperience(Player* player, uint64_t& exp)
+void onLoseExperience(const std::shared_ptr<Player>& player, uint64_t& exp)
 {
 	// Player:onLoseExperience(exp)
 	if (playerHandlers.onLoseExperience == -1) {
@@ -1274,7 +1287,7 @@ void onLoseExperience(Player* player, uint64_t& exp)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onLoseExperience);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushNumber(L, exp);
@@ -1289,7 +1302,7 @@ void onLoseExperience(Player* player, uint64_t& exp)
 	tfs::lua::resetScriptEnv();
 }
 
-void onGainSkillTries(Player* player, skills_t skill, uint64_t& tries)
+void onGainSkillTries(const std::shared_ptr<Player>& player, skills_t skill, uint64_t& tries)
 {
 	// Player:onGainSkillTries(skill, tries)
 	if (playerHandlers.onGainSkillTries == -1) {
@@ -1307,7 +1320,7 @@ void onGainSkillTries(Player* player, skills_t skill, uint64_t& tries)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onGainSkillTries);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushNumber(L, skill);
@@ -1323,7 +1336,7 @@ void onGainSkillTries(Player* player, skills_t skill, uint64_t& tries)
 	tfs::lua::resetScriptEnv();
 }
 
-void onWrapItem(Player* player, Item* item)
+void onWrapItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item)
 {
 	// Player:onWrapItem(item)
 	if (playerHandlers.onWrapItem == -1) {
@@ -1341,16 +1354,17 @@ void onWrapItem(Player* player, Item* item)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onWrapItem);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	scriptInterface.callVoidFunction(2);
 }
 
-void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip)
+void onInventoryUpdate(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+                       bool equip)
 {
 	// Player:onInventoryUpdate(item, slot, equip)
 	if (playerHandlers.onInventoryUpdate == -1) {
@@ -1368,10 +1382,10 @@ void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onInventoryUpdate);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
-	tfs::lua::pushUserdata(L, item);
+	tfs::lua::pushSharedPtr(L, item);
 	tfs::lua::setItemMetatable(L, -1, item);
 
 	tfs::lua::pushNumber(L, slot);
@@ -1380,7 +1394,7 @@ void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip)
 	scriptInterface.callVoidFunction(4);
 }
 
-void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr& msg)
+void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, NetworkMessage_ptr& msg)
 {
 	// Player:onNetworkMessage(recvByte, msg)
 	if (playerHandlers.onNetworkMessage == -1) {
@@ -1398,7 +1412,7 @@ void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr& msg)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onNetworkMessage);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushNumber(L, recvByte);
@@ -1409,7 +1423,7 @@ void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr& msg)
 	scriptInterface.callVoidFunction(3);
 }
 
-bool onSpellCheck(Player* player, const Spell* spell)
+bool onSpellCheck(const std::shared_ptr<Player>& player, const Spell* spell)
 {
 	// Player:onSpellCheck(spell)
 	if (playerHandlers.onSpellCheck == -1) {
@@ -1427,7 +1441,7 @@ bool onSpellCheck(Player* player, const Spell* spell)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(playerHandlers.onSpellCheck);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushSpell(L, *spell);
@@ -1439,7 +1453,7 @@ bool onSpellCheck(Player* player, const Spell* spell)
 
 namespace tfs::events::monster {
 
-bool onSpawn(Monster* monster, const Position& position, bool startup, bool artificial)
+bool onSpawn(const std::shared_ptr<Monster>& monster, const Position& position, bool startup, bool artificial)
 {
 	// Monster:onSpawn(position, startup, artificial)
 	if (monsterHandlers.onSpawn == -1) {
@@ -1457,7 +1471,7 @@ bool onSpawn(Monster* monster, const Position& position, bool startup, bool arti
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(monsterHandlers.onSpawn);
 
-	tfs::lua::pushUserdata(L, monster);
+	tfs::lua::pushSharedPtr(L, monster);
 	tfs::lua::setMetatable(L, -1, "Monster");
 	tfs::lua::pushPosition(L, position);
 	tfs::lua::pushBoolean(L, startup);
@@ -1466,7 +1480,7 @@ bool onSpawn(Monster* monster, const Position& position, bool startup, bool arti
 	return scriptInterface.callFunction(4);
 }
 
-void onDropLoot(Monster* monster, Container* corpse)
+void onDropLoot(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Container>& corpse)
 {
 	// Monster:onDropLoot(corpse)
 	if (monsterHandlers.onDropLoot == -1) {
@@ -1484,10 +1498,10 @@ void onDropLoot(Monster* monster, Container* corpse)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(monsterHandlers.onDropLoot);
 
-	tfs::lua::pushUserdata(L, monster);
+	tfs::lua::pushSharedPtr(L, monster);
 	tfs::lua::setMetatable(L, -1, "Monster");
 
-	tfs::lua::pushUserdata(L, corpse);
+	tfs::lua::pushSharedPtr(L, corpse);
 	tfs::lua::setMetatable(L, -1, "Container");
 
 	return scriptInterface.callVoidFunction(2);

--- a/src/events.h
+++ b/src/events.h
@@ -33,65 +33,79 @@ int32_t getScriptId(EventInfoId eventInfoId);
 
 namespace tfs::events::creature {
 
-bool onChangeOutfit(Creature* creature, const Outfit_t& outfit);
-ReturnValue onAreaCombat(Creature* creature, Tile* tile, bool aggressive);
-ReturnValue onTargetCombat(Creature* creature, Creature* target);
-void onHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
-void onChangeZone(Creature* creature, ZoneType_t fromZone, ZoneType_t toZone);
-void onUpdateStorage(Creature* creature, uint32_t key, std::optional<int32_t> value, std::optional<int32_t> oldValue,
-                     bool isSpawn);
+bool onChangeOutfit(const std::shared_ptr<Creature>& creature, const Outfit_t& outfit);
+ReturnValue onAreaCombat(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Tile>& tile, bool aggressive);
+ReturnValue onTargetCombat(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target);
+void onHear(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& speaker,
+            const std::string& words, SpeakClasses type);
+void onChangeZone(const std::shared_ptr<Creature>& creature, ZoneType_t fromZone, ZoneType_t toZone);
+void onUpdateStorage(const std::shared_ptr<Creature>& creature, uint32_t key, std::optional<int32_t> value,
+                     std::optional<int32_t> oldValue, bool isSpawn);
 
 } // namespace tfs::events::creature
 
 namespace tfs::events::party {
 
-bool onJoin(Party* party, Player* player);
-bool onLeave(Party* party, Player* player);
+bool onJoin(Party* party, const std::shared_ptr<Player>& player);
+bool onLeave(Party* party, const std::shared_ptr<Player>& player);
 bool onDisband(Party* party);
 void onShareExperience(Party* party, uint64_t& exp);
-bool onInvite(Party* party, Player* player);
-bool onRevokeInvitation(Party* party, Player* player);
-bool onPassLeadership(Party* party, Player* player);
+bool onInvite(Party* party, const std::shared_ptr<Player>& player);
+bool onRevokeInvitation(Party* party, const std::shared_ptr<Player>& player);
+bool onPassLeadership(Party* party, const std::shared_ptr<Player>& player);
 
 } // namespace tfs::events::party
 
 namespace tfs::events::player {
 
-bool onBrowseField(Player* player, const Position& position);
-void onLook(Player* player, const Position& position, Thing* thing, uint8_t stackpos, int32_t lookDistance);
-void onLookInBattleList(Player* player, Creature* creature, int32_t lookDistance);
-void onLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDistance);
-bool onLookInShop(Player* player, const ItemType* itemType, uint8_t count);
-bool onLookInMarket(Player* player, const ItemType* itemType);
-ReturnValue onMoveItem(Player* player, Item* item, uint16_t count, const Position& fromPosition,
-                       const Position& toPosition, Thing* fromThing, Thing* toThing);
-void onItemMoved(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition,
-                 Thing* fromThing, Thing* toThing);
-bool onMoveCreature(Player* player, Creature* creature, const Position& fromPosition, const Position& toPosition);
-void onReportRuleViolation(Player* player, const std::string& targetName, uint8_t reportType, uint8_t reportReason,
-                           const std::string& comment, const std::string& translation);
-bool onReportBug(Player* player, const std::string& message, const Position& position, uint8_t category);
-void onRotateItem(Player* player, Item* item);
-bool onTurn(Player* player, Direction direction);
-bool onTradeRequest(Player* player, Player* target, Item* item);
-bool onTradeAccept(Player* player, Player* target, Item* item, Item* targetItem);
-void onTradeCompleted(Player* player, Player* target, Item* item, Item* targetItem, bool isSuccess);
-void onPodiumRequest(Player* player, Item* item);
-void onPodiumEdit(Player* player, Item* item, const Outfit_t& outfit, bool podiumVisible, Direction direction);
-void onGainExperience(Player* player, Creature* source, uint64_t& exp, uint64_t rawExp, bool sendText);
-void onLoseExperience(Player* player, uint64_t& exp);
-void onGainSkillTries(Player* player, skills_t skill, uint64_t& tries);
-void onWrapItem(Player* player, Item* item);
-void onInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
-void onNetworkMessage(Player* player, uint8_t recvByte, NetworkMessage_ptr& msg);
-bool onSpellCheck(Player* player, const Spell* spell);
+bool onBrowseField(const std::shared_ptr<Player>& player, const Position& position);
+void onLook(const std::shared_ptr<Player>& player, const Position& position, const std::shared_ptr<Thing>& thing,
+            uint8_t stackpos, int32_t lookDistance);
+void onLookInBattleList(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& creature,
+                        int32_t lookDistance);
+void onLookInTrade(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& partner,
+                   const std::shared_ptr<Item>& item, int32_t lookDistance);
+bool onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemType, uint8_t count);
+bool onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemType);
+ReturnValue onMoveItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, uint16_t count,
+                       const Position& fromPosition, const Position& toPosition,
+                       const std::shared_ptr<Thing>& fromThing, const std::shared_ptr<Thing>& toThing);
+void onItemMoved(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, uint16_t count,
+                 const Position& fromPosition, const Position& toPosition, const std::shared_ptr<Thing>& fromThing,
+                 const std::shared_ptr<Thing>& toThing);
+bool onMoveCreature(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& creature,
+                    const Position& fromPosition, const Position& toPosition);
+void onReportRuleViolation(const std::shared_ptr<Player>& player, const std::string& targetName, uint8_t reportType,
+                           uint8_t reportReason, const std::string& comment, const std::string& translation);
+bool onReportBug(const std::shared_ptr<Player>& player, const std::string& message, const Position& position,
+                 uint8_t category);
+void onRotateItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item);
+bool onTurn(const std::shared_ptr<Player>& player, Direction direction);
+bool onTradeRequest(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target,
+                    const std::shared_ptr<Item>& item);
+bool onTradeAccept(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target,
+                   const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& targetItem);
+void onTradeCompleted(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target,
+                      const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& targetItem, bool isSuccess);
+void onPodiumRequest(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item);
+void onPodiumEdit(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, const Outfit_t& outfit,
+                  bool podiumVisible, Direction direction);
+void onGainExperience(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& source, uint64_t& exp,
+                      uint64_t rawExp, bool sendText);
+void onLoseExperience(const std::shared_ptr<Player>& player, uint64_t& exp);
+void onGainSkillTries(const std::shared_ptr<Player>& player, skills_t skill, uint64_t& tries);
+void onWrapItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item);
+void onInventoryUpdate(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+                       bool equip);
+void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, NetworkMessage_ptr& msg);
+bool onSpellCheck(const std::shared_ptr<Player>& player, const Spell* spell);
 
 } // namespace tfs::events::player
 
 namespace tfs::events::monster {
 
-void onDropLoot(Monster* monster, Container* corpse);
-bool onSpawn(Monster* monster, const Position& position, bool startup, bool artificial);
+void onDropLoot(const std::shared_ptr<Monster>& monster, const std::shared_ptr<Container>& corpse);
+bool onSpawn(const std::shared_ptr<Monster>& monster, const Position& position, bool startup, bool artificial);
 
 } // namespace tfs::events::monster
 

--- a/src/game.h
+++ b/src/game.h
@@ -6,7 +6,9 @@
 
 #include "groups.h"
 #include "map.h"
+#include "monster.h"
 #include "mounts.h"
+#include "npc.h"
 #include "player.h"
 #include "wildcardtree.h"
 
@@ -98,67 +100,66 @@ public:
 	void setWorldType(WorldType_t type);
 	WorldType_t getWorldType() const { return worldType; }
 
-	Thing* internalGetThing(Player* player, const Position& pos) const;
-	Thing* internalGetThing(Player* player, const Position& pos, int32_t index, uint32_t spriteId,
-	                        stackPosType_t type) const;
-	static void internalGetPosition(Item* item, Position& pos, uint8_t& stackpos);
+	std::shared_ptr<Thing> internalGetThing(const std::shared_ptr<Player>& player, const Position& pos) const;
+	std::shared_ptr<Thing> internalGetThing(const std::shared_ptr<Player>& player, const Position& pos, int32_t index,
+	                                        uint32_t spriteId, stackPosType_t type) const;
 
-	static std::string getTradeErrorDescription(ReturnValue ret, Item* item);
+	static std::string getTradeErrorDescription(ReturnValue ret, const std::shared_ptr<Item>& item);
 
 	/**
 	 * Returns a creature based on the unique creature identifier
 	 * \param id is the unique creature id to get a creature pointer to
 	 * \returns A Creature pointer to the creature
 	 */
-	Creature* getCreatureByID(uint32_t id);
+	std::shared_ptr<Creature> getCreatureByID(uint32_t id);
 
 	/**
 	 * Returns a monster based on the unique creature identifier
 	 * \param id is the unique monster id to get a monster pointer to
 	 * \returns A Monster pointer to the monster
 	 */
-	Monster* getMonsterByID(uint32_t id);
+	std::shared_ptr<Monster> getMonsterByID(uint32_t id);
 
 	/**
 	 * Returns an npc based on the unique creature identifier
 	 * \param id is the unique npc id to get a npc pointer to
 	 * \returns A NPC pointer to the npc
 	 */
-	Npc* getNpcByID(uint32_t id);
+	std::shared_ptr<Npc> getNpcByID(uint32_t id);
 
 	/**
 	 * Returns a player based on the unique creature identifier
 	 * \param id is the unique player id to get a player pointer to
 	 * \returns A Pointer to the player
 	 */
-	Player* getPlayerByID(uint32_t id);
+	std::shared_ptr<Player> getPlayerByID(uint32_t id);
 
 	/**
 	 * Returns a creature based on a string name identifier
 	 * \param s is the name identifier
 	 * \returns A Pointer to the creature
 	 */
-	Creature* getCreatureByName(const std::string& s);
+	std::shared_ptr<Creature> getCreatureByName(const std::string& s);
 
 	/**
 	 * Returns a npc based on a string name identifier
 	 * \param s is the name identifier
 	 * \returns A Pointer to the npc
 	 */
-	Npc* getNpcByName(const std::string& s);
+	std::shared_ptr<Npc> getNpcByName(const std::string& s);
 
 	/**
 	 * Returns a player based on a string name identifier
 	 * \param s is the name identifier
 	 * \returns A Pointer to the player
 	 */
-	Player* getPlayerByName(const std::string& s);
+	std::shared_ptr<Player> getPlayerByName(const std::string& s);
 
 	/**
 	 * Returns a player based on guid
 	 * \returns A Pointer to the player
 	 */
-	Player* getPlayerByGUID(const uint32_t& guid);
+	std::shared_ptr<Player> getPlayerByGUID(const uint32_t& guid);
 
 	/**
 	 * Returns a player based on a string name identifier, with support for the "~" wildcard.
@@ -166,14 +167,14 @@ public:
 	 * \param player will point to the found player (if any)
 	 * \return "RETURNVALUE_PLAYERWITHTHISNAMEISNOTONLINE" or "RETURNVALUE_NAMEISTOOAMBIGIOUS"
 	 */
-	ReturnValue getPlayerByNameWildcard(const std::string& s, Player*& player);
+	ReturnValue getPlayerByNameWildcard(const std::string& s, std::shared_ptr<Player>& player);
 
 	/**
 	 * Returns a player based on an account number identifier
 	 * \param acc is the account identifier
 	 * \returns A Pointer to the player
 	 */
-	Player* getPlayerByAccount(uint32_t acc);
+	std::shared_ptr<Player> getPlayerByAccount(uint32_t acc);
 
 	/**
 	 * Place Creature on the map without sending out events to the surrounding.
@@ -182,7 +183,8 @@ public:
 	 * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 	 * \param forced If true, placing the creature will not fail because of obstacles (creatures/items)
 	 */
-	bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false);
+	bool internalPlaceCreature(const std::shared_ptr<Creature>& creature, const Position& pos, bool extendedPos = false,
+	                           bool forced = false);
 
 	/**
 	 * Place Creature on the map.
@@ -191,41 +193,45 @@ public:
 	 * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 	 * \param force If true, placing the creature will not fail because of obstacles (creatures/items)
 	 */
-	bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false,
-	                   MagicEffectClasses magicEffect = CONST_ME_TELEPORT);
+	bool placeCreature(const std::shared_ptr<Creature>& creature, const Position& pos, bool extendedPos = false,
+	                   bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT);
 
 	/**
 	 * Remove Creature from the map.
 	 * Removes the Creature from the map
 	 * \param c Creature to remove
 	 */
-	bool removeCreature(Creature* creature, bool isLogout = true);
+	bool removeCreature(const std::shared_ptr<Creature>& creature, bool isLogout = true);
 	void executeDeath(uint32_t creatureId);
 
-	void addCreatureCheck(Creature* creature);
-	static void removeCreatureCheck(Creature* creature);
+	void addCreatureCheck(std::shared_ptr<Creature> creature);
+	static void removeCreatureCheck(const std::shared_ptr<Creature>& creature);
 
 	size_t getPlayersOnline() const { return players.size(); }
 	size_t getMonstersOnline() const { return monsters.size(); }
 	size_t getNpcsOnline() const { return npcs.size(); }
 	uint32_t getPlayersRecord() const { return playersRecord; }
 
-	ReturnValue internalMoveCreature(Creature* creature, Direction direction, uint32_t flags = 0);
-	ReturnValue internalMoveCreature(Creature& creature, Tile& toTile, uint32_t flags = 0);
+	ReturnValue internalMoveCreature(const std::shared_ptr<Creature>& creature, Direction direction,
+	                                 uint32_t flags = 0);
+	ReturnValue internalMoveCreature(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Tile>& toTile,
+	                                 uint32_t flags = 0);
 
-	ReturnValue internalMoveItem(Thing* fromThing, Thing* toThing, int32_t index, Item* item, uint32_t count,
-	                             Item** _moveItem, uint32_t flags = 0, Creature* actor = nullptr,
-	                             Item* tradeItem = nullptr, const Position* fromPos = nullptr,
+	ReturnValue internalMoveItem(std::shared_ptr<Thing> fromThing, std::shared_ptr<Thing> toThing, int32_t index,
+	                             const std::shared_ptr<Item>& item, uint32_t count, std::shared_ptr<Item>& moveItem,
+	                             uint32_t flags = 0, const std::shared_ptr<Creature>& actor = nullptr,
+	                             const std::shared_ptr<Item>& tradeItem = nullptr, const Position* fromPos = nullptr,
 	                             const Position* toPos = nullptr);
 
-	ReturnValue internalAddItem(Thing* toThing, Item* item, int32_t index = INDEX_WHEREEVER, uint32_t flags = 0,
-	                            bool test = false);
-	ReturnValue internalAddItem(Thing* toThing, Item* item, int32_t index, uint32_t flags, bool test,
-	                            uint32_t& remainderCount);
-	ReturnValue internalRemoveItem(Item* item, int32_t count = -1, bool test = false, uint32_t flags = 0);
+	ReturnValue internalAddItem(const std::shared_ptr<Thing>& toThing, const std::shared_ptr<Item>& item,
+	                            int32_t index = INDEX_WHEREEVER, uint32_t flags = 0, bool test = false);
+	ReturnValue internalAddItem(const std::shared_ptr<Thing>& toThing, const std::shared_ptr<Item>& item, int32_t index,
+	                            uint32_t flags, bool test, uint32_t& remainderCount);
+	ReturnValue internalRemoveItem(const std::shared_ptr<Item>& item, int32_t count = -1, bool test = false,
+	                               uint32_t flags = 0);
 
-	ReturnValue internalPlayerAddItem(Player* player, Item* item, bool dropOnMap = true,
-	                                  slots_t slot = CONST_SLOT_WHEREEVER);
+	ReturnValue internalPlayerAddItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                                  bool dropOnMap = true, slots_t slot = CONST_SLOT_WHEREEVER);
 
 	/**
 	 * Find an item of a certain type
@@ -236,7 +242,8 @@ public:
 	 * \param depthSearch if true it will check child containers aswell
 	 * \returns A pointer to the item to an item and nullptr if not found
 	 */
-	Item* findItemOfType(Thing* fromThing, uint16_t itemId, bool depthSearch = true, int32_t subType = -1) const;
+	std::shared_ptr<Item> findItemOfType(const std::shared_ptr<Thing>& fromThing, uint16_t itemId,
+	                                     bool depthSearch = true, int32_t subType = -1) const;
 
 	/**
 	 * Remove/Add item(s) with a monetary value
@@ -245,16 +252,15 @@ public:
 	 * \param flags optional flags to modify the default behavior
 	 * \returns true if the removal was successful
 	 */
-	bool removeMoney(Thing* fromThing, uint64_t money, uint32_t flags = 0);
+	bool removeMoney(const std::shared_ptr<Thing>& fromThing, uint64_t money, uint32_t flags = 0);
 
 	/**
 	 * Add item(s) with monetary value
-	 * \param thing which will receive money
+	 * \param fromThing which will receive money
 	 * \param money the amount to give
 	 * \param flags optional flags to modify default behavior
 	 */
-	void addMoney(Thing* thing, uint64_t money, uint32_t flags = 0);
-
+	void addMoney(const std::shared_ptr<Thing>& fromThing, uint64_t money, uint32_t flags = 0);
 	/**
 	 * Transform one item to another type/count
 	 * \param item is the item to transform
@@ -262,7 +268,7 @@ public:
 	 * \param newCount is the new count value, use default value (-1) to not change it
 	 * \returns true if the transformation was successful
 	 */
-	Item* transformItem(Item* item, uint16_t newId, int32_t newCount = -1);
+	std::shared_ptr<Item> transformItem(const std::shared_ptr<Item>& item, uint16_t newId, int32_t newCount = -1);
 
 	/**
 	 * Teleports an object to another position
@@ -272,14 +278,15 @@ public:
 	 * \param flags optional flags to modify default behavior
 	 * \returns true if the teleportation was successful
 	 */
-	ReturnValue internalTeleport(Thing* thing, const Position& newPos, bool pushMove = true, uint32_t flags = 0);
+	ReturnValue internalTeleport(const std::shared_ptr<Thing>& thing, const Position& newPos, bool pushMove = true,
+	                             uint32_t flags = 0);
 
 	/**
 	 * Turn a creature to a different direction.
 	 * \param creature Creature to change the direction
 	 * \param dir Direction to turn to
 	 */
-	bool internalCreatureTurn(Creature* creature, Direction dir);
+	bool internalCreatureTurn(const std::shared_ptr<Creature>& creature, Direction dir);
 
 	/**
 	 * Creature wants to say something.
@@ -287,8 +294,9 @@ public:
 	 * \param type Type of message
 	 * \param text The text to say
 	 */
-	bool internalCreatureSay(Creature* creature, SpeakClasses type, const std::string& text, bool ghostMode,
-	                         SpectatorVec* spectatorsPtr = nullptr, const Position* pos = nullptr, bool echo = false);
+	bool internalCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type, const std::string& text,
+	                         bool ghostMode, SpectatorVec* spectatorsPtr = nullptr, const Position* pos = nullptr,
+	                         bool echo = false);
 
 	void loadPlayersRecord();
 	void checkPlayersRecord();
@@ -301,9 +309,10 @@ public:
 	void playerReportRuleViolation(uint32_t playerId, const std::string& targetName, uint8_t reportType,
 	                               uint8_t reportReason, const std::string& comment, const std::string& translation);
 
-	bool internalStartTrade(Player* player, Player* tradePartner, Item* tradeItem);
-	void internalCloseTrade(Player* player, bool sendCancel = true);
-	bool playerBroadcastMessage(Player* player, const std::string& text) const;
+	bool internalStartTrade(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& tradePartner,
+	                        const std::shared_ptr<Item>& tradeItem);
+	void internalCloseTrade(const std::shared_ptr<Player>& player, bool sendCancel = true);
+	bool playerBroadcastMessage(const std::shared_ptr<Player>& player, const std::string& text) const;
 	void broadcastMessage(const std::string& text, MessageClasses type) const;
 
 	// Implementation of player invoked events
@@ -311,12 +320,13 @@ public:
 	                     const Position& toPos, uint8_t count);
 	void playerMoveCreatureByID(uint32_t playerId, uint32_t movingCreatureId, const Position& movingCreatureOrigPos,
 	                            const Position& toPos);
-	void playerMoveCreature(Player* player, Creature* movingCreature, const Position& movingCreatureOrigPos,
-	                        Tile* toTile);
+	void playerMoveCreature(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& movingCreature,
+	                        const Position& movingCreatureOrigPos, const std::shared_ptr<Tile>& toTile);
 	void playerMoveItemByPlayerID(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 	                              const Position& toPos, uint8_t count);
-	void playerMoveItem(Player* player, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
-	                    const Position& toPos, uint8_t count, Item* item, Thing* toThing);
+	void playerMoveItem(const std::shared_ptr<Player>& player, const Position& fromPos, uint16_t spriteId,
+	                    uint8_t fromStackPos, const Position& toPos, uint8_t count, std::shared_ptr<Item> item,
+	                    std::shared_ptr<Thing> toThing);
 	void playerEquipItem(uint32_t playerId, uint16_t spriteId);
 	void playerMove(uint32_t playerId, Direction direction);
 	void playerCreatePrivateChannel(uint32_t playerId);
@@ -394,26 +404,24 @@ public:
 	void parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, const std::string& buffer);
 	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, NetworkMessage_ptr msg);
 
-	std::vector<Item*> getMarketItemList(uint16_t wareId, uint16_t sufficientCount, Player& player);
+	std::vector<std::shared_ptr<Item>> getMarketItemList(uint16_t wareId, uint16_t sufficientCount, Player& player);
 
 	void cleanup();
 	void shutdown();
-	void ReleaseCreature(Creature* creature);
-	void ReleaseItem(Item* item);
 
 	bool canThrowObjectTo(const Position& fromPos, const Position& toPos, bool checkLineOfSight = true,
 	                      bool sameFloor = false, int32_t rangex = Map::maxClientViewportX,
 	                      int32_t rangey = Map::maxClientViewportY) const;
 	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false) const;
 
-	void changeSpeed(Creature* creature, int32_t varSpeedDelta);
-	void internalCreatureChangeOutfit(Creature* creature, const Outfit_t& outfit);
-	void internalCreatureChangeVisible(Creature* creature, bool visible);
-	void changeLight(const Creature* creature);
-	void updateCreatureSkull(const Creature* creature);
-	void updatePlayerShield(Player* player);
-	void updateCreatureWalkthrough(const Creature* creature);
-	void updateKnownCreature(const Creature* creature);
+	void changeSpeed(const std::shared_ptr<Creature>& creature, int32_t varSpeedDelta);
+	void internalCreatureChangeOutfit(const std::shared_ptr<Creature>& creature, const Outfit_t& outfit);
+	void internalCreatureChangeVisible(const std::shared_ptr<Creature>& creature, bool visible);
+	void changeLight(const std::shared_ptr<const Creature>& creature);
+	void updateCreatureSkull(const std::shared_ptr<const Creature>& creature);
+	void updatePlayerShield(const std::shared_ptr<Player>& player);
+	void updateCreatureWalkthrough(const std::shared_ptr<const Creature>& creature);
+	void updateKnownCreature(const std::shared_ptr<const Creature>& creature);
 
 	GameState_t getGameState() const;
 	void setGameState(GameState_t newState);
@@ -426,58 +434,61 @@ public:
 	void checkCreatures(size_t index);
 	void updateCreaturesPath(size_t index);
 
-	bool combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* target, bool checkDefense, bool checkArmor,
-	                    bool field, bool ignoreResistances = false);
+	bool combatBlockHit(CombatDamage& damage, const std::shared_ptr<Creature>& attacker,
+	                    const std::shared_ptr<Creature>& target, bool checkDefense, bool checkArmor, bool field,
+	                    bool ignoreResistances = false);
 
-	void combatGetTypeInfo(CombatType_t combatType, Creature* target, TextColor_t& color, uint8_t& effect);
+	void combatGetTypeInfo(CombatType_t combatType, const std::shared_ptr<Creature>& target, TextColor_t& color,
+	                       uint8_t& effect);
 
-	bool combatChangeHealth(Creature* attacker, Creature* target, CombatDamage& damage);
-	bool combatChangeMana(Creature* attacker, Creature* target, CombatDamage& damage);
+	bool combatChangeHealth(const std::shared_ptr<Creature>& attacker, const std::shared_ptr<Creature>& target,
+	                        CombatDamage& damage);
+	bool combatChangeMana(const std::shared_ptr<Creature>& attacker, const std::shared_ptr<Creature>& target,
+	                      CombatDamage& damage);
 
 	// animation help functions
-	void addCreatureHealth(const Creature* target);
-	static void addCreatureHealth(const SpectatorVec& spectators, const Creature* target);
+	void addCreatureHealth(const std::shared_ptr<const Creature>& target);
+	static void addCreatureHealth(const SpectatorVec& spectators, const std::shared_ptr<const Creature>& target);
 	void addMagicEffect(const Position& pos, uint8_t effect);
 	static void addMagicEffect(const SpectatorVec& spectators, const Position& pos, uint8_t effect);
 	void addDistanceEffect(const Position& fromPos, const Position& toPos, uint8_t effect);
 	static void addDistanceEffect(const SpectatorVec& spectators, const Position& fromPos, const Position& toPos,
 	                              uint8_t effect);
 
-	void startDecay(Item* item);
+	void startDecay(const std::shared_ptr<Item>& item);
 
-	void sendOfflineTrainingDialog(Player* player);
+	void sendOfflineTrainingDialog(const std::shared_ptr<Player>& player);
 
-	const std::unordered_map<uint32_t, Player*>& getPlayers() const { return players; }
-	const std::map<uint32_t, Npc*>& getNpcs() const { return npcs; }
-	const std::map<uint32_t, Monster*>& getMonsters() const { return monsters; }
+	auto getPlayers() const { return players | std::views::values; }
+	auto getNpcs() const { return npcs | std::views::values; }
+	auto getMonsters() const { return monsters | std::views::values; }
 
-	void addPlayer(Player* player);
-	void removePlayer(Player* player);
+	void addPlayer(const std::shared_ptr<Player>& player);
+	void removePlayer(const std::shared_ptr<Player>& player);
 
-	void addNpc(Npc* npc);
-	void removeNpc(Npc* npc);
+	void addNpc(const std::shared_ptr<Npc>& npc) { npcs[npc->getID()] = npc; }
+	void removeNpc(const std::shared_ptr<Npc>& npc) { npcs.erase(npc->getID()); }
 
-	void addMonster(Monster* monster);
-	void removeMonster(Monster* monster);
+	void addMonster(const std::shared_ptr<Monster>& monster) { monsters[monster->getID()] = monster; }
+	void removeMonster(const std::shared_ptr<Monster>& monster) { monsters.erase(monster->getID()); }
 
-	Guild_ptr getGuild(uint32_t id) const;
-	void addGuild(Guild_ptr guild);
-	void removeGuild(uint32_t guildId);
-	void decreaseBrowseFieldRef(const Position& pos);
+	std::shared_ptr<Guild> getGuild(uint32_t id) const;
+	void addGuild(std::shared_ptr<Guild> guild) { guilds[guild->getId()] = std::move(guild); }
+	void removeGuild(uint32_t guildId) { guilds.erase(guildId); }
 
-	std::unordered_map<Tile*, Container*> browseFields;
+	std::unordered_map<Tile*, std::shared_ptr<Container>> browseFields;
 
-	void internalRemoveItems(std::vector<Item*> itemList, uint32_t amount, bool stackable);
+	void internalRemoveItems(const std::vector<std::shared_ptr<Item>>& itemList, uint32_t amount, bool stackable);
 
-	BedItem* getBedBySleeper(uint32_t guid) const;
-	void setBedSleeper(BedItem* bed, uint32_t guid);
-	void removeBedSleeper(uint32_t guid);
+	std::shared_ptr<BedItem> getBedBySleeper(uint32_t guid) const;
+	void setBedSleeper(std::shared_ptr<BedItem> bed, uint32_t guid) { bedSleepersMap[guid] = std::move(bed); }
+	void removeBedSleeper(uint32_t guid) { bedSleepersMap.erase(guid); }
 
-	void updatePodium(Item* item);
+	void updatePodium(const std::shared_ptr<Podium>& podium);
 
-	Item* getUniqueItem(uint16_t uniqueId);
-	bool addUniqueItem(uint16_t uniqueId, Item* item);
-	void removeUniqueItem(uint16_t uniqueId);
+	std::shared_ptr<Item> getUniqueItem(uint16_t uniqueId);
+	bool addUniqueItem(uint16_t uniqueId, std::shared_ptr<Item> item);
+	void removeUniqueItem(uint16_t uniqueId) { uniqueItems.erase(uniqueId); }
 
 	bool reload(ReloadTypes_t reloadType);
 
@@ -485,49 +496,47 @@ public:
 	Map map;
 	Mounts mounts;
 
-	std::forward_list<Item*> toDecayItems;
+	std::vector<std::shared_ptr<Item>> toDecayItems;
 
-	std::unordered_set<Tile*> getTilesToClean() const { return tilesToClean; }
-	bool isTileInCleanList(Tile* tile) { return tilesToClean.find(tile) != tilesToClean.end(); }
-	void addTileToClean(Tile* tile) { tilesToClean.emplace(tile); }
-	void removeTileToClean(Tile* tile) { tilesToClean.erase(tile); }
+	std::unordered_set<std::shared_ptr<Tile>> getTilesToClean() const { return tilesToClean; }
+	bool isTileInCleanList(const std::shared_ptr<Tile>& tile) { return tilesToClean.find(tile) != tilesToClean.end(); }
+	void addTileToClean(const std::shared_ptr<Tile>& tile) { tilesToClean.emplace(tile); }
+	void removeTileToClean(const std::shared_ptr<Tile>& tile) { tilesToClean.erase(tile); }
 	void clearTilesToClean() { tilesToClean.clear(); }
 
 private:
-	bool playerSaySpell(Player* player, SpeakClasses type, const std::string& text);
-	void playerWhisper(Player* player, const std::string& text);
-	bool playerYell(Player* player, const std::string& text);
-	bool playerSpeakTo(Player* player, SpeakClasses type, const std::string& receiver, const std::string& text);
-	void playerSpeakToNpc(Player* player, const std::string& text);
+	bool playerSaySpell(const std::shared_ptr<Player>& player, SpeakClasses type, const std::string& text);
+	void playerWhisper(const std::shared_ptr<Player>& player, const std::string& text);
+	bool playerYell(const std::shared_ptr<Player>& player, const std::string& text);
+	bool playerSpeakTo(const std::shared_ptr<Player>& player, SpeakClasses type, const std::string& receiver,
+	                   const std::string& text);
+	void playerSpeakToNpc(const std::shared_ptr<Player>& player, const std::string& text);
 
 	void checkDecay();
-	void internalDecayItem(Item* item);
+	void internalDecayItem(const std::shared_ptr<Item>& item);
 
-	std::unordered_map<uint32_t, Player*> players;
-	std::unordered_map<std::string, Player*> mappedPlayerNames;
-	std::unordered_map<uint32_t, Player*> mappedPlayerGuids;
-	std::unordered_map<uint32_t, Guild_ptr> guilds;
-	std::unordered_map<uint16_t, Item*> uniqueItems;
+	std::unordered_map<uint32_t, std::weak_ptr<Player>> players;
+	std::unordered_map<std::string, std::weak_ptr<Player>> mappedPlayerNames;
+	std::unordered_map<uint32_t, std::weak_ptr<Player>> mappedPlayerGuids;
+	std::unordered_map<uint32_t, std::shared_ptr<Guild>> guilds;
+	std::unordered_map<uint16_t, std::shared_ptr<Item>> uniqueItems;
 
-	std::list<Item*> decayItems[EVENT_DECAY_BUCKETS];
-	std::list<Creature*> checkCreatureLists[EVENT_CREATURECOUNT];
-
-	std::vector<Creature*> ToReleaseCreatures;
-	std::vector<Item*> ToReleaseItems;
+	std::list<std::weak_ptr<Item>> decayItems[EVENT_DECAY_BUCKETS];
+	std::list<std::weak_ptr<Creature>> checkCreatureLists[EVENT_CREATURECOUNT];
 
 	size_t lastBucket = 0;
 
 	WildcardTreeNode wildcardTree{false};
 
-	std::map<uint32_t, Npc*> npcs;
-	std::map<uint32_t, Monster*> monsters;
+	std::map<uint32_t, std::weak_ptr<Npc>> npcs;
+	std::map<uint32_t, std::weak_ptr<Monster>> monsters;
 
-	// list of items that are in trading state, mapped to the player
-	std::map<Item*, uint32_t> tradeItems;
+	// list of items that are in trading state, mapped to the player holding them
+	std::map<std::shared_ptr<Item>, uint32_t> tradeItems;
 
-	std::map<uint32_t, BedItem*> bedSleepersMap;
+	std::map<uint32_t, std::shared_ptr<BedItem>> bedSleepersMap;
 
-	std::unordered_set<Tile*> tilesToClean;
+	std::unordered_set<std::shared_ptr<Tile>> tilesToClean;
 
 	ModalWindow offlineTrainingWindow{std::numeric_limits<uint32_t>::max(), "Choose a Skill", "Please choose a skill:"};
 

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -10,9 +10,7 @@
 
 extern Game g_game;
 
-void Guild::addMember(Player* player) { membersOnline.insert(player); }
-
-void Guild::removeMember(Player* player)
+void Guild::removeMember(const std::shared_ptr<Player>& player)
 {
 	membersOnline.erase(player);
 
@@ -26,9 +24,9 @@ void Guild::addRank(uint32_t rankId, std::string_view rankName, uint8_t level)
 	ranks.emplace_back(std::make_shared<GuildRank>(rankId, rankName, level));
 }
 
-GuildRank_ptr Guild::getRankById(uint32_t rankId)
+std::shared_ptr<GuildRank> Guild::getRankById(uint32_t rankId)
 {
-	for (auto rank : ranks) {
+	for (const auto& rank : ranks) {
 		if (rank->id == rankId) {
 			return rank;
 		}
@@ -36,9 +34,9 @@ GuildRank_ptr Guild::getRankById(uint32_t rankId)
 	return nullptr;
 }
 
-GuildRank_ptr Guild::getRankByName(const std::string& name) const
+std::shared_ptr<GuildRank> Guild::getRankByName(const std::string& name) const
 {
-	for (auto rank : ranks) {
+	for (const auto& rank : ranks) {
 		if (boost::iequals(rank->name, name)) {
 			return rank;
 		}
@@ -46,9 +44,9 @@ GuildRank_ptr Guild::getRankByName(const std::string& name) const
 	return nullptr;
 }
 
-GuildRank_ptr Guild::getRankByLevel(uint8_t level) const
+std::shared_ptr<GuildRank> Guild::getRankByLevel(uint8_t level) const
 {
-	for (auto rank : ranks) {
+	for (const auto& rank : ranks) {
 		if (rank->level == level) {
 			return rank;
 		}
@@ -56,7 +54,7 @@ GuildRank_ptr Guild::getRankByLevel(uint8_t level) const
 	return nullptr;
 }
 
-Guild_ptr IOGuild::loadGuild(uint32_t guildId)
+std::shared_ptr<Guild> IOGuild::loadGuild(uint32_t guildId)
 {
 	Database& db = Database::getInstance();
 	DBResult_ptr result = db.storeQuery(std::format("SELECT `name` FROM `guilds` WHERE `id` = {:d}", guildId));

--- a/src/guild.h
+++ b/src/guild.h
@@ -17,8 +17,6 @@ struct GuildRank
 	GuildRank(uint32_t id, std::string_view name, uint8_t level) : id{id}, name{name}, level{level} {}
 };
 
-using GuildRank_ptr = std::shared_ptr<GuildRank>;
-
 class Guild
 {
 public:
@@ -29,35 +27,35 @@ public:
 	uint32_t getId() const { return id; }
 	const std::string& getName() const { return name; }
 
-	void addMember(Player* player);
-	void removeMember(Player* player);
+	void addMember(const std::shared_ptr<Player>& player) { membersOnline.emplace(player); }
+	void removeMember(const std::shared_ptr<Player>& player);
 	const auto& getMembersOnline() const { return membersOnline; }
 	uint32_t getMemberCount() const { return memberCount; }
 	void setMemberCount(uint32_t count) { memberCount = count; }
 
 	void addRank(uint32_t rankId, std::string_view rankName, uint8_t level);
-	const std::vector<GuildRank_ptr>& getRanks() const { return ranks; }
-	GuildRank_ptr getRankById(uint32_t rankId);
-	GuildRank_ptr getRankByName(const std::string& name) const;
-	GuildRank_ptr getRankByLevel(uint8_t level) const;
+	const auto& getRanks() const { return ranks; }
+	std::shared_ptr<GuildRank> getRankById(uint32_t rankId);
+	std::shared_ptr<GuildRank> getRankByName(const std::string& name) const;
+	std::shared_ptr<GuildRank> getRankByLevel(uint8_t level) const;
 
 	const std::string& getMotd() const { return motd; }
-	void setMotd(const std::string& motd) { this->motd = motd; }
+	void setMotd(std::string motd) { this->motd = std::move(motd); }
 
 private:
-	boost::container::flat_set<Player*> membersOnline;
-	std::vector<GuildRank_ptr> ranks;
+	boost::container::flat_set<std::weak_ptr<Player>, std::owner_less<std::weak_ptr<Player>>> membersOnline;
+	std::vector<std::shared_ptr<GuildRank>> ranks;
 	std::string name;
 	std::string motd;
 	uint32_t id;
 	uint32_t memberCount = 0;
 };
 
-using Guild_ptr = std::shared_ptr<Guild>;
-
 namespace IOGuild {
-Guild_ptr loadGuild(uint32_t guildId);
+
+std::shared_ptr<Guild> loadGuild(uint32_t guildId);
 uint32_t getGuildIdByName(const std::string& name);
+
 }; // namespace IOGuild
 
 #endif // FS_GUILD_H

--- a/src/house.h
+++ b/src/house.h
@@ -22,7 +22,7 @@ public:
 	void addGuild(const std::string& name);
 	void addGuildRank(const std::string& name, const std::string& rankName);
 
-	bool isInList(const Player* player) const;
+	bool isInList(const std::shared_ptr<const Player>& player) const;
 
 	void getList(std::string& list) const;
 
@@ -42,8 +42,11 @@ public:
 	Door(const Door&) = delete;
 	Door& operator=(const Door&) = delete;
 
-	Door* getDoor() override { return this; }
-	const Door* getDoor() const override { return this; }
+	std::shared_ptr<Door> getDoor() override { return std::static_pointer_cast<Door>(shared_from_this()); }
+	std::shared_ptr<const Door> getDoor() const override
+	{
+		return std::static_pointer_cast<const Door>(shared_from_this());
+	}
 
 	House* getHouse() { return house; }
 
@@ -54,7 +57,7 @@ public:
 	void setDoorId(uint32_t doorId) { setIntAttr(ITEM_ATTRIBUTE_DOORID, doorId); }
 	uint32_t getDoorId() const { return getIntAttr(ITEM_ATTRIBUTE_DOORID); }
 
-	bool canUse(const Player* player);
+	bool canUse(const std::shared_ptr<const Player>& player);
 
 	void setAccessList(std::string_view textlist);
 	bool getAccessList(std::string& list) const;
@@ -86,11 +89,11 @@ enum AccessHouseLevel_t
 class HouseTransferItem final : public Item
 {
 public:
-	static HouseTransferItem* createHouseTransferItem(House* house);
+	static std::shared_ptr<HouseTransferItem> createHouseTransferItem(House* house);
 
-	explicit HouseTransferItem(House* house) : Item(0), house(house) {}
+	explicit HouseTransferItem(House* house) : Item{0}, house{house} {}
 
-	void onTradeEvent(TradeEvents_t event, Player* owner) override;
+	void onTradeEvent(TradeEvents_t event, const std::shared_ptr<Player>& owner) override;
 	bool canTransform() const override { return false; }
 
 private:
@@ -102,19 +105,19 @@ class House
 public:
 	explicit House(uint32_t houseId);
 
-	void addTile(HouseTile* tile);
+	void addTile(const std::shared_ptr<HouseTile>& tile);
 
-	bool canEditAccessList(uint32_t listId, const Player* player);
+	bool canEditAccessList(uint32_t listId, const std::shared_ptr<const Player>& player);
 	// listId special values:
 	// GUEST_LIST	 guest list
 	// SUBOWNER_LIST subowner list
 	void setAccessList(uint32_t listId, std::string_view textlist);
 	bool getAccessList(uint32_t listId, std::string& list) const;
 
-	bool isInvited(const Player* player) const;
+	bool isInvited(const std::shared_ptr<const Player>& player) const;
 
-	AccessHouseLevel_t getHouseAccessLevel(const Player* player) const;
-	bool kickPlayer(Player* player, Player* target);
+	AccessHouseLevel_t getHouseAccessLevel(const std::shared_ptr<const Player>& player) const;
+	bool kickPlayer(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& target);
 
 	void setEntryPos(Position pos) { posEntry = pos; }
 	const Position& getEntryPosition() const { return posEntry; }
@@ -124,7 +127,7 @@ public:
 
 	const std::string& getOwnerName() const { return ownerName; }
 
-	void setOwner(uint32_t guid, bool updateDatabase = true, Player* player = nullptr);
+	void setOwner(uint32_t guid, bool updateDatabase = true, const std::shared_ptr<Player>& player = nullptr);
 	uint32_t getOwner() const { return owner; }
 
 	void setPaidUntil(time_t paid) { paidUntil = paid; }
@@ -141,44 +144,41 @@ public:
 
 	uint32_t getId() const { return id; }
 
-	void addDoor(Door* door);
-	void removeDoor(Door* door);
-	Door* getDoorByNumber(uint32_t doorId) const;
-	Door* getDoorByPosition(const Position& pos);
+	void addDoor(const std::shared_ptr<Door>& door);
+	void removeDoor(const std::shared_ptr<Door>& door);
+	std::shared_ptr<Door> getDoorByNumber(uint32_t doorId) const;
+	std::shared_ptr<Door> getDoorByPosition(const Position& pos);
 
-	HouseTransferItem* getTransferItem();
+	std::shared_ptr<HouseTransferItem> getTransferItem();
 	void resetTransferItem();
-	bool executeTransfer(HouseTransferItem* item, Player* newOwner);
+	bool executeTransfer(const std::shared_ptr<HouseTransferItem>& item, const std::shared_ptr<Player>& newOwner);
 
-	const auto& getTiles() const { return houseTiles; }
+	const auto& getTiles() const { return tiles; }
+	const auto& getDoors() const { return doors; }
 
-	const auto& getDoors() const { return doorSet; }
+	void addBed(const std::shared_ptr<BedItem>& bed);
+	const auto& getBeds() const { return beds; }
 
-	void addBed(BedItem* bed);
-	const auto& getBeds() const { return bedsList; }
-	uint32_t getBedCount()
-	{
-		return static_cast<uint32_t>(
-		    std::ceil(bedsList.size() / 2.)); // each bed takes 2 sqms of space, ceil is just for bad maps
-	}
+	// each bed takes 2 sqms of space, ceil is just for bad maps
+	auto getBedCount() const { return (beds.size() + 1) / 2; }
 
 private:
 	bool transferToDepot() const;
-	bool transferToDepot(Player* player) const;
+	bool transferToDepot(const std::shared_ptr<Player>& player) const;
 
 	AccessList guestList;
 	AccessList subOwnerList;
 
-	Container transfer_container{ITEM_LOCKER};
+	Container transferContainer{ITEM_LOCKER};
 
-	boost::container::flat_set<HouseTile*> houseTiles;
-	boost::container::flat_set<Door*> doorSet;
-	boost::container::flat_set<BedItem*> bedsList;
+	boost::container::flat_set<std::weak_ptr<HouseTile>, std::owner_less<std::weak_ptr<HouseTile>>> tiles;
+	boost::container::flat_set<std::weak_ptr<Door>, std::owner_less<std::weak_ptr<Door>>> doors;
+	boost::container::flat_set<std::weak_ptr<BedItem>, std::owner_less<std::weak_ptr<BedItem>>> beds;
 
 	std::string houseName;
 	std::string ownerName;
 
-	HouseTransferItem* transferItem = nullptr;
+	std::shared_ptr<HouseTransferItem> transferItem = nullptr;
 
 	time_t paidUntil = 0;
 

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -11,25 +11,34 @@ class House;
 class HouseTile final : public DynamicTile
 {
 public:
-	HouseTile(int32_t x, int32_t y, int32_t z, House* house);
+	HouseTile(uint16_t x, uint16_t y, uint8_t z, House* house) : DynamicTile{x, y, z}, house{house} {}
 
-	HouseTile* getHouseTile() override final { return this; }
-	const HouseTile* getHouseTile() const override final { return this; }
+	std::shared_ptr<HouseTile> getHouseTile() override
+	{
+		return std::static_pointer_cast<HouseTile>(shared_from_this());
+	}
+	std::shared_ptr<const HouseTile> getHouseTile() const override
+	{
+		return std::static_pointer_cast<const HouseTile>(shared_from_this());
+	}
 
-	// cylinder implementations
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                     Creature* actor = nullptr) const override;
-	Tile* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override;
-	ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags,
-	                        Creature* actor = nullptr) const override;
+	// Thing implementations
+	ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                     const std::shared_ptr<Creature>& actor = nullptr) const override;
 
-	void addThing(int32_t index, Thing* thing) override;
-	void internalAddThing(uint32_t index, Thing* thing) override;
+	std::shared_ptr<Thing> queryDestination(int32_t& index, const std::shared_ptr<const Thing>& thing,
+	                                        std::shared_ptr<Item>& destItem, uint32_t& flags) override;
+
+	ReturnValue queryRemove(const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                        const std::shared_ptr<Creature>& actor = nullptr) const override;
+
+	void addThing(int32_t index, const std::shared_ptr<Thing>& thing) override;
+	void internalAddThing(uint32_t index, const std::shared_ptr<Thing>& thing) override;
 
 	House* getHouse() const { return house; }
 
 private:
-	void updateHouse(Item* item);
+	void updateHouse(const std::shared_ptr<Item>& item);
 
 	House* house;
 };

--- a/src/inbox.cpp
+++ b/src/inbox.cpp
@@ -7,20 +7,19 @@
 
 #include "tools.h"
 
-Inbox::Inbox(uint16_t type) : Container(type, 30, false, true) {}
-
-ReturnValue Inbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags, Creature*) const
+ReturnValue Inbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, uint32_t, uint32_t flags,
+                            const std::shared_ptr<Creature>&) const
 {
 	if (!hasBitSet(FLAG_NOLIMIT, flags)) {
 		return RETURNVALUE_CONTAINERNOTENOUGHROOM;
 	}
 
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	if (item == this) {
+	if (item.get() == this) {
 		return RETURNVALUE_THISISIMPOSSIBLE;
 	}
 
@@ -31,22 +30,24 @@ ReturnValue Inbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flag
 	return RETURNVALUE_NOERROR;
 }
 
-void Inbox::postAddNotification(Thing* thing, const Thing* oldParent, int32_t index, ReceiverLink_t)
+void Inbox::postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+                                int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void Inbox::postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index, ReceiverLink_t)
+void Inbox::postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+                                   int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }
 
-Thing* Inbox::getParent() const
+std::shared_ptr<Thing> Inbox::getParent() const
 {
-	const auto parent = Container::getParent();
+	const auto& parent = Container::getParent();
 	return parent ? parent->getParent() : nullptr;
 }

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -6,24 +6,21 @@
 
 #include "container.h"
 
-class Inbox;
-using Inbox_ptr = std::shared_ptr<Inbox>;
-
 class Inbox final : public Container
 {
 public:
-	explicit Inbox(uint16_t type);
+	explicit Inbox(uint16_t type) : Container{type, 30, false, true} {}
 
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                     Creature* actor = nullptr) const override;
+	ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                     const std::shared_ptr<Creature>& actor = nullptr) const override;
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 
 	bool canRemove() const override { return false; }
-	Thing* getParent() const override;
+	std::shared_ptr<Thing> getParent() const override;
 };
 
 #endif // FS_INBOX_H

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -7,10 +7,7 @@
 
 #include "condition.h"
 #include "configmanager.h"
-#include "depotchest.h"
 #include "game.h"
-#include "inbox.h"
-#include "storeinbox.h"
 
 extern Game g_game;
 
@@ -67,7 +64,7 @@ void IOLoginData::updateOnlineStatus(uint32_t guid, bool login)
 	}
 }
 
-bool IOLoginData::preloadPlayer(Player* player)
+bool IOLoginData::preloadPlayer(const std::shared_ptr<Player>& player)
 {
 	Database& db = Database::getInstance();
 
@@ -92,7 +89,7 @@ bool IOLoginData::preloadPlayer(Player* player)
 	return true;
 }
 
-bool IOLoginData::loadPlayerById(Player* player, uint32_t id)
+bool IOLoginData::loadPlayerById(const std::shared_ptr<Player>& player, uint32_t id)
 {
 	Database& db = Database::getInstance();
 	return loadPlayer(
@@ -102,7 +99,7 @@ bool IOLoginData::loadPlayerById(Player* player, uint32_t id)
 	        id)));
 }
 
-bool IOLoginData::loadPlayerByName(Player* player, const std::string& name)
+bool IOLoginData::loadPlayerByName(const std::shared_ptr<Player>& player, const std::string& name)
 {
 	Database& db = Database::getInstance();
 	return loadPlayer(
@@ -133,7 +130,7 @@ static GuildWarVector getWarList(uint32_t guildId)
 	return guildWarVector;
 }
 
-bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
+bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, DBResult_ptr result)
 {
 	if (!result) {
 		return false;
@@ -257,9 +254,8 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 		}
 	}
 
-	player->loginPosition.x = result->getNumber<uint16_t>("posx");
-	player->loginPosition.y = result->getNumber<uint16_t>("posy");
-	player->loginPosition.z = result->getNumber<uint16_t>("posz");
+	player->setLoginPosition(
+	    {result->getNumber<uint16_t>("posx"), result->getNumber<uint16_t>("posy"), result->getNumber<uint8_t>("posz")});
 
 	player->lastLoginSaved = result->getNumber<time_t>("lastlogin");
 	player->lastLogout = result->getNumber<time_t>("lastlogout");
@@ -276,9 +272,9 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	player->town = town;
 
-	const Position& loginPos = player->loginPosition;
+	const Position& loginPos = player->getLoginPosition();
 	if (loginPos.x == 0 && loginPos.y == 0 && loginPos.z == 0) {
-		player->loginPosition = player->getTemplePosition();
+		player->setLoginPosition(player->getTemplePosition());
 	}
 
 	player->staminaMinutes = result->getNumber<uint16_t>("stamina");
@@ -332,7 +328,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 				rank = guild->getRankById(playerRankId);
 				if (!rank) {
-					player->guild = nullptr;
+					player->guild.reset();
 				}
 			}
 
@@ -355,18 +351,15 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 
 	// load inventory items
 	ItemMap itemMap;
-	std::map<uint8_t, Container*> openContainersList;
+	std::map<uint8_t, std::shared_ptr<Container>> openContainersList;
 
 	if ((result = db.storeQuery(std::format(
 	         "SELECT `pid`, `sid`, `itemtype`, `count`, `attributes` FROM `player_items` WHERE `player_id` = {:d} ORDER BY `sid` DESC",
 	         player->getGUID())))) {
 		loadItems(itemMap, result);
 
-		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
-			auto&& [item, pid] = it->second;
-
-			Container* itemContainer = item->getContainer();
-			if (itemContainer) {
+		for (auto&& [item, pid] : itemMap | std::views::reverse | std::views::values) {
+			if (const auto& itemContainer = item->getContainer()) {
 				uint8_t cid = item->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
 				if (cid > 0) {
 					openContainersList.emplace(cid, itemContainer);
@@ -376,13 +369,12 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 			if (pid >= CONST_SLOT_FIRST && pid <= CONST_SLOT_LAST) {
 				player->internalAddThing(pid, item);
 			} else {
-				ItemMap::const_iterator it2 = itemMap.find(pid);
+				auto it2 = itemMap.find(pid);
 				if (it2 == itemMap.end()) {
 					continue;
 				}
 
-				Container* container = it2->second.first->getContainer();
-				if (container) {
+				if (const auto& container = it2->second.first->getContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -402,21 +394,18 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	         player->getGUID())))) {
 		loadItems(itemMap, result);
 
-		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
-			auto&& [item, pid] = it->second;
-
+		for (auto&& [item, pid] : itemMap | std::views::reverse | std::views::values | std::views::as_const) {
 			if (pid < 100) {
 				if (const auto& depotChest = player->getDepotChest(pid, true)) {
 					depotChest->internalAddThing(item);
 				}
 			} else {
-				ItemMap::const_iterator it2 = itemMap.find(pid);
+				auto it2 = itemMap.find(pid);
 				if (it2 == itemMap.end()) {
 					continue;
 				}
 
-				Container* container = it2->second.first->getContainer();
-				if (container) {
+				if (const auto& container = it2->second.first->getContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -431,20 +420,16 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	         player->getGUID())))) {
 		loadItems(itemMap, result);
 
-		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
-			auto&& [item, pid] = it->second;
-
+		for (auto&& [item, pid] : itemMap | std::views::reverse | std::views::values | std::views::as_const) {
 			if (pid < 100) {
 				player->getInbox()->internalAddThing(item);
 			} else {
-				ItemMap::const_iterator it2 = itemMap.find(pid);
-
+				auto it2 = itemMap.find(pid);
 				if (it2 == itemMap.end()) {
 					continue;
 				}
 
-				Container* container = it2->second.first->getContainer();
-				if (container) {
+				if (const auto& container = it2->second.first->getContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -459,20 +444,16 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	         player->getGUID())))) {
 		loadItems(itemMap, result);
 
-		for (ItemMap::const_reverse_iterator it = itemMap.rbegin(), end = itemMap.rend(); it != end; ++it) {
-			auto&& [item, pid] = it->second;
-
+		for (auto&& [item, pid] : itemMap | std::views::reverse | std::views::values | std::views::as_const) {
 			if (pid < 100) {
 				player->getStoreInbox()->internalAddThing(item);
 			} else {
-				ItemMap::const_iterator it2 = itemMap.find(pid);
-
+				auto it2 = itemMap.find(pid);
 				if (it2 == itemMap.end()) {
 					continue;
 				}
 
-				Container* container = it2->second.first->getContainer();
-				if (container) {
+				if (const auto& container = it2->second.first->getContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -517,10 +498,10 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 	return true;
 }
 
-bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert,
-                            PropWriteStream& propWriteStream)
+bool IOLoginData::saveItems(const std::shared_ptr<const Player>& player, const ItemBlockList& itemList,
+                            DBInsert& query_insert, PropWriteStream& propWriteStream)
 {
-	using ContainerBlock = std::pair<Container*, int32_t>;
+	using ContainerBlock = std::pair<std::shared_ptr<const Container>, int32_t>;
 	std::vector<ContainerBlock> containers;
 	containers.reserve(32);
 
@@ -531,14 +512,14 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 	for (auto&& [pid, item] : itemList | std::views::as_const) {
 		++runningId;
 
-		if (Container* container = item->getContainer()) {
+		if (const auto& container = item->getContainer()) {
 			if (container->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER)) {
 				container->setIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER, 0);
 			}
 
 			if (!openContainers.empty()) {
 				for (auto&& [cid, openContainer] : openContainers | std::views::as_const) {
-					auto opcontainer = openContainer.container;
+					const auto& opcontainer = openContainer.container;
 
 					if (opcontainer == container) {
 						container->setIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER, static_cast<int64_t>(cid) + 1);
@@ -560,14 +541,13 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 		}
 	}
 
-	for (size_t i = 0; i < containers.size(); i++) {
-		auto&& [container, parentId] = containers[i];
+	for (size_t i = 0; i < containers.size(); ++i) {
+		const auto& [container, parentId] = containers[i];
 
-		for (Item* item : container->getItemList()) {
+		for (const auto& item : container->getItemList()) {
 			++runningId;
 
-			Container* subContainer = item->getContainer();
-			if (subContainer) {
+			if (const auto& subContainer = item->getContainer()) {
 				containers.emplace_back(subContainer, runningId);
 
 				if (subContainer->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER)) {
@@ -576,7 +556,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 
 				if (!openContainers.empty()) {
 					for (auto&& [cid, openContainer] : openContainers | std::views::as_const) {
-						auto opcontainer = openContainer.container;
+						const auto& opcontainer = openContainer.container;
 
 						if (opcontainer == subContainer) {
 							subContainer->setIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER, cid + 1);
@@ -599,7 +579,7 @@ bool IOLoginData::saveItems(const Player* player, const ItemBlockList& itemList,
 	return query_insert.execute();
 }
 
-bool IOLoginData::savePlayer(Player* player)
+bool IOLoginData::savePlayer(const std::shared_ptr<Player>& player)
 {
 	if (player->isDead()) {
 		player->changeHealth(1);
@@ -755,8 +735,7 @@ bool IOLoginData::savePlayer(Player* player)
 
 	ItemBlockList itemList;
 	for (int32_t slotId = CONST_SLOT_FIRST; slotId <= CONST_SLOT_LAST; ++slotId) {
-		Item* item = player->inventory[slotId];
-		if (item) {
+		if (const auto& item = player->inventory[slotId]) {
 			itemList.emplace_back(slotId, item);
 		}
 	}
@@ -774,8 +753,8 @@ bool IOLoginData::savePlayer(Player* player)
 	    "INSERT INTO `player_depotitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 	itemList.clear();
 
-	for (auto&& [depotId, depotChest] : player->depotChests | std::views::as_const) {
-		for (Item* item : depotChest->getItemList()) {
+	for (auto&& [depotId, depotChest] : player->getDepotChests()) {
+		for (const auto& item : depotChest->getItemList()) {
 			itemList.emplace_back(depotId, item);
 		}
 	}
@@ -793,7 +772,7 @@ bool IOLoginData::savePlayer(Player* player)
 	    "INSERT INTO `player_inboxitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 	itemList.clear();
 
-	for (Item* item : player->getInbox()->getItemList()) {
+	for (const auto& item : player->getInbox()->getItemList()) {
 		itemList.emplace_back(0, item);
 	}
 
@@ -811,7 +790,7 @@ bool IOLoginData::savePlayer(Player* player)
 	    "INSERT INTO `player_storeinboxitems` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`) VALUES ");
 	itemList.clear();
 
-	for (Item* item : player->getStoreInbox()->getItemList()) {
+	for (const auto& item : player->getStoreInbox()->getItemList()) {
 		itemList.emplace_back(0, item);
 	}
 
@@ -948,14 +927,12 @@ void IOLoginData::loadItems(ItemMap& itemMap, DBResult_ptr result)
 		PropStream propStream;
 		propStream.init(attr.data(), attr.size());
 
-		Item* item = Item::CreateItem(type, count);
-		if (item) {
+		if (const auto& item = Item::CreateItem(type, count)) {
 			if (!item->unserializeAttr(propStream)) {
 				std::cout << "WARNING: Serialize error in IOLoginData::loadItems" << std::endl;
 			}
 
-			std::pair<Item*, uint32_t> pair(item, pid);
-			itemMap[sid] = pair;
+			itemMap[sid] = std::make_pair(std::move(item), pid);
 		}
 	} while (result->next());
 }

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -12,7 +12,7 @@ class Player;
 class PropWriteStream;
 struct VIPEntry;
 
-using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
+using ItemBlockList = std::list<std::pair<int32_t, std::shared_ptr<Item>>>;
 
 class IOLoginData
 {
@@ -23,12 +23,12 @@ public:
 	static AccountType_t getAccountType(uint32_t accountId);
 	static void setAccountType(uint32_t accountId, AccountType_t accountType);
 	static void updateOnlineStatus(uint32_t guid, bool login);
-	static bool preloadPlayer(Player* player);
+	static bool preloadPlayer(const std::shared_ptr<Player>& player);
 
-	static bool loadPlayerById(Player* player, uint32_t id);
-	static bool loadPlayerByName(Player* player, const std::string& name);
-	static bool loadPlayer(Player* player, DBResult_ptr result);
-	static bool savePlayer(Player* player);
+	static bool loadPlayerById(const std::shared_ptr<Player>& player, uint32_t id);
+	static bool loadPlayerByName(const std::shared_ptr<Player>& player, const std::string& name);
+	static bool loadPlayer(const std::shared_ptr<Player>& player, DBResult_ptr result);
+	static bool savePlayer(const std::shared_ptr<Player>& player);
 	static uint32_t getGuidByName(const std::string& name);
 	static bool getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name);
 	static std::string getNameByGuid(uint32_t guid);
@@ -46,11 +46,11 @@ public:
 	static void updatePremiumTime(uint32_t accountId, time_t endTime);
 
 private:
-	using ItemMap = std::map<uint32_t, std::pair<Item*, uint32_t>>;
+	using ItemMap = std::map<uint32_t, std::pair<std::shared_ptr<Item>, uint32_t>>;
 
 	static void loadItems(ItemMap& itemMap, DBResult_ptr result);
-	static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert,
-	                      PropWriteStream& propWriteStream);
+	static bool saveItems(const std::shared_ptr<const Player>& player, const ItemBlockList& itemList,
+	                      DBInsert& query_insert, PropWriteStream& propWriteStream);
 };
 
 #endif // FS_IOLOGINDATA_H

--- a/src/iomap.cpp
+++ b/src/iomap.cpp
@@ -31,31 +31,315 @@
         |--- OTBM_ITEM_DEF (not implemented)
 */
 
-Tile* IOMap::createTile(Item*& ground, Item* item, uint16_t x, uint16_t y, uint8_t z)
+namespace {
+
+std::shared_ptr<Tile> createTile(const std::shared_ptr<Item>& ground, const std::shared_ptr<Item>& item, uint16_t x,
+                                 uint16_t y, uint8_t z)
 {
 	if (!ground) {
-		return new StaticTile(x, y, z);
+		return std::make_shared<StaticTile>(x, y, z);
 	}
 
-	Tile* tile;
+	std::shared_ptr<Tile> tile;
 	if ((item && item->isBlocking()) || ground->isBlocking()) {
-		tile = new StaticTile(x, y, z);
+		tile = std::make_shared<StaticTile>(x, y, z);
 	} else {
-		tile = new DynamicTile(x, y, z);
+		tile = std::make_shared<DynamicTile>(x, y, z);
 	}
 
 	tile->internalAddThing(ground);
 	ground->startDecaying();
-	ground = nullptr;
 	return tile;
 }
+
+std::optional<std::string> parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map,
+                                                  const std::filesystem::path& fileName)
+{
+	PropStream propStream;
+	if (!loader.getProps(mapNode, propStream)) {
+		return std::make_optional("Could not read map data attributes.");
+	}
+
+	uint8_t attribute;
+	while (propStream.read<uint8_t>(attribute)) {
+		switch (attribute) {
+			case OTBM_ATTR_DESCRIPTION: {
+				auto [mapDescription, ok] = propStream.readString();
+				if (!ok) {
+					return std::make_optional("Invalid description tag.");
+				}
+				break;
+			}
+
+			case OTBM_ATTR_EXT_SPAWN_FILE: {
+				auto [spawnFile, ok] = propStream.readString();
+				if (!ok) {
+					return std::make_optional("Invalid spawn tag.");
+				}
+
+				map.spawnfile = fileName.parent_path() / spawnFile;
+				break;
+			}
+
+			case OTBM_ATTR_EXT_HOUSE_FILE: {
+				auto [houseFile, ok] = propStream.readString();
+				if (!ok) {
+					return std::make_optional("Invalid house tag.");
+				}
+
+				map.housefile = fileName.parent_path() / houseFile;
+				break;
+			}
+
+			default:
+				return std::make_optional("Unknown header node.");
+		}
+	}
+	return std::nullopt;
+}
+
+std::optional<std::string> parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Map& map)
+{
+	PropStream propStream;
+	if (!loader.getProps(tileAreaNode, propStream)) {
+		return std::make_optional("Invalid map node.");
+	}
+
+	OTBM_Destination_coords area_coord;
+	if (!propStream.read(area_coord)) {
+		return std::make_optional("Invalid map node.");
+	}
+
+	uint16_t base_x = area_coord.x;
+	uint16_t base_y = area_coord.y;
+	uint16_t z = area_coord.z;
+
+	for (const auto& tileNode : tileAreaNode.children) {
+		if (tileNode.type != OTBM_TILE && tileNode.type != OTBM_HOUSETILE) {
+			return std::make_optional("Unknown tile node.");
+		}
+
+		if (!loader.getProps(tileNode, propStream)) {
+			return std::make_optional("Could not read node data.");
+		}
+
+		OTBM_Tile_coords tile_coord;
+		if (!propStream.read(tile_coord)) {
+			return std::make_optional("Could not read tile position.");
+		}
+
+		uint16_t x = base_x + tile_coord.x;
+		uint16_t y = base_y + tile_coord.y;
+
+		bool isHouseTile = false;
+		House* house = nullptr;
+		std::shared_ptr<Tile> tile = nullptr;
+		std::shared_ptr<Item> ground_item = nullptr;
+		uint32_t tileflags = TILESTATE_NONE;
+
+		if (tileNode.type == OTBM_HOUSETILE) {
+			uint32_t houseId;
+			if (!propStream.read<uint32_t>(houseId)) {
+				return std::make_optional(std::format("[x:{:d}, y:{:d}, z:{:d}] Could not read house id.", x, y, z));
+			}
+
+			house = map.houses.addHouse(houseId);
+			if (!house) {
+				return std::make_optional(
+				    std::format("[x:{:d}, y:{:d}, z:{:d}] Could not create house id: {:d}", x, y, z, houseId));
+			}
+
+			tile = std::make_shared<HouseTile>(x, y, z, house);
+			house->addTile(std::static_pointer_cast<HouseTile>(tile));
+			isHouseTile = true;
+		}
+
+		uint8_t attribute;
+		// read tile attributes
+		while (propStream.read<uint8_t>(attribute)) {
+			switch (attribute) {
+				case OTBM_ATTR_TILE_FLAGS: {
+					uint32_t flags;
+					if (!propStream.read<uint32_t>(flags)) {
+						return std::make_optional(
+						    std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to read tile flags.", x, y, z));
+					}
+
+					if ((flags & OTBM_TILEFLAG_PROTECTIONZONE) != 0) {
+						tileflags |= TILESTATE_PROTECTIONZONE;
+					} else if ((flags & OTBM_TILEFLAG_NOPVPZONE) != 0) {
+						tileflags |= TILESTATE_NOPVPZONE;
+					} else if ((flags & OTBM_TILEFLAG_PVPZONE) != 0) {
+						tileflags |= TILESTATE_PVPZONE;
+					}
+
+					if ((flags & OTBM_TILEFLAG_NOLOGOUT) != 0) {
+						tileflags |= TILESTATE_NOLOGOUT;
+					}
+					break;
+				}
+
+				case OTBM_ATTR_ITEM: {
+					const auto item = Item::CreateItem(propStream);
+					if (!item) {
+						return std::make_optional(
+						    std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to create item.", x, y, z));
+					}
+
+					if (isHouseTile && item->isMoveable()) {
+						std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID()
+						          << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y
+						          << ", z: " << z << "]." << std::endl;
+					} else {
+						if (item->getItemCount() == 0) {
+							item->setItemCount(1);
+						}
+
+						if (tile) {
+							tile->internalAddThing(item);
+							item->startDecaying();
+							item->setLoadedFromMap(true);
+						} else if (item->isGroundTile()) {
+							ground_item = std::move(item);
+						} else {
+							tile = createTile(std::move(ground_item), item, x, y, z);
+							tile->internalAddThing(item);
+							item->startDecaying();
+							item->setLoadedFromMap(true);
+						}
+					}
+					break;
+				}
+
+				default:
+					return std::make_optional(std::format("[x:{:d}, y:{:d}, z:{:d}] Unknown tile attribute.", x, y, z));
+			}
+		}
+
+		for (const auto& itemNode : tileNode.children) {
+			if (itemNode.type != OTBM_ITEM) {
+				return std::make_optional(std::format("[x:{:d}, y:{:d}, z:{:d}] Unknown node type.", x, y, z));
+			}
+
+			PropStream stream;
+			if (!loader.getProps(itemNode, stream)) {
+				return std::make_optional("Invalid item node.");
+			}
+
+			const auto item = Item::CreateItem(stream);
+			if (!item) {
+				return std::make_optional(std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to create item.", x, y, z));
+			}
+
+			if (!item->unserializeItemNode(loader, itemNode, stream)) {
+				return std::make_optional(
+				    std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to load item {:d}.", x, y, z, item->getID()));
+			}
+
+			if (isHouseTile && item->isMoveable()) {
+				std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID()
+				          << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y
+				          << ", z: " << z << "]." << std::endl;
+			} else {
+				if (item->getItemCount() == 0) {
+					item->setItemCount(1);
+				}
+
+				if (tile) {
+					tile->internalAddThing(item);
+					item->startDecaying();
+					item->setLoadedFromMap(true);
+				} else if (item->isGroundTile()) {
+					ground_item = std::move(item);
+				} else {
+					tile = createTile(std::move(ground_item), item, x, y, z);
+					tile->internalAddThing(item);
+					item->startDecaying();
+					item->setLoadedFromMap(true);
+				}
+			}
+		}
+
+		if (!tile) {
+			tile = createTile(std::move(ground_item), nullptr, x, y, z);
+		}
+
+		tile->setFlag(tileflags);
+
+		map.setTile(x, y, z, tile);
+	}
+	return std::nullopt;
+}
+
+std::optional<std::string> parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map)
+{
+	for (const auto& townNode : townsNode.children) {
+		PropStream propStream;
+		if (townNode.type != OTBM_TOWN) {
+			return std::make_optional("Unknown town node.");
+		}
+
+		if (!loader.getProps(townNode, propStream)) {
+			return std::make_optional("Could not read town data.");
+		}
+
+		uint32_t townId;
+		if (!propStream.read<uint32_t>(townId)) {
+			return std::make_optional("Could not read town id.");
+		}
+
+		auto [townName, ok] = propStream.readString();
+		if (!ok) {
+			return std::make_optional("Could not read town name.");
+		}
+
+		OTBM_Destination_coords town_coords;
+		if (!propStream.read(town_coords)) {
+			return std::make_optional("Could not read town coordinates.");
+		}
+
+		map.towns.setTown(townId, new Town{.id = townId,
+		                                   .name = std::string{townName},
+		                                   .templePosition = {town_coords.x, town_coords.y, town_coords.z}});
+	}
+	return std::nullopt;
+}
+
+std::optional<std::string> parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map)
+{
+	PropStream propStream;
+	for (const auto& node : waypointsNode.children) {
+		if (node.type != OTBM_WAYPOINT) {
+			return std::make_optional("Unknown waypoint node.");
+		}
+
+		if (!loader.getProps(node, propStream)) {
+			return std::make_optional("Could not read waypoint data.");
+		}
+
+		auto [name, ok] = propStream.readString();
+		if (!ok) {
+			return std::make_optional("Could not read waypoint name.");
+		}
+
+		OTBM_Destination_coords waypoint_coords;
+		if (!propStream.read(waypoint_coords)) {
+			return std::make_optional("Could not read waypoint coordinates.");
+		}
+
+		map.waypoints[std::string{name}] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
+	}
+	return std::nullopt;
+}
+
+} // namespace
 
 bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName)
 {
 	int64_t start = OTSYS_TIME();
 	try {
 		OTB::Loader loader{fileName.string(), OTB::Identifier{{'O', 'T', 'B', 'M'}}};
-		auto& root = loader.parseTree();
+		const auto& root = loader.parseTree();
 
 		PropStream propStream;
 		if (!loader.getProps(root, propStream)) {
@@ -114,22 +398,26 @@ bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName)
 			return false;
 		}
 
-		auto& mapNode = root.children[0];
-		if (!parseMapDataAttributes(loader, mapNode, *map, fileName)) {
+		const auto& mapNode = root.children[0];
+		if (const auto& errorString = parseMapDataAttributes(loader, mapNode, *map, fileName)) {
+			setLastErrorString(*errorString);
 			return false;
 		}
 
-		for (auto& mapDataNode : mapNode.children) {
+		for (const auto& mapDataNode : mapNode.children) {
 			if (mapDataNode.type == OTBM_TILE_AREA) {
-				if (!parseTileArea(loader, mapDataNode, *map)) {
+				if (const auto& errorString = parseTileArea(loader, mapDataNode, *map)) {
+					setLastErrorString(*errorString);
 					return false;
 				}
 			} else if (mapDataNode.type == OTBM_TOWNS) {
-				if (!parseTowns(loader, mapDataNode, *map)) {
+				if (const auto& errorString = parseTowns(loader, mapDataNode, *map)) {
+					setLastErrorString(*errorString);
 					return false;
 				}
 			} else if (mapDataNode.type == OTBM_WAYPOINTS && headerVersion > 1) {
-				if (!parseWaypoints(loader, mapDataNode, *map)) {
+				if (const auto& errorString = parseWaypoints(loader, mapDataNode, *map)) {
+					setLastErrorString(*errorString);
 					return false;
 				}
 			} else {
@@ -143,316 +431,5 @@ bool IOMap::loadMap(Map* map, const std::filesystem::path& fileName)
 	}
 
 	std::cout << "> Map loading time: " << (OTSYS_TIME() - start) / (1000.) << " seconds." << std::endl;
-	return true;
-}
-
-bool IOMap::parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map,
-                                   const std::filesystem::path& fileName)
-{
-	PropStream propStream;
-	if (!loader.getProps(mapNode, propStream)) {
-		setLastErrorString("Could not read map data attributes.");
-		return false;
-	}
-
-	uint8_t attribute;
-	while (propStream.read<uint8_t>(attribute)) {
-		switch (attribute) {
-			case OTBM_ATTR_DESCRIPTION: {
-				auto [mapDescription, ok] = propStream.readString();
-				if (!ok) {
-					setLastErrorString("Invalid description tag.");
-					return false;
-				}
-				break;
-			}
-
-			case OTBM_ATTR_EXT_SPAWN_FILE: {
-				auto [spawnFile, ok] = propStream.readString();
-				if (!ok) {
-					setLastErrorString("Invalid spawn tag.");
-					return false;
-				}
-
-				map.spawnfile = fileName.parent_path() / spawnFile;
-				break;
-			}
-
-			case OTBM_ATTR_EXT_HOUSE_FILE: {
-				auto [houseFile, ok] = propStream.readString();
-				if (!ok) {
-					setLastErrorString("Invalid house tag.");
-					return false;
-				}
-
-				map.housefile = fileName.parent_path() / houseFile;
-				break;
-			}
-
-			default:
-				setLastErrorString("Unknown header node.");
-				return false;
-		}
-	}
-	return true;
-}
-
-bool IOMap::parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Map& map)
-{
-	PropStream propStream;
-	if (!loader.getProps(tileAreaNode, propStream)) {
-		setLastErrorString("Invalid map node.");
-		return false;
-	}
-
-	OTBM_Destination_coords area_coord;
-	if (!propStream.read(area_coord)) {
-		setLastErrorString("Invalid map node.");
-		return false;
-	}
-
-	uint16_t base_x = area_coord.x;
-	uint16_t base_y = area_coord.y;
-	uint16_t z = area_coord.z;
-
-	for (auto& tileNode : tileAreaNode.children) {
-		if (tileNode.type != OTBM_TILE && tileNode.type != OTBM_HOUSETILE) {
-			setLastErrorString("Unknown tile node.");
-			return false;
-		}
-
-		if (!loader.getProps(tileNode, propStream)) {
-			setLastErrorString("Could not read node data.");
-			return false;
-		}
-
-		OTBM_Tile_coords tile_coord;
-		if (!propStream.read(tile_coord)) {
-			setLastErrorString("Could not read tile position.");
-			return false;
-		}
-
-		uint16_t x = base_x + tile_coord.x;
-		uint16_t y = base_y + tile_coord.y;
-
-		bool isHouseTile = false;
-		House* house = nullptr;
-		Tile* tile = nullptr;
-		Item* ground_item = nullptr;
-		uint32_t tileflags = TILESTATE_NONE;
-
-		if (tileNode.type == OTBM_HOUSETILE) {
-			uint32_t houseId;
-			if (!propStream.read<uint32_t>(houseId)) {
-				setLastErrorString(std::format("[x:{:d}, y:{:d}, z:{:d}] Could not read house id.", x, y, z));
-				return false;
-			}
-
-			house = map.houses.addHouse(houseId);
-			if (!house) {
-				setLastErrorString(
-				    std::format("[x:{:d}, y:{:d}, z:{:d}] Could not create house id: {:d}", x, y, z, houseId));
-				return false;
-			}
-
-			tile = new HouseTile(x, y, z, house);
-			house->addTile(static_cast<HouseTile*>(tile));
-			isHouseTile = true;
-		}
-
-		uint8_t attribute;
-		// read tile attributes
-		while (propStream.read<uint8_t>(attribute)) {
-			switch (attribute) {
-				case OTBM_ATTR_TILE_FLAGS: {
-					uint32_t flags;
-					if (!propStream.read<uint32_t>(flags)) {
-						setLastErrorString(std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to read tile flags.", x, y, z));
-						return false;
-					}
-
-					if ((flags & OTBM_TILEFLAG_PROTECTIONZONE) != 0) {
-						tileflags |= TILESTATE_PROTECTIONZONE;
-					} else if ((flags & OTBM_TILEFLAG_NOPVPZONE) != 0) {
-						tileflags |= TILESTATE_NOPVPZONE;
-					} else if ((flags & OTBM_TILEFLAG_PVPZONE) != 0) {
-						tileflags |= TILESTATE_PVPZONE;
-					}
-
-					if ((flags & OTBM_TILEFLAG_NOLOGOUT) != 0) {
-						tileflags |= TILESTATE_NOLOGOUT;
-					}
-					break;
-				}
-
-				case OTBM_ATTR_ITEM: {
-					Item* item = Item::CreateItem(propStream);
-					if (!item) {
-						setLastErrorString(std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to create item.", x, y, z));
-						return false;
-					}
-
-					if (isHouseTile && item->isMoveable()) {
-						std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID()
-						          << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y
-						          << ", z: " << z << "]." << std::endl;
-						delete item;
-					} else {
-						if (item->getItemCount() == 0) {
-							item->setItemCount(1);
-						}
-
-						if (tile) {
-							tile->internalAddThing(item);
-							item->startDecaying();
-							item->setLoadedFromMap(true);
-						} else if (item->isGroundTile()) {
-							delete ground_item;
-							ground_item = item;
-						} else {
-							tile = createTile(ground_item, item, x, y, z);
-							tile->internalAddThing(item);
-							item->startDecaying();
-							item->setLoadedFromMap(true);
-						}
-					}
-					break;
-				}
-
-				default:
-					setLastErrorString(std::format("[x:{:d}, y:{:d}, z:{:d}] Unknown tile attribute.", x, y, z));
-					return false;
-			}
-		}
-
-		for (auto& itemNode : tileNode.children) {
-			if (itemNode.type != OTBM_ITEM) {
-				setLastErrorString(std::format("[x:{:d}, y:{:d}, z:{:d}] Unknown node type.", x, y, z));
-				return false;
-			}
-
-			PropStream stream;
-			if (!loader.getProps(itemNode, stream)) {
-				setLastErrorString("Invalid item node.");
-				return false;
-			}
-
-			Item* item = Item::CreateItem(stream);
-			if (!item) {
-				setLastErrorString(std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to create item.", x, y, z));
-				return false;
-			}
-
-			if (!item->unserializeItemNode(loader, itemNode, stream)) {
-				setLastErrorString(
-				    std::format("[x:{:d}, y:{:d}, z:{:d}] Failed to load item {:d}.", x, y, z, item->getID()));
-				delete item;
-				return false;
-			}
-
-			if (isHouseTile && item->isMoveable()) {
-				std::cout << "[Warning - IOMap::loadMap] Moveable item with ID: " << item->getID()
-				          << ", in house: " << house->getId() << ", at position [x: " << x << ", y: " << y
-				          << ", z: " << z << "]." << std::endl;
-				delete item;
-			} else {
-				if (item->getItemCount() == 0) {
-					item->setItemCount(1);
-				}
-
-				if (tile) {
-					tile->internalAddThing(item);
-					item->startDecaying();
-					item->setLoadedFromMap(true);
-				} else if (item->isGroundTile()) {
-					delete ground_item;
-					ground_item = item;
-				} else {
-					tile = createTile(ground_item, item, x, y, z);
-					tile->internalAddThing(item);
-					item->startDecaying();
-					item->setLoadedFromMap(true);
-				}
-			}
-		}
-
-		if (!tile) {
-			tile = createTile(ground_item, nullptr, x, y, z);
-		}
-
-		tile->setFlag(static_cast<tileflags_t>(tileflags));
-
-		map.setTile(x, y, z, tile);
-	}
-	return true;
-}
-
-bool IOMap::parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map)
-{
-	for (auto& townNode : townsNode.children) {
-		PropStream propStream;
-		if (townNode.type != OTBM_TOWN) {
-			setLastErrorString("Unknown town node.");
-			return false;
-		}
-
-		if (!loader.getProps(townNode, propStream)) {
-			setLastErrorString("Could not read town data.");
-			return false;
-		}
-
-		uint32_t townId;
-		if (!propStream.read<uint32_t>(townId)) {
-			setLastErrorString("Could not read town id.");
-			return false;
-		}
-
-		auto [townName, ok] = propStream.readString();
-		if (!ok) {
-			setLastErrorString("Could not read town name.");
-			return false;
-		}
-
-		OTBM_Destination_coords town_coords;
-		if (!propStream.read(town_coords)) {
-			setLastErrorString("Could not read town coordinates.");
-			return false;
-		}
-
-		map.towns.setTown(townId, new Town{.id = townId,
-		                                   .name = std::string{townName},
-		                                   .templePosition = {town_coords.x, town_coords.y, town_coords.z}});
-	}
-	return true;
-}
-
-bool IOMap::parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map)
-{
-	PropStream propStream;
-	for (auto& node : waypointsNode.children) {
-		if (node.type != OTBM_WAYPOINT) {
-			setLastErrorString("Unknown waypoint node.");
-			return false;
-		}
-
-		if (!loader.getProps(node, propStream)) {
-			setLastErrorString("Could not read waypoint data.");
-			return false;
-		}
-
-		auto [name, ok] = propStream.readString();
-		if (!ok) {
-			setLastErrorString("Could not read waypoint name.");
-			return false;
-		}
-
-		OTBM_Destination_coords waypoint_coords;
-		if (!propStream.read(waypoint_coords)) {
-			setLastErrorString("Could not read waypoint coordinates.");
-			return false;
-		}
-
-		map.waypoints[std::string{name}] = Position(waypoint_coords.x, waypoint_coords.y, waypoint_coords.z);
-	}
 	return true;
 }

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -91,8 +91,6 @@ struct OTBM_Tile_coords
 
 class IOMap
 {
-	static Tile* createTile(Item*& ground, Item* item, uint16_t x, uint16_t y, uint8_t z);
-
 public:
 	bool loadMap(Map* map, const std::filesystem::path& fileName);
 
@@ -128,14 +126,9 @@ public:
 
 	const std::string& getLastErrorString() const { return errorString; }
 
-	void setLastErrorString(std::string error) { errorString = error; }
+	void setLastErrorString(std::string error) { errorString = std::move(error); }
 
 private:
-	bool parseMapDataAttributes(OTB::Loader& loader, const OTB::Node& mapNode, Map& map,
-	                            const std::filesystem::path& fileName);
-	bool parseWaypoints(OTB::Loader& loader, const OTB::Node& waypointsNode, Map& map);
-	bool parseTowns(OTB::Loader& loader, const OTB::Node& townsNode, Map& map);
-	bool parseTileArea(OTB::Loader& loader, const OTB::Node& tileAreaNode, Map& map);
 	std::string errorString;
 };
 

--- a/src/iomapserialize.h
+++ b/src/iomapserialize.h
@@ -24,11 +24,11 @@ public:
 	static bool saveHouse(House* house);
 
 private:
-	static void saveItem(PropWriteStream& stream, const Item* item);
-	static void saveTile(PropWriteStream& stream, const Tile* tile);
+	static void saveItem(PropWriteStream& stream, const std::shared_ptr<const Item>& item);
+	static void saveTile(PropWriteStream& stream, const std::shared_ptr<const Tile>& tile);
 
-	static bool loadContainer(PropStream& propStream, Container* container);
-	static bool loadItem(PropStream& propStream, Thing* parent);
+	static bool loadContainer(PropStream& propStream, const std::shared_ptr<Container>& container);
+	static bool loadItem(PropStream& propStream, const std::shared_ptr<Thing>& parent);
 };
 
 #endif // FS_IOMAPSERIALIZE_H

--- a/src/iomarket.cpp
+++ b/src/iomarket.cpp
@@ -8,7 +8,6 @@
 #include "configmanager.h"
 #include "databasetasks.h"
 #include "game.h"
-#include "inbox.h"
 #include "iologindata.h"
 #include "scheduler.h"
 
@@ -127,11 +126,10 @@ void processExpiredOffers(DBResult_ptr result, bool)
 				continue;
 			}
 
-			Player* player = g_game.getPlayerByGUID(playerId);
+			auto player = g_game.getPlayerByGUID(playerId);
 			if (!player) {
-				player = new Player(nullptr);
+				player = std::make_shared<Player>(nullptr);
 				if (!IOLoginData::loadPlayerById(player, playerId)) {
-					delete player;
 					continue;
 				}
 			}
@@ -140,10 +138,9 @@ void processExpiredOffers(DBResult_ptr result, bool)
 				uint16_t tmpAmount = amount;
 				while (tmpAmount > 0) {
 					uint16_t stackCount = std::min<uint16_t>(ITEM_STACK_SIZE, tmpAmount);
-					Item* item = Item::CreateItem(itemType.id, stackCount);
-					if (g_game.internalAddItem(player->getInbox().get(), item, INDEX_WHEREEVER, FLAG_NOLIMIT) !=
+					const auto item = Item::CreateItem(itemType.id, stackCount);
+					if (g_game.internalAddItem(player->getInbox(), item, INDEX_WHEREEVER, FLAG_NOLIMIT) !=
 					    RETURNVALUE_NOERROR) {
-						delete item;
 						break;
 					}
 
@@ -158,10 +155,9 @@ void processExpiredOffers(DBResult_ptr result, bool)
 				}
 
 				for (uint16_t i = 0; i < amount; ++i) {
-					Item* item = Item::CreateItem(itemType.id, subType);
-					if (g_game.internalAddItem(player->getInbox().get(), item, INDEX_WHEREEVER, FLAG_NOLIMIT) !=
+					const auto item = Item::CreateItem(itemType.id, subType);
+					if (g_game.internalAddItem(player->getInbox(), item, INDEX_WHEREEVER, FLAG_NOLIMIT) !=
 					    RETURNVALUE_NOERROR) {
-						delete item;
 						break;
 					}
 				}
@@ -169,12 +165,11 @@ void processExpiredOffers(DBResult_ptr result, bool)
 
 			if (player->isOffline()) {
 				IOLoginData::savePlayer(player);
-				delete player;
 			}
 		} else {
 			uint64_t totalPrice = result->getNumber<uint64_t>("price") * amount;
 
-			Player* player = g_game.getPlayerByGUID(playerId);
+			auto player = g_game.getPlayerByGUID(playerId);
 			if (player) {
 				player->setBankBalance(player->getBankBalance() + totalPrice);
 			} else {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -254,7 +254,7 @@ std::shared_ptr<Thing> Item::getTopParent()
 	}
 
 	while (parent->hasParent()) {
-		receiver = std::move(parent);
+		receiver = parent;
 		parent = parent->getParent();
 	}
 
@@ -273,7 +273,7 @@ std::shared_ptr<const Thing> Item::getTopParent() const
 	}
 
 	while (parent->hasParent()) {
-		receiver = std::move(parent);
+		receiver = parent;
 		parent = parent->getParent();
 	}
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -293,7 +293,7 @@ std::shared_ptr<Tile> Item::getTile()
 	if (const auto& parent = topParent->getParent()) {
 		topParent = parent;
 	}
-	return topParent->getTile();
+	return std::dynamic_pointer_cast<Tile>(topParent);
 }
 
 std::shared_ptr<const Tile> Item::getTile() const
@@ -306,7 +306,7 @@ std::shared_ptr<const Tile> Item::getTile() const
 	if (const auto& parent = topParent->getParent()) {
 		topParent = parent;
 	}
-	return topParent->getTile();
+	return std::dynamic_pointer_cast<const Tile>(topParent);
 }
 
 uint16_t Item::getSubType() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -23,49 +23,46 @@ extern Vocations g_vocations;
 
 Items Item::items;
 
-Item* Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/)
+std::shared_ptr<Item> Item::CreateItem(const uint16_t type, uint16_t count /*= 0*/)
 {
-	Item* newItem = nullptr;
-
 	const ItemType& it = Item::items[type];
-	if (it.group == ITEM_GROUP_DEPRECATED) {
-		return nullptr;
-	}
+	assert(it.id != 0 && it.group != ITEM_GROUP_DEPRECATED);
 
 	if (it.stackable && count == 0) {
 		count = 1;
 	}
 
-	if (it.id != 0) {
-		if (it.isDepot()) {
-			newItem = new DepotLocker(type);
-		} else if (it.isContainer()) {
-			newItem = new Container(type);
-		} else if (it.isTeleport()) {
-			newItem = new Teleport(type);
-		} else if (it.isMagicField()) {
-			newItem = new MagicField(type);
-		} else if (it.isDoor()) {
-			newItem = new Door(type);
-		} else if (it.isTrashHolder()) {
-			newItem = new TrashHolder(type);
-		} else if (it.isMailbox()) {
-			newItem = new Mailbox(type);
-		} else if (it.isBed()) {
-			newItem = new BedItem(type);
-		} else if (it.isPodium()) {
-			newItem = new Podium(type);
-		} else {
-			newItem = new Item(type, count);
-		}
-
-		newItem->incrementReferenceCounter();
+	if (it.isDepot()) {
+		return std::make_shared<DepotLocker>(type);
 	}
-
-	return newItem;
+	if (it.isContainer()) {
+		return std::make_shared<Container>(type);
+	}
+	if (it.isTeleport()) {
+		return std::make_shared<Teleport>(type);
+	}
+	if (it.isMagicField()) {
+		return std::make_shared<MagicField>(type);
+	}
+	if (it.isDoor()) {
+		return std::make_shared<Door>(type);
+	}
+	if (it.isTrashHolder()) {
+		return std::make_shared<TrashHolder>(type);
+	}
+	if (it.isMailbox()) {
+		return std::make_shared<Mailbox>(type);
+	}
+	if (it.isBed()) {
+		return std::make_shared<BedItem>(type);
+	}
+	if (it.isPodium()) {
+		return std::make_shared<Podium>(type);
+	}
+	return std::make_shared<Item>(type, count);
 }
 
-Container* Item::CreateItemAsContainer(const uint16_t type, uint16_t size)
+std::shared_ptr<Container> Item::CreateItemAsContainer(const uint16_t type, uint16_t size)
 {
 	const ItemType& it = Item::items[type];
 	if (it.id == 0 || it.group == ITEM_GROUP_DEPRECATED || it.stackable || it.useable || it.moveable || it.pickupable ||
@@ -73,12 +70,10 @@ Container* Item::CreateItemAsContainer(const uint16_t type, uint16_t size)
 		return nullptr;
 	}
 
-	Container* newItem = new Container(type, size);
-	newItem->incrementReferenceCounter();
-	return newItem;
+	return std::make_shared<Container>(type, size);
 }
 
-Item* Item::CreateItem(PropStream& propStream)
+std::shared_ptr<Item> Item::CreateItem(PropStream& propStream)
 {
 	uint16_t id;
 	if (!propStream.read<uint16_t>(id)) {
@@ -121,7 +116,7 @@ Item* Item::CreateItem(PropStream& propStream)
 	return Item::CreateItem(id, 0);
 }
 
-Item::Item(const uint16_t type, uint16_t count /*= 0*/) : id(type)
+Item::Item(const uint16_t type, uint16_t count /*= 0*/) : id{type}
 {
 	const ItemType& it = items[id];
 
@@ -144,34 +139,33 @@ Item::Item(const uint16_t type, uint16_t count /*= 0*/) : id(type)
 	setDefaultDuration();
 }
 
-Item::Item(const Item& i) : Thing(), id(i.id), count(i.count), loadedFromMap(i.loadedFromMap)
+Item::Item(const Item& i) : Thing{}, id{i.id}, count{i.count}, loadedFromMap{i.loadedFromMap}
 {
 	if (i.attributes) {
-		attributes.reset(new ItemAttributes(*i.attributes));
+		attributes = std::make_unique<ItemAttributes>(*i.attributes);
 	}
 }
 
-Item* Item::clone() const
+std::shared_ptr<Item> Item::clone() const
 {
-	Item* item = Item::CreateItem(id, count);
+	const auto item = Item::CreateItem(id, count);
 	if (attributes) {
 		item->attributes.reset(new ItemAttributes(*attributes));
 		if (item->getDuration() > 0) {
-			item->incrementReferenceCounter();
 			item->setDecaying(DECAYING_TRUE);
-			g_game.toDecayItems.push_front(item);
+			g_game.toDecayItems.push_back(item);
 		}
 	}
 	return item;
 }
 
-bool Item::equals(const Item* otherItem) const
+bool Item::operator==(const Item& otherItem) const
 {
-	if (!otherItem || id != otherItem->id) {
+	if (id != otherItem.id) {
 		return false;
 	}
 
-	const auto& otherAttributes = otherItem->attributes;
+	const auto& otherAttributes = otherItem.attributes;
 	if (!attributes) {
 		return !otherAttributes || (otherAttributes->attributeBits == 0);
 	} else if (!otherAttributes) {
@@ -225,8 +219,6 @@ void Item::setDefaultSubtype()
 
 void Item::onRemoved()
 {
-	tfs::lua::removeTempItem(this);
-
 	if (hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		g_game.removeUniqueItem(getUniqueId());
 	}
@@ -253,7 +245,7 @@ void Item::setID(uint16_t newid)
 	}
 }
 
-Thing* Item::getTopParent()
+std::shared_ptr<Thing> Item::getTopParent()
 {
 	auto parent = getParent();
 	auto receiver = getReceiver();
@@ -262,7 +254,7 @@ Thing* Item::getTopParent()
 	}
 
 	while (parent->hasParent()) {
-		receiver = parent;
+		receiver = std::move(parent);
 		parent = parent->getParent();
 	}
 
@@ -272,7 +264,7 @@ Thing* Item::getTopParent()
 	return parent;
 }
 
-const Thing* Item::getTopParent() const
+std::shared_ptr<const Thing> Item::getTopParent() const
 {
 	auto parent = getParent();
 	auto receiver = getReceiver();
@@ -281,7 +273,7 @@ const Thing* Item::getTopParent() const
 	}
 
 	while (parent->hasParent()) {
-		receiver = parent;
+		receiver = std::move(parent);
 		parent = parent->getParent();
 	}
 
@@ -291,27 +283,27 @@ const Thing* Item::getTopParent() const
 	return parent;
 }
 
-Tile* Item::getTile()
+std::shared_ptr<Tile> Item::getTile()
 {
 	auto topParent = getTopParent();
 	if (!topParent) {
 		return nullptr;
 	}
 
-	if (const auto parent = topParent->getParent()) {
+	if (const auto& parent = topParent->getParent()) {
 		topParent = parent;
 	}
 	return topParent->getTile();
 }
 
-const Tile* Item::getTile() const
+std::shared_ptr<const Tile> Item::getTile() const
 {
 	auto topParent = getTopParent();
 	if (!topParent) {
 		return nullptr;
 	}
 
-	if (const auto parent = topParent->getParent()) {
+	if (const auto& parent = topParent->getParent()) {
 		topParent = parent;
 	}
 	return topParent->getTile();
@@ -330,14 +322,14 @@ uint16_t Item::getSubType() const
 	return count;
 }
 
-const Player* Item::getHoldingPlayer() const
+std::shared_ptr<const Player> Item::getHoldingPlayer() const
 {
-	const auto topParent = getTopParent();
+	const auto& topParent = getTopParent();
 	if (!topParent) {
 		return nullptr;
 	}
 
-	if (const auto creature = topParent->getCreature()) {
+	if (const auto& creature = topParent->getCreature()) {
 		return creature->getPlayer();
 	}
 	return nullptr;
@@ -970,8 +962,8 @@ uint32_t Item::getWeight() const
 	return weight;
 }
 
-std::string Item::getNameDescription(const ItemType& it, const Item* item /*= nullptr*/, int32_t subType /*= -1*/,
-                                     bool addArticle /*= true*/)
+std::string Item::getNameDescription(const ItemType& it, const std::shared_ptr<const Item>& item /*= nullptr*/,
+                                     int32_t subType /*= -1*/, bool addArticle /*= true*/)
 {
 	if (item) {
 		subType = item->getSubType();
@@ -1009,7 +1001,7 @@ std::string Item::getNameDescription(const ItemType& it, const Item* item /*= nu
 std::string Item::getNameDescription() const
 {
 	const ItemType& it = items[id];
-	return getNameDescription(it, this);
+	return getNameDescription(it, getItem());
 }
 
 std::string Item::getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count /*= 1*/)
@@ -1056,7 +1048,7 @@ void Item::setUniqueId(uint16_t n)
 		return;
 	}
 
-	if (g_game.addUniqueItem(n, this)) {
+	if (g_game.addUniqueItem(n, getItem())) {
 		getAttributes()->setUniqueId(n);
 	}
 }
@@ -1241,7 +1233,7 @@ ItemAttributes::Attribute& ItemAttributes::getAttr(itemAttrTypes type)
 	return attributes.back();
 }
 
-void Item::startDecaying() { g_game.startDecay(this); }
+void Item::startDecaying() { g_game.startDecay(getItem()); }
 
 bool Item::hasMarketAttributes() const
 {

--- a/src/item.h
+++ b/src/item.h
@@ -466,45 +466,48 @@ public:
 	friend class Item;
 };
 
-class Item : virtual public Thing
+class Item : public Thing
 {
 public:
 	// Factory member to create item of right type based on type
-	static Item* CreateItem(const uint16_t type, uint16_t count = 0);
-	static Container* CreateItemAsContainer(const uint16_t type, uint16_t size);
-	static Item* CreateItem(PropStream& propStream);
+	static std::shared_ptr<Item> CreateItem(const uint16_t type, uint16_t count = 0);
+	static std::shared_ptr<Container> CreateItemAsContainer(const uint16_t type, uint16_t size);
+	static std::shared_ptr<Item> CreateItem(PropStream& propStream);
 	static Items items;
 
 	// Constructor for items
 	Item(const uint16_t type, uint16_t count = 0);
 	Item(const Item& i);
-	virtual Item* clone() const;
+	virtual std::shared_ptr<Item> clone() const;
 
 	virtual ~Item() = default;
 
 	// non-assignable
 	Item& operator=(const Item&) = delete;
+	bool operator==(const Item& otherItem) const;
 
-	bool equals(const Item* otherItem) const;
+	std::shared_ptr<Item> getItem() override final { return std::static_pointer_cast<Item>(shared_from_this()); }
+	std::shared_ptr<const Item> getItem() const override final
+	{
+		return std::static_pointer_cast<const Item>(shared_from_this());
+	}
 
-	Item* getItem() override final { return this; }
-	const Item* getItem() const override final { return this; }
-	virtual Container* getContainer() { return nullptr; }
-	virtual const Container* getContainer() const { return nullptr; }
-	virtual Teleport* getTeleport() { return nullptr; }
-	virtual const Teleport* getTeleport() const { return nullptr; }
-	virtual TrashHolder* getTrashHolder() { return nullptr; }
-	virtual const TrashHolder* getTrashHolder() const { return nullptr; }
-	virtual Mailbox* getMailbox() { return nullptr; }
-	virtual const Mailbox* getMailbox() const { return nullptr; }
-	virtual Door* getDoor() { return nullptr; }
-	virtual const Door* getDoor() const { return nullptr; }
-	virtual MagicField* getMagicField() { return nullptr; }
-	virtual const MagicField* getMagicField() const { return nullptr; }
-	virtual BedItem* getBed() { return nullptr; }
-	virtual const BedItem* getBed() const { return nullptr; }
-	virtual Podium* getPodium() { return nullptr; }
-	virtual const Podium* getPodium() const { return nullptr; }
+	virtual std::shared_ptr<Container> getContainer() { return nullptr; }
+	virtual std::shared_ptr<const Container> getContainer() const { return nullptr; }
+	virtual std::shared_ptr<Teleport> getTeleport() { return nullptr; }
+	virtual std::shared_ptr<const Teleport> getTeleport() const { return nullptr; }
+	virtual std::shared_ptr<TrashHolder> getTrashHolder() { return nullptr; }
+	virtual std::shared_ptr<const TrashHolder> getTrashHolder() const { return nullptr; }
+	virtual std::shared_ptr<Mailbox> getMailbox() { return nullptr; }
+	virtual std::shared_ptr<const Mailbox> getMailbox() const { return nullptr; }
+	virtual std::shared_ptr<Door> getDoor() { return nullptr; }
+	virtual std::shared_ptr<const Door> getDoor() const { return nullptr; }
+	virtual std::shared_ptr<MagicField> getMagicField() { return nullptr; }
+	virtual std::shared_ptr<const MagicField> getMagicField() const { return nullptr; }
+	virtual std::shared_ptr<BedItem> getBed() { return nullptr; }
+	virtual std::shared_ptr<const BedItem> getBed() const { return nullptr; }
+	virtual std::shared_ptr<Podium> getPodium() { return nullptr; }
+	virtual std::shared_ptr<const Podium> getPodium() const { return nullptr; }
 
 	const std::string& getStrAttr(itemAttrTypes type) const
 	{
@@ -700,8 +703,8 @@ public:
 		return items[id].decayTo;
 	}
 
-	static std::string getNameDescription(const ItemType& it, const Item* item = nullptr, int32_t subType = -1,
-	                                      bool addArticle = true);
+	static std::string getNameDescription(const ItemType& it, const std::shared_ptr<const Item>& item = nullptr,
+	                                      int32_t subType = -1, bool addArticle = true);
 	static std::string getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count = 1);
 
 	std::string getNameDescription() const;
@@ -722,7 +725,7 @@ public:
 	void setID(uint16_t newid);
 
 	// Returns the player that is holding this item in his inventory
-	const Player* getHoldingPlayer() const;
+	std::shared_ptr<const Player> getHoldingPlayer() const;
 
 	WeaponType_t getWeaponType() const { return items[id].weaponType; }
 	Ammo_t getAmmoType() const { return items[id].ammoType; }
@@ -848,7 +851,7 @@ public:
 	uint16_t getItemCount() const { return count; }
 	void setItemCount(uint8_t n) { count = n; }
 
-	static uint32_t countByType(const Item* i, int32_t subType)
+	static uint32_t countByType(const std::shared_ptr<const Item>& i, int32_t subType)
 	{
 		if (subType == -1 || subType == i->getSubType()) {
 			return i->getItemCount();
@@ -871,7 +874,7 @@ public:
 	virtual bool canRemove() const { return true; }
 	virtual bool canTransform() const { return true; }
 	virtual void onRemoved();
-	virtual void onTradeEvent(TradeEvents_t, Player*) {}
+	virtual void onTradeEvent(TradeEvents_t, const std::shared_ptr<Player>&) {}
 
 	virtual void startDecaying();
 
@@ -888,23 +891,15 @@ public:
 	std::unique_ptr<ItemAttributes>& getAttributes()
 	{
 		if (!attributes) {
-			attributes.reset(new ItemAttributes());
+			attributes = std::make_unique<ItemAttributes>();
 		}
 		return attributes;
 	}
 
-	void incrementReferenceCounter() { ++referenceCounter; }
-	void decrementReferenceCounter()
-	{
-		if (--referenceCounter == 0) {
-			delete this;
-		}
-	}
-
-	Thing* getTopParent();
-	const Thing* getTopParent() const;
-	Tile* getTile() override;
-	const Tile* getTile() const override;
+	std::shared_ptr<Thing> getTopParent();
+	std::shared_ptr<const Thing> getTopParent() const;
+	std::shared_ptr<Tile> getTile() override final;
+	std::shared_ptr<const Tile> getTile() const override final;
 	bool isRemoved() const override { return !getParent() || getParent()->isRemoved(); }
 
 protected:
@@ -915,8 +910,6 @@ private:
 
 	std::unique_ptr<ItemAttributes> attributes;
 
-	uint32_t referenceCounter = 0;
-
 	uint8_t count = 1; // number of stacked items
 
 	bool loadedFromMap = false;
@@ -924,7 +917,7 @@ private:
 	// Don't add variables here, use the ItemAttribute class.
 };
 
-using ItemList = std::list<Item*>;
-using ItemDeque = std::deque<Item*>;
+using ItemList = std::list<std::shared_ptr<Item>>;
+using ItemDeque = std::deque<std::shared_ptr<Item>>;
 
 #endif // FS_ITEM_H

--- a/src/luavariant.h
+++ b/src/luavariant.h
@@ -1,6 +1,8 @@
 #ifndef FS_LUAVARIANT_H
 #define FS_LUAVARIANT_H
 
+#include "position.h"
+
 enum LuaVariantType_t
 {
 	VARIANT_NUMBER = 0,

--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -6,100 +6,109 @@
 #include "mailbox.h"
 
 #include "game.h"
-#include "inbox.h"
 #include "iologindata.h"
 
 extern Game g_game;
 
-ReturnValue Mailbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t, Creature*) const
+namespace {
+
+bool canSend(const std::shared_ptr<const Item>& item)
 {
-	const Item* item = thing.getItem();
-	if (item && Mailbox::canSend(item)) {
-		return RETURNVALUE_NOERROR;
-	}
-	return RETURNVALUE_NOTPOSSIBLE;
+	return item->getID() == ITEM_PARCEL || item->getID() == ITEM_LETTER;
 }
 
-ReturnValue Mailbox::queryMaxCount(int32_t, const Thing&, uint32_t count, uint32_t& maxQueryCount, uint32_t) const
+std::string getReceiverName(const std::shared_ptr<Item>& item)
 {
-	maxQueryCount = std::max<uint32_t>(1, count);
-	return RETURNVALUE_NOERROR;
-}
-
-void Mailbox::addThing(int32_t, Thing* thing)
-{
-	Item* item = thing->getItem();
-	if (item && Mailbox::canSend(item)) {
-		sendItem(item);
-	}
-}
-
-void Mailbox::postAddNotification(Thing* thing, const Thing* oldParent, int32_t index, ReceiverLink_t)
-{
-	getParent()->postAddNotification(thing, oldParent, index, LINK_PARENT);
-}
-
-void Mailbox::postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index, ReceiverLink_t)
-{
-	getParent()->postRemoveNotification(thing, newParent, index, LINK_PARENT);
-}
-
-bool Mailbox::sendItem(Item* item) const
-{
-	std::string receiver;
-	if (!getReceiver(item, receiver)) {
-		return false;
+	if (const auto& container = item->getContainer()) {
+		for (const auto& containerItem : container->getItemList()) {
+			if (containerItem->getID() == ITEM_LABEL) {
+				return getReceiverName(containerItem);
+			}
+		}
+		return "";
 	}
 
+	const std::string& text = item->getText();
+	if (text.empty()) {
+		return "";
+	}
+
+	std::string name;
+	std::getline(std::istringstream{text}, name);
+	boost::algorithm::trim(name);
+	return name;
+}
+
+bool sendItem(const std::shared_ptr<Item>& item)
+{
+	const auto& receiver = getReceiverName(item);
 	/**No need to continue if its still empty**/
 	if (receiver.empty()) {
 		return false;
 	}
 
-	Player* player = g_game.getPlayerByName(receiver);
-	if (player) {
-		if (g_game.internalMoveItem(item->getParent(), player->getInbox().get(), INDEX_WHEREEVER, item,
-		                            item->getItemCount(), nullptr, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
+	if (const auto& player = g_game.getPlayerByName(receiver)) {
+		std::shared_ptr<Item> moveItem = nullptr;
+		if (g_game.internalMoveItem(item->getParent(), player->getInbox(), INDEX_WHEREEVER, item, item->getItemCount(),
+		                            moveItem, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
 			g_game.transformItem(item, item->getID() + 1);
 			player->onReceiveMail();
 			return true;
 		}
 	} else {
-		Player tmpPlayer(nullptr);
-		if (!IOLoginData::loadPlayerByName(&tmpPlayer, receiver)) {
+		auto tmpPlayer = std::make_shared<Player>(nullptr);
+		if (!IOLoginData::loadPlayerByName(tmpPlayer, receiver)) {
 			return false;
 		}
 
-		if (g_game.internalMoveItem(item->getParent(), tmpPlayer.getInbox().get(), INDEX_WHEREEVER, item,
-		                            item->getItemCount(), nullptr, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
+		std::shared_ptr<Item> moveItem = nullptr;
+		if (g_game.internalMoveItem(item->getParent(), tmpPlayer->getInbox(), INDEX_WHEREEVER, item,
+		                            item->getItemCount(), moveItem, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
 			g_game.transformItem(item, item->getID() + 1);
-			IOLoginData::savePlayer(&tmpPlayer);
+			IOLoginData::savePlayer(tmpPlayer);
 			return true;
 		}
 	}
 	return false;
 }
 
-bool Mailbox::getReceiver(Item* item, std::string& name) const
+} // namespace
+
+ReturnValue Mailbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, uint32_t, uint32_t,
+                              const std::shared_ptr<Creature>&) const
 {
-	const Container* container = item->getContainer();
-	if (container) {
-		for (Item* containerItem : container->getItemList()) {
-			if (containerItem->getID() == ITEM_LABEL && getReceiver(containerItem, name)) {
-				return true;
-			}
-		}
-		return false;
+	if (const auto& item = thing->getItem(); item && canSend(item)) {
+		return RETURNVALUE_NOERROR;
 	}
-
-	const std::string& text = item->getText();
-	if (text.empty()) {
-		return false;
-	}
-
-	name = getFirstLine(text);
-	boost::algorithm::trim(name);
-	return true;
+	return RETURNVALUE_NOTPOSSIBLE;
 }
 
-bool Mailbox::canSend(const Item* item) { return item->getID() == ITEM_PARCEL || item->getID() == ITEM_LETTER; }
+ReturnValue Mailbox::queryMaxCount(int32_t, const std::shared_ptr<const Thing>&, uint32_t count,
+                                   uint32_t& maxQueryCount, uint32_t) const
+{
+	maxQueryCount = std::max<uint32_t>(1, count);
+	return RETURNVALUE_NOERROR;
+}
+
+void Mailbox::addThing(int32_t, const std::shared_ptr<Thing>& thing)
+{
+	if (const auto& item = thing->getItem(); item && canSend(item)) {
+		sendItem(item);
+	}
+}
+
+void Mailbox::postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+                                  int32_t index, ReceiverLink_t)
+{
+	if (const auto& parent = getParent()) {
+		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
+	}
+}
+
+void Mailbox::postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+                                     int32_t index, ReceiverLink_t)
+{
+	if (const auto& parent = getParent()) {
+		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
+	}
+}

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -9,33 +9,35 @@
 class Mailbox final : public Item
 {
 public:
-	explicit Mailbox(uint16_t itemId) : Item(itemId) {}
+	explicit Mailbox(uint16_t itemId) : Item{itemId} {}
 
-	Thing* getReceiver() override final { return this; }
-	const Thing* getReceiver() const override final { return this; }
+	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	Mailbox* getMailbox() override { return this; }
-	const Mailbox* getMailbox() const override { return this; }
+	std::shared_ptr<Mailbox> getMailbox() override { return std::static_pointer_cast<Mailbox>(shared_from_this()); }
+	std::shared_ptr<const Mailbox> getMailbox() const override
+	{
+		return std::static_pointer_cast<const Mailbox>(shared_from_this());
+	}
 
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                     Creature* actor = nullptr) const override;
-	ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-	                          uint32_t flags) const override;
-	Thing* queryDestination(int32_t&, const Thing&, Item**, uint32_t&) override { return this; }
+	ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                     const std::shared_ptr<Creature>& actor = nullptr) const override;
+	ReturnValue queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+	                          uint32_t& maxQueryCount, uint32_t flags) const override;
 
-	void addThing(Thing* thing) override { return addThing(0, thing); }
-	void addThing(int32_t index, Thing* thing) override;
+	std::shared_ptr<Thing> queryDestination(int32_t&, const std::shared_ptr<const Thing>&, std::shared_ptr<Item>&,
+	                                        uint32_t&) override
+	{
+		return shared_from_this();
+	}
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void addThing(const std::shared_ptr<Thing>& thing) override { return addThing(0, thing); }
+	void addThing(int32_t index, const std::shared_ptr<Thing>& thing) override;
 
-private:
-	bool getReceiver(Item* item, std::string& name) const;
-	bool sendItem(Item* item) const;
-
-	static bool canSend(const Item* item);
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 };
 
 #endif // FS_MAILBOX_H

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10,7 +10,6 @@
 #include "game.h"
 #include "iomap.h"
 #include "iomapserialize.h"
-#include "monster.h"
 
 extern Game g_game;
 
@@ -61,7 +60,7 @@ bool Map::save()
 	return saved;
 }
 
-Tile* Map::getTile(uint16_t x, uint16_t y, uint8_t z) const
+std::shared_ptr<Tile> Map::getTile(uint16_t x, uint16_t y, uint8_t z) const
 {
 	if (z >= MAP_MAX_LAYERS) {
 		return nullptr;
@@ -79,7 +78,7 @@ Tile* Map::getTile(uint16_t x, uint16_t y, uint8_t z) const
 	return floor->tiles[x & FLOOR_MASK][y & FLOOR_MASK];
 }
 
-void Map::setTile(uint16_t x, uint16_t y, uint8_t z, Tile* newTile)
+void Map::setTile(uint16_t x, uint16_t y, uint8_t z, const std::shared_ptr<Tile>& newTile)
 {
 	if (z >= MAP_MAX_LAYERS) {
 		std::cout << "ERROR: Attempt to set tile on invalid coordinate " << Position(x, y, z) << "!" << std::endl;
@@ -119,7 +118,7 @@ void Map::setTile(uint16_t x, uint16_t y, uint8_t z, Tile* newTile)
 	uint32_t offsetX = x & FLOOR_MASK;
 	uint32_t offsetY = y & FLOOR_MASK;
 
-	Tile*& tile = floor->tiles[offsetX][offsetY];
+	auto& tile = floor->tiles[offsetX][offsetY];
 	if (tile) {
 		TileItemVector* items = newTile->getItemList();
 		if (items) {
@@ -129,12 +128,10 @@ void Map::setTile(uint16_t x, uint16_t y, uint8_t z, Tile* newTile)
 			items->clear();
 		}
 
-		Item* ground = newTile->getGround();
-		if (ground) {
+		if (const auto& ground = newTile->getGround()) {
 			tile->addThing(ground);
 			newTile->setGround(nullptr);
 		}
-		delete newTile;
 	} else {
 		tile = newTile;
 	}
@@ -156,11 +153,10 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 		return;
 	}
 
-	Tile* tile = floor->tiles[x & FLOOR_MASK][y & FLOOR_MASK];
-	if (tile) {
+	if (const auto& tile = floor->tiles[x & FLOOR_MASK][y & FLOOR_MASK]) {
 		if (const CreatureVector* creatures = tile->getCreatures()) {
 			for (int32_t i = creatures->size(); --i >= 0;) {
-				if (Player* player = (*creatures)[i]->getPlayer()) {
+				if (const auto& player = (*creatures)[i]->getPlayer()) {
 					g_game.internalTeleport(player, player->getTown()->templePosition, false, FLAG_NOLIMIT);
 				} else {
 					g_game.removeCreature((*creatures)[i]);
@@ -174,38 +170,34 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 			}
 		}
 
-		Item* ground = tile->getGround();
-		if (ground) {
+		if (const auto& ground = tile->getGround()) {
 			g_game.internalRemoveItem(ground);
 			tile->setGround(nullptr);
 		}
 	}
 }
 
-bool Map::placeCreature(const Position& centerPos, Creature* creature, bool extendedPos /* = false*/,
-                        bool forceLogin /* = false*/)
+bool Map::placeCreature(const Position& centerPos, const std::shared_ptr<Creature>& creature,
+                        bool extendedPos /* = false*/, bool forceLogin /* = false*/)
 {
-	bool foundTile;
-	bool placeInPZ;
+	bool foundTile = false;
+	bool placeInPZ = false;
 
-	Tile* tile = getTile(centerPos.x, centerPos.y, centerPos.z);
+	auto tile = getTile(centerPos.x, centerPos.y, centerPos.z);
 	if (tile) {
 		placeInPZ = tile->hasFlag(TILESTATE_PROTECTIONZONE);
-		ReturnValue ret = tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM);
+		ReturnValue ret = tile->queryAdd(0, creature, 1, FLAG_IGNOREBLOCKITEM);
 		foundTile = forceLogin || ret == RETURNVALUE_NOERROR || ret == RETURNVALUE_PLAYERISNOTINVITED;
-	} else {
-		placeInPZ = false;
-		foundTile = false;
 	}
 
 	if (!foundTile) {
-		static std::vector<std::pair<int32_t, int32_t>> extendedRelList{
-		    {0, -2}, {2, 0}, {0, 2}, {-2, 0}, {-1, -1}, {0, -1}, {1, -1}, {-1, 0}, {1, 0}, {-1, 1}, {0, 1}, {1, 1}};
+		static auto extendedRelList = std::vector{std::pair{0, -2}, {2, 0},  {0, 2}, {-2, 0}, {-1, -1}, {0, -1},
+		                                          {1, -1},          {-1, 0}, {1, 0}, {-1, 1}, {0, 1},   {1, 1}};
 
-		static std::vector<std::pair<int32_t, int32_t>> normalRelList{{-1, -1}, {0, -1}, {1, -1}, {-1, 0},
-		                                                              {1, 0},   {-1, 1}, {0, 1},  {1, 1}};
+		static auto normalRelList =
+		    std::vector{std::pair{-1, -1}, {0, -1}, {1, -1}, {-1, 0}, {1, 0}, {-1, 1}, {0, 1}, {1, 1}};
 
-		std::vector<std::pair<int32_t, int32_t>>& relList = (extendedPos ? extendedRelList : normalRelList);
+		auto& relList = extendedPos ? extendedRelList : normalRelList;
 
 		if (extendedPos) {
 			std::shuffle(relList.begin(), relList.begin() + 4, getRandomGenerator());
@@ -222,7 +214,7 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 				continue;
 			}
 
-			if (tile->queryAdd(0, *creature, 1, 0) == RETURNVALUE_NOERROR) {
+			if (tile->queryAdd(0, creature, 1, 0) == RETURNVALUE_NOERROR) {
 				if (!extendedPos || isSightClear(centerPos, tryPos, false)) {
 					foundTile = true;
 					break;
@@ -237,9 +229,9 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 
 	int32_t index = 0;
 	uint32_t flags = 0;
-	Item* toItem = nullptr;
+	std::shared_ptr<Item> toItem = nullptr;
 
-	const auto toThing = tile->queryDestination(index, *creature, &toItem, flags);
+	const auto& toThing = tile->queryDestination(index, creature, toItem, flags);
 	toThing->internalAddThing(creature);
 
 	const Position& dest = toThing->getPosition();
@@ -247,19 +239,20 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 	return true;
 }
 
-void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport /* = false*/)
+void Map::moveCreature(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Tile>& newTile,
+                       bool forceTeleport /* = false*/)
 {
-	Tile& oldTile = *creature.getTile();
+	const auto& oldTile = creature->getTile();
 
 	// If the tile does not have the creature it means that the creature is ready for elimination, we skip the move.
-	if (!oldTile.hasCreature(&creature)) {
+	if (!oldTile->hasCreature(creature)) {
 		return;
 	}
 
-	Position oldPos = oldTile.getPosition();
-	Position newPos = newTile.getPosition();
+	Position oldPos = oldTile->getPosition();
+	Position newPos = newTile->getPosition();
 
-	bool teleport = forceTeleport || !newTile.getGround() || !oldPos.isInRange(newPos, 1, 1, 0);
+	bool teleport = forceTeleport || !newTile->getGround() || !oldPos.isInRange(newPos, 1, 1, 0);
 
 	SpectatorVec spectators, newPosSpectators;
 	getSpectators(spectators, oldPos, true);
@@ -267,10 +260,10 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport /* 
 	spectators.insert(newPosSpectators.begin(), newPosSpectators.end());
 
 	std::vector<int32_t> oldStackPosVector;
-	for (Creature* spectator : spectators) {
-		if (Player* tmpPlayer = spectator->getPlayer()) {
-			if (tmpPlayer->canSeeCreature(&creature)) {
-				oldStackPosVector.push_back(oldTile.getClientIndexOfCreature(tmpPlayer, &creature));
+	for (const auto& spectator : spectators) {
+		if (const auto& tmpPlayer = spectator->getPlayer()) {
+			if (tmpPlayer->canSeeCreature(creature)) {
+				oldStackPosVector.push_back(oldTile->getClientIndexOfCreature(tmpPlayer, creature));
 			} else {
 				oldStackPosVector.push_back(-1);
 			}
@@ -278,54 +271,54 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport /* 
 	}
 
 	// remove the creature
-	oldTile.removeThing(&creature, 0);
+	oldTile->removeThing(creature, 0);
 
 	QTreeLeafNode* leaf = getQTNode(oldPos.x, oldPos.y);
 	QTreeLeafNode* new_leaf = getQTNode(newPos.x, newPos.y);
 
 	// Switch the node ownership
 	if (leaf != new_leaf) {
-		leaf->removeCreature(&creature);
-		new_leaf->addCreature(&creature);
+		leaf->removeCreature(creature);
+		new_leaf->addCreature(creature);
 	}
 
 	// add the creature
-	newTile.addThing(&creature);
+	newTile->addThing(creature);
 
 	if (!teleport) {
 		if (oldPos.y > newPos.y) {
-			creature.setDirection(DIRECTION_NORTH);
+			creature->setDirection(DIRECTION_NORTH);
 		} else if (oldPos.y < newPos.y) {
-			creature.setDirection(DIRECTION_SOUTH);
+			creature->setDirection(DIRECTION_SOUTH);
 		}
 
 		if (oldPos.x < newPos.x) {
-			creature.setDirection(DIRECTION_EAST);
+			creature->setDirection(DIRECTION_EAST);
 		} else if (oldPos.x > newPos.x) {
-			creature.setDirection(DIRECTION_WEST);
+			creature->setDirection(DIRECTION_WEST);
 		}
 	}
 
 	// send to client
 	size_t i = 0;
-	for (Creature* spectator : spectators) {
-		if (Player* tmpPlayer = spectator->getPlayer()) {
+	for (const auto& spectator : spectators) {
+		if (const auto& tmpPlayer = spectator->getPlayer()) {
 			// Use the correct stackpos
 			int32_t stackpos = oldStackPosVector[i++];
 			if (stackpos != -1) {
-				tmpPlayer->sendCreatureMove(&creature, newPos, newTile.getClientIndexOfCreature(tmpPlayer, &creature),
+				tmpPlayer->sendCreatureMove(creature, newPos, newTile->getClientIndexOfCreature(tmpPlayer, creature),
 				                            oldPos, stackpos, teleport);
 			}
 		}
 	}
 
 	// event method
-	for (Creature* spectator : spectators) {
-		spectator->onCreatureMove(&creature, &newTile, newPos, &oldTile, oldPos, teleport);
+	for (const auto& spectator : spectators) {
+		spectator->onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 	}
 
-	oldTile.postRemoveNotification(&creature, &newTile, 0);
-	newTile.postAddNotification(&creature, &oldTile, 0);
+	oldTile->postRemoveNotification(creature, newTile, 0);
+	newTile->postAddNotification(creature, oldTile, 0);
 }
 
 void Map::getSpectatorsInternal(SpectatorVec& spectators, const Position& centerPos, int32_t minRangeX,
@@ -359,8 +352,9 @@ void Map::getSpectatorsInternal(SpectatorVec& spectators, const Position& center
 		leafE = leafS;
 		for (int_fast32_t nx = startx1; nx <= endx2; nx += FLOOR_SIZE) {
 			if (leafE) {
-				const CreatureVector& node_list = (onlyPlayers ? leafE->player_list : leafE->creature_list);
-				for (Creature* creature : node_list) {
+				for (auto&& creature : leafE->creatures | std::views::filter([onlyPlayers](const auto& creature) {
+					                       return !onlyPlayers || creature->getPlayer() != nullptr;
+				                       })) {
 					const Position& cpos = creature->getPosition();
 					if (minRangeZ > cpos.z || maxRangeZ < cpos.z) {
 						continue;
@@ -372,7 +366,7 @@ void Map::getSpectatorsInternal(SpectatorVec& spectators, const Position& center
 						continue;
 					}
 
-					spectators.insert(creature);
+					spectators.emplace(creature);
 				}
 				leafE = leafE->leafE;
 			} else {
@@ -431,9 +425,9 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 					}
 				} else {
 					const SpectatorVec& cachedSpectators = it->second;
-					for (Creature* spectator : cachedSpectators) {
+					for (const auto& spectator : cachedSpectators) {
 						if (spectator->getPlayer()) {
-							spectators.insert(spectator);
+							spectators.emplace(spectator);
 						}
 					}
 				}
@@ -500,7 +494,7 @@ bool Map::canThrowObjectTo(const Position& fromPos, const Position& toPos, bool 
 bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= false*/,
                       bool pathfinding /*= false*/) const
 {
-	const Tile* tile = getTile(x, y, z);
+	const auto& tile = getTile(x, y, z);
 	if (!tile) {
 		return true;
 	}
@@ -642,16 +636,16 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 	return checkSightLine(fromPos.x, fromPos.y, toPos.x, toPos.y, fromPos.z);
 }
 
-const Tile* Map::canWalkTo(const Creature& creature, const Position& pos) const
+const std::shared_ptr<Tile> Map::canWalkTo(const std::shared_ptr<const Creature>& creature, const Position& pos) const
 {
-	Tile* tile = getTile(pos.x, pos.y, pos.z);
-	if (creature.getTile() != tile) {
+	const auto& tile = getTile(pos.x, pos.y, pos.z);
+	if (creature->getTile() != tile) {
 		if (!tile) {
 			return nullptr;
 		}
 
 		uint32_t flags = FLAG_PATHFINDING;
-		if (!creature.getPlayer()) {
+		if (!creature->getPlayer()) {
 			flags |= FLAG_IGNOREFIELDDAMAGE;
 		}
 
@@ -669,14 +663,15 @@ static uint16_t calculateHeuristic(const Position& p1, const Position& p2)
 	return dx * dx + dy * dy;
 }
 
-bool Map::getPathMatching(const Creature& creature, const Position& targetPos, std::vector<Direction>& dirList,
-                          const FrozenPathingConditionCall& pathCondition, const FindPathParams& fpp) const
+bool Map::getPathMatching(const std::shared_ptr<const Creature>& creature, const Position& targetPos,
+                          std::vector<Direction>& dirList, const FrozenPathingConditionCall& pathCondition,
+                          const FindPathParams& fpp) const
 {
-	Position pos = creature.getPosition();
+	Position pos = creature->getPosition();
 	const Position startPos = pos;
 
 	// We can't walk, no need to create path.
-	if (creature.getSpeed() <= 0) {
+	if (creature->getSpeed() <= 0) {
 		return false;
 	}
 
@@ -782,7 +777,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 				}
 			}
 
-			const Tile* tile;
+			std::shared_ptr<const Tile> tile;
 			AStarNode* neighborNode = nodes.getNodeByPosition(pos.x, pos.y);
 			if (neighborNode) {
 				tile = getTile(pos.x, pos.y, pos.z);
@@ -862,7 +857,7 @@ bool Map::getPathMatching(const Creature& creature, const Position& targetPos, s
 }
 
 // AStarNodes
-AStarNodes::AStarNodes(uint16_t x, uint16_t y) : nodes(), nodeMap()
+AStarNodes::AStarNodes(uint16_t x, uint16_t y)
 {
 	nodes.reserve(Map::nodeReserveSize);
 	nodeMap.reserve(Map::nodeReserveSize);
@@ -945,33 +940,23 @@ constexpr ConditionType_t DamageToConditionType(CombatType_t type)
 	}
 }
 
-uint16_t AStarNodes::getTileWalkCost(const Creature& creature, const Tile* tile)
+uint16_t AStarNodes::getTileWalkCost(const std::shared_ptr<const Creature>& creature,
+                                     const std::shared_ptr<const Tile>& tile)
 {
 	uint16_t cost = 0;
-	if (tile->getTopVisibleCreature(&creature)) {
-		// destroy creature cost
+	if (tile->getTopVisibleCreature(creature)) {
 		cost += MAP_NORMALWALKCOST * 3;
 	}
 
-	if (const MagicField* field = tile->getFieldItem()) {
+	if (const auto& field = tile->getFieldItem()) {
 		CombatType_t combatType = field->getCombatType();
-		const Monster* monster = creature.getMonster();
-		if (!creature.isImmune(combatType) && !creature.hasCondition(DamageToConditionType(combatType)) &&
+		const auto& monster = creature->getMonster();
+		if (!creature->isImmune(combatType) && !creature->hasCondition(DamageToConditionType(combatType)) &&
 		    (monster && !monster->canWalkOnFieldType(combatType))) {
 			cost += MAP_NORMALWALKCOST * 18;
 		}
 	}
 	return cost;
-}
-
-// Floor
-Floor::~Floor()
-{
-	for (auto& row : tiles) {
-		for (auto tile : row) {
-			delete tile;
-		}
-	}
 }
 
 // QTreeNode
@@ -988,7 +973,7 @@ QTreeLeafNode* QTreeNode::getLeaf(uint32_t x, uint32_t y)
 		return static_cast<QTreeLeafNode*>(this);
 	}
 
-	QTreeNode* node = child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
+	auto node = child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
 	if (!node) {
 		return nullptr;
 	}
@@ -1030,30 +1015,6 @@ Floor* QTreeLeafNode::createFloor(uint32_t z)
 	return array[z];
 }
 
-void QTreeLeafNode::addCreature(Creature* c)
-{
-	creature_list.push_back(c);
-
-	if (c->getPlayer()) {
-		player_list.push_back(c);
-	}
-}
-
-void QTreeLeafNode::removeCreature(Creature* c)
-{
-	auto iter = std::find(creature_list.begin(), creature_list.end(), c);
-	assert(iter != creature_list.end());
-	*iter = creature_list.back();
-	creature_list.pop_back();
-
-	if (c->getPlayer()) {
-		iter = std::find(player_list.begin(), player_list.end(), c);
-		assert(iter != player_list.end());
-		*iter = player_list.back();
-		player_list.pop_back();
-	}
-}
-
 uint32_t Map::clean() const
 {
 	uint64_t start = OTSYS_TIME();
@@ -1063,24 +1024,21 @@ uint32_t Map::clean() const
 		g_game.setGameState(GAME_STATE_MAINTAIN);
 	}
 
-	std::vector<Item*> toRemove;
+	std::vector<std::shared_ptr<Item>> toRemove;
 
-	for (auto tile : g_game.getTilesToClean()) {
-		if (!tile) {
-			continue;
-		}
-
-		if (auto items = tile->getItemList()) {
+	for (const auto& tile :
+	     g_game.getTilesToClean() | std::views::filter([](const auto& tile) { return tile != nullptr; })) {
+		if (const auto& items = tile->getItemList()) {
 			++tiles;
-			for (auto item : *items) {
-				if (item->isCleanable()) {
+			for (const auto& item : *items) {
+				if (item && item->isCleanable()) {
 					toRemove.emplace_back(item);
 				}
 			}
 		}
 	}
 
-	for (auto item : toRemove) {
+	for (const auto& item : toRemove) {
 		g_game.internalRemoveItem(item, -1);
 	}
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -20,13 +20,13 @@ int32_t Monster::despawnRadius;
 
 uint32_t Monster::monsterAutoID = 0x21000000;
 
-Monster* Monster::createMonster(const std::string& name)
+std::shared_ptr<Monster> Monster::createMonster(const std::string& name)
 {
 	MonsterType* mType = g_monsters.getMonsterType(name);
 	if (!mType) {
 		return nullptr;
 	}
-	return new Monster(mType);
+	return std::make_shared<Monster>(mType);
 }
 
 Monster::Monster(MonsterType* mType) : Creature(), nameDescription(mType->nameDescription), mType(mType)
@@ -48,15 +48,9 @@ Monster::Monster(MonsterType* mType) : Creature(), nameDescription(mType->nameDe
 	}
 }
 
-Monster::~Monster()
-{
-	clearTargetList();
-	clearFriendList();
-}
+void Monster::addList() { g_game.addMonster(getMonster()); }
 
-void Monster::addList() { g_game.addMonster(this); }
-
-void Monster::removeList() { g_game.removeMonster(this); }
+void Monster::removeList() { g_game.removeMonster(getMonster()); }
 
 const std::string& Monster::getName() const
 {
@@ -76,7 +70,7 @@ void Monster::setName(const std::string& name)
 
 	// NOTE: Due to how client caches known creatures, it is not feasible to send creature update to everyone that has
 	// ever met it
-	g_game.updateKnownCreature(this);
+	g_game.updateKnownCreature(getMonster());
 }
 
 const std::string& Monster::getNameDescription() const
@@ -108,9 +102,9 @@ bool Monster::canWalkOnFieldType(CombatType_t combatType) const
 
 void Monster::onAttackedCreatureDisappear(bool) { attackTicks = 0; }
 
-void Monster::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
+void Monster::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, MagicEffectClasses)
 {
-	if (creature == this) {
+	if (creature.get() == this) {
 		setLastPosition(getPosition());
 
 		// We just spawned lets look around to see who is there.
@@ -138,10 +132,10 @@ void Monster::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
 		lua_State* L = scriptInterface->getLuaState();
 		scriptInterface->pushFunction(mType->info.creatureAppearEvent);
 
-		tfs::lua::pushUserdata(L, this);
+		tfs::lua::pushSharedPtr(L, getMonster());
 		tfs::lua::setMetatable(L, -1, "Monster");
 
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 
 		if (scriptInterface->callFunction(2)) {
@@ -150,7 +144,7 @@ void Monster::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
 	}
 }
 
-void Monster::onRemoveCreature(Creature* creature, bool isLogout)
+void Monster::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
@@ -168,10 +162,10 @@ void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 		lua_State* L = scriptInterface->getLuaState();
 		scriptInterface->pushFunction(mType->info.creatureDisappearEvent);
 
-		tfs::lua::pushUserdata(L, this);
+		tfs::lua::pushSharedPtr(L, getMonster());
 		tfs::lua::setMetatable(L, -1, "Monster");
 
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 
 		if (scriptInterface->callFunction(2)) {
@@ -179,7 +173,7 @@ void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 		}
 	}
 
-	if (creature == this) {
+	if (creature.get() == this) {
 		if (spawn) {
 			spawn->startSpawnCheck();
 		}
@@ -190,8 +184,9 @@ void Monster::onRemoveCreature(Creature* creature, bool isLogout)
 	}
 }
 
-void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
-                             const Position& oldPos, bool teleport)
+void Monster::onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+                             const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
+                             bool teleport)
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
@@ -209,10 +204,10 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 		lua_State* L = scriptInterface->getLuaState();
 		scriptInterface->pushFunction(mType->info.creatureMoveEvent);
 
-		tfs::lua::pushUserdata(L, this);
+		tfs::lua::pushSharedPtr(L, getMonster());
 		tfs::lua::setMetatable(L, -1, "Monster");
 
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 
 		tfs::lua::pushPosition(L, oldPos);
@@ -223,7 +218,7 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 		}
 	}
 
-	if (creature == this) {
+	if (creature.get() == this) {
 		if (isSummon()) {
 			isMasterInRange = canSee(getMaster()->getPosition());
 		}
@@ -247,7 +242,7 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 		updateIdleStatus();
 
 		if (!isSummon()) {
-			if (followCreature) {
+			if (const auto& followCreature = getFollowCreature()) {
 				const Position& followPosition = followCreature->getPosition();
 				const Position& position = getPosition();
 
@@ -257,11 +252,11 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 					Direction dir = getDirectionTo(position, followPosition);
 					const Position& checkPosition = getNextPosition(dir, position);
 
-					Tile* tile = g_game.map.getTile(checkPosition);
-					if (tile) {
-						Creature* topCreature = tile->getTopCreature();
-						if (topCreature && followCreature != topCreature && isOpponent(topCreature)) {
-							selectTarget(topCreature);
+					if (const auto& tile = g_game.map.getTile(checkPosition)) {
+						if (const auto& topCreature = tile->getTopCreature()) {
+							if (followCreature != topCreature && isOpponent(topCreature)) {
+								selectTarget(topCreature);
+							}
 						}
 					}
 				}
@@ -273,7 +268,7 @@ void Monster::onCreatureMove(Creature* creature, const Tile* newTile, const Posi
 	}
 }
 
-void Monster::onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text)
+void Monster::onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type, const std::string& text)
 {
 	Creature::onCreatureSay(creature, type, text);
 
@@ -291,10 +286,10 @@ void Monster::onCreatureSay(Creature* creature, SpeakClasses type, const std::st
 		lua_State* L = scriptInterface->getLuaState();
 		scriptInterface->pushFunction(mType->info.creatureSayEvent);
 
-		tfs::lua::pushUserdata(L, this);
+		tfs::lua::pushSharedPtr(L, getMonster());
 		tfs::lua::setMetatable(L, -1, "Monster");
 
-		tfs::lua::pushUserdata(L, creature);
+		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
 
 		tfs::lua::pushNumber(L, type);
@@ -304,29 +299,11 @@ void Monster::onCreatureSay(Creature* creature, SpeakClasses type, const std::st
 	}
 }
 
-void Monster::addFriend(Creature* creature)
+void Monster::addTarget(const std::shared_ptr<Creature>& creature, bool pushFront /* = false*/)
 {
-	assert(creature != this);
-	auto result = friendList.insert(creature);
-	if (result.second) {
-		creature->incrementReferenceCounter();
-	}
-}
-
-void Monster::removeFriend(Creature* creature)
-{
-	auto it = friendList.find(creature);
-	if (it != friendList.end()) {
-		creature->decrementReferenceCounter();
-		friendList.erase(it);
-	}
-}
-
-void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
-{
-	assert(creature != this);
-	if (std::find(targetList.begin(), targetList.end(), creature) == targetList.end()) {
-		creature->incrementReferenceCounter();
+	assert(creature.get() != this);
+	if (std::ranges::none_of(targetList,
+	                         [&creature](const auto& target) { return tfs::owner_equal(target, creature); })) {
 		if (pushFront) {
 			targetList.push_front(creature);
 		} else {
@@ -335,64 +312,36 @@ void Monster::addTarget(Creature* creature, bool pushFront /* = false*/)
 	}
 }
 
-void Monster::removeTarget(Creature* creature)
+void Monster::removeTarget(const std::shared_ptr<Creature>& creature)
 {
-	auto it = std::find(targetList.begin(), targetList.end(), creature);
+	auto it = std::ranges::find_if(targetList,
+	                               [&creature](const auto& target) { return tfs::owner_equal(target, creature); });
 	if (it != targetList.end()) {
-		creature->decrementReferenceCounter();
 		targetList.erase(it);
 	}
 }
 
 void Monster::updateTargetList()
 {
-	auto friendIterator = friendList.begin();
-	while (friendIterator != friendList.end()) {
-		Creature* creature = *friendIterator;
-		if (creature->isDead() || !canSee(creature->getPosition())) {
-			creature->decrementReferenceCounter();
-			friendIterator = friendList.erase(friendIterator);
-		} else {
-			++friendIterator;
-		}
-	}
+	friendList = friendList | tfs::views::lock_weak_ptrs | std::views::filter([this](const auto& creature) {
+		             return !creature->isDead() && canSee(creature->getPosition());
+	             }) |
+	             std::ranges::to<decltype(friendList)>();
 
-	auto targetIterator = targetList.begin();
-	while (targetIterator != targetList.end()) {
-		Creature* creature = *targetIterator;
-		if (creature->isDead() || !canSee(creature->getPosition())) {
-			creature->decrementReferenceCounter();
-			targetIterator = targetList.erase(targetIterator);
-		} else {
-			++targetIterator;
-		}
-	}
+	targetList = targetList | tfs::views::lock_weak_ptrs | std::views::filter([this](const auto& creature) {
+		             return !creature->isDead() && canSee(creature->getPosition());
+	             }) |
+	             std::ranges::to<decltype(targetList)>();
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, true);
-	spectators.erase(this);
-	for (Creature* spectator : spectators) {
+	spectators.erase(getMonster());
+	for (const auto& spectator : spectators) {
 		onCreatureFound(spectator);
 	}
 }
 
-void Monster::clearTargetList()
-{
-	for (Creature* creature : targetList) {
-		creature->decrementReferenceCounter();
-	}
-	targetList.clear();
-}
-
-void Monster::clearFriendList()
-{
-	for (Creature* creature : friendList) {
-		creature->decrementReferenceCounter();
-	}
-	friendList.clear();
-}
-
-void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/)
+void Monster::onCreatureFound(const std::shared_ptr<Creature>& creature, bool pushFront /* = false*/)
 {
 	if (!creature) {
 		return;
@@ -413,7 +362,7 @@ void Monster::onCreatureFound(Creature* creature, bool pushFront /* = false*/)
 	updateIdleStatus();
 }
 
-void Monster::onCreatureEnter(Creature* creature)
+void Monster::onCreatureEnter(const std::shared_ptr<Creature>& creature)
 {
 	// std::cout << "onCreatureEnter - " << creature->getName() << std::endl;
 
@@ -425,16 +374,16 @@ void Monster::onCreatureEnter(Creature* creature)
 	onCreatureFound(creature, true);
 }
 
-bool Monster::isFriend(const Creature* creature) const
+bool Monster::isFriend(const std::shared_ptr<const Creature>& creature) const
 {
 	if (isSummon() && getMaster()->getPlayer()) {
-		const Player* masterPlayer = getMaster()->getPlayer();
-		const Player* tmpPlayer = nullptr;
+		const auto& masterPlayer = getMaster()->getPlayer();
+		std::shared_ptr<const Player> tmpPlayer = nullptr;
 
 		if (creature->getPlayer()) {
 			tmpPlayer = creature->getPlayer();
 		} else {
-			const Creature* creatureMaster = creature->getMaster();
+			const auto& creatureMaster = creature->getMaster();
 
 			if (creatureMaster && creatureMaster->getPlayer()) {
 				tmpPlayer = creatureMaster->getPlayer();
@@ -451,7 +400,7 @@ bool Monster::isFriend(const Creature* creature) const
 	return false;
 }
 
-bool Monster::isOpponent(const Creature* creature) const
+bool Monster::isOpponent(const std::shared_ptr<const Creature>& creature) const
 {
 	if (isSummon() && getMaster()->getPlayer()) {
 		if (creature != getMaster()) {
@@ -467,7 +416,7 @@ bool Monster::isOpponent(const Creature* creature) const
 	return false;
 }
 
-void Monster::onCreatureLeave(Creature* creature)
+void Monster::onCreatureLeave(const std::shared_ptr<Creature>& creature)
 {
 	// std::cout << "onCreatureLeave - " << creature->getName() << std::endl;
 
@@ -497,20 +446,18 @@ void Monster::onCreatureLeave(Creature* creature)
 
 bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAULT*/)
 {
-	std::list<Creature*> resultList;
 	const Position& myPos = getPosition();
 
-	for (Creature* creature : targetList) {
-		if (followCreature != creature && isTarget(creature)) {
-			if (searchType == TARGETSEARCH_RANDOM || canUseAttack(myPos, creature)) {
-				resultList.push_back(creature);
-			}
-		}
-	}
+	auto resultList = targetList | tfs::views::lock_weak_ptrs |
+	                  std::views::filter([&, followCreature = getFollowCreature()](const auto& creature) {
+		                  return followCreature != creature && isTarget(creature) &&
+		                         (searchType == TARGETSEARCH_RANDOM || canUseAttack(myPos, creature));
+	                  }) |
+	                  std::ranges::to<std::vector>();
 
 	switch (searchType) {
 		case TARGETSEARCH_NEAREST: {
-			Creature* target = nullptr;
+			std::shared_ptr<Creature> target = nullptr;
 			if (!resultList.empty()) {
 				auto it = resultList.begin();
 				target = *it;
@@ -529,7 +476,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 				}
 			} else {
 				int32_t minRange = std::numeric_limits<int32_t>::max();
-				for (Creature* creature : targetList) {
+				for (const auto& creature : targetList | tfs::views::lock_weak_ptrs) {
 					if (!isTarget(creature)) {
 						continue;
 					}
@@ -567,7 +514,8 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 	}
 
 	// lets just pick the first target in the list
-	for (Creature* target : targetList) {
+	const auto& followCreature = getFollowCreature();
+	for (const auto& target : targetList | tfs::views::lock_weak_ptrs) {
 		if (followCreature != target && selectTarget(target)) {
 			return true;
 		}
@@ -577,6 +525,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 
 void Monster::goToFollowCreature()
 {
+	const auto& followCreature = getFollowCreature();
 	if (!followCreature) {
 		return;
 	}
@@ -613,22 +562,21 @@ void Monster::goToFollowCreature()
 
 void Monster::onFollowCreatureComplete()
 {
-	auto it = std::find(targetList.begin(), targetList.end(), followCreature);
+	auto it = std::ranges::find_if(targetList, [followCreature = getFollowCreature()](const auto& target) {
+		return tfs::owner_equal(target, followCreature);
+	});
 	if (it != targetList.end()) {
-		Creature* target = (*it);
-		targetList.erase(it);
-
 		if (hasFollowPath) {
-			targetList.push_front(target);
+			std::iter_swap(it, targetList.begin());
 		} else if (!isSummon()) {
-			targetList.push_back(target);
+			std::iter_swap(it, targetList.end() - 1);
 		} else {
-			target->decrementReferenceCounter();
+			targetList.erase(it);
 		}
 	}
 }
 
-BlockType_t Monster::blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
+BlockType_t Monster::blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,
                               bool checkDefense /* = false*/, bool checkArmor /* = false*/, bool /* field = false */,
                               bool /* ignoreResistances = false */)
 {
@@ -653,7 +601,7 @@ BlockType_t Monster::blockHit(Creature* attacker, CombatType_t combatType, int32
 	return blockType;
 }
 
-bool Monster::isTarget(const Creature* creature) const
+bool Monster::isTarget(const std::shared_ptr<const Creature>& creature) const
 {
 	if (creature->isRemoved() || !creature->isAttackable() || creature->getZone() == ZONE_PROTECTION ||
 	    !canSeeCreature(creature)) {
@@ -666,13 +614,14 @@ bool Monster::isTarget(const Creature* creature) const
 	return true;
 }
 
-bool Monster::selectTarget(Creature* creature)
+bool Monster::selectTarget(const std::shared_ptr<Creature>& creature)
 {
 	if (!isTarget(creature)) {
 		return false;
 	}
 
-	auto it = std::find(targetList.begin(), targetList.end(), creature);
+	auto it = std::ranges::find_if(targetList,
+	                               [&creature](const auto& target) { return tfs::owner_equal(target, creature); });
 	if (it == targetList.end()) {
 		// Target not found in our target list.
 		return false;
@@ -706,12 +655,12 @@ void Monster::setIdle(bool idle)
 	isIdle = idle;
 
 	if (!isIdle) {
-		g_game.addCreatureCheck(this);
+		g_game.addCreatureCheck(getMonster());
 	} else {
 		onIdleStatus();
 		clearTargetList();
 		clearFriendList();
-		Game::removeCreatureCheck(this);
+		Game::removeCreatureCheck(getMonster());
 	}
 }
 
@@ -756,7 +705,7 @@ void Monster::onThink(uint32_t interval)
 		lua_State* L = scriptInterface->getLuaState();
 		scriptInterface->pushFunction(mType->info.thinkEvent);
 
-		tfs::lua::pushUserdata(L, this);
+		tfs::lua::pushSharedPtr(L, getMonster());
 		tfs::lua::setMetatable(L, -1, "Monster");
 
 		tfs::lua::pushNumber(L, interval);
@@ -769,16 +718,16 @@ void Monster::onThink(uint32_t interval)
 	if (!isInSpawnRange(position)) {
 		if (getBoolean(ConfigManager::MONSTER_OVERSPAWN)) {
 			if (spawn) {
-				spawn->removeMonster(this);
+				spawn->removeMonster(getMonster());
 				spawn->startSpawnCheck();
 				spawn = nullptr;
 			}
 		} else {
 			g_game.addMagicEffect(this->getPosition(), CONST_ME_POFF);
 			if (getBoolean(ConfigManager::REMOVE_ON_DESPAWN)) {
-				g_game.removeCreature(this, false);
+				g_game.removeCreature(getMonster(), false);
 			} else {
-				g_game.internalTeleport(this, masterPos);
+				g_game.internalTeleport(getMonster(), masterPos);
 				setIdle(true);
 			}
 		}
@@ -788,26 +737,27 @@ void Monster::onThink(uint32_t interval)
 		if (!isIdle) {
 			addEventWalk();
 
-			if (isSummon()) {
-				if (!attackedCreature) {
-					if (getMaster() && getMaster()->getAttackedCreature()) {
+			if (const auto& master = getMaster()) {
+				if (const auto& attackedCreature = getAttackedCreature(); !attackedCreature) {
+					if (master->getAttackedCreature()) {
 						// This happens if the monster is summoned during combat
-						selectTarget(getMaster()->getAttackedCreature());
-					} else if (getMaster() != followCreature) {
+						selectTarget(master->getAttackedCreature());
+					} else if (tfs::owner_equal(master, getFollowCreature())) {
 						// Our master has not ordered us to attack anything, lets follow him around instead.
-						setFollowCreature(getMaster());
+						setFollowCreature(master);
 					}
-				} else if (attackedCreature == this) {
+				} else if (attackedCreature.get() == this) {
 					removeFollowCreature();
-				} else if (followCreature != attackedCreature) {
+				} else if (tfs::owner_equal(attackedCreature, getFollowCreature())) {
 					// This happens just after a master orders an attack, so lets follow it as well.
 					setFollowCreature(attackedCreature);
 				}
 			} else if (!targetList.empty()) {
-				if (!followCreature || !hasFollowPath) {
+				if (!getFollowCreature() || !hasFollowPath) {
 					searchTarget();
 				} else if (isFleeing()) {
-					if (attackedCreature && !canUseAttack(getPosition(), attackedCreature)) {
+					if (const auto& attackedCreature = getAttackedCreature();
+					    attackedCreature && !canUseAttack(getPosition(), attackedCreature)) {
 						searchTarget(TARGETSEARCH_ATTACKRANGE);
 					}
 				}
@@ -822,7 +772,8 @@ void Monster::onThink(uint32_t interval)
 
 void Monster::doAttacking(uint32_t interval)
 {
-	if (!attackedCreature || (isSummon() && attackedCreature == this)) {
+	const auto& attackedCreature = getAttackedCreature();
+	if (!attackedCreature || (isSummon() && attackedCreature.get() == this)) {
 		return;
 	}
 
@@ -849,7 +800,7 @@ void Monster::doAttacking(uint32_t interval)
 
 				minCombatValue = spellBlock.minCombatValue;
 				maxCombatValue = spellBlock.maxCombatValue;
-				spellBlock.spell->castSpell(this, attackedCreature);
+				spellBlock.spell->castSpell(getMonster(), attackedCreature);
 
 				if (spellBlock.isMelee) {
 					lastMeleeAttack = OTSYS_TIME();
@@ -873,7 +824,7 @@ void Monster::doAttacking(uint32_t interval)
 	}
 }
 
-bool Monster::canUseAttack(const Position& pos, const Creature* target) const
+bool Monster::canUseAttack(const Position& pos, const std::shared_ptr<const Creature>& target) const
 {
 	if (isHostile()) {
 		const Position& targetPos = target->getPosition();
@@ -984,10 +935,11 @@ void Monster::onThinkDefense(uint32_t interval)
 		if ((spellBlock.chance >= static_cast<uint32_t>(uniform_random(1, 100)))) {
 			minCombatValue = spellBlock.minCombatValue;
 			maxCombatValue = spellBlock.maxCombatValue;
-			spellBlock.spell->castSpell(this, this);
+			spellBlock.spell->castSpell(getMonster(), getMonster());
 		}
 	}
 
+	const auto summons = getSummons() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 	if (!isSummon() && summons.size() < mType->info.maxSummons && hasFollowPath) {
 		for (const summonBlock_t& summonBlock : mType->info.summons) {
 			if (summonBlock.speed > defenseTicks) {
@@ -1005,7 +957,7 @@ void Monster::onThinkDefense(uint32_t interval)
 			}
 
 			uint32_t summonCount = 0;
-			for (Creature* summon : summons) {
+			for (const auto& summon : summons) {
 				if (summon->getName() == summonBlock.name) {
 					++summonCount;
 				}
@@ -1019,17 +971,14 @@ void Monster::onThinkDefense(uint32_t interval)
 				continue;
 			}
 
-			Monster* summon = Monster::createMonster(summonBlock.name);
-			if (summon) {
+			if (const auto& summon = Monster::createMonster(summonBlock.name)) {
 				if (g_game.placeCreature(summon, getPosition(), false, summonBlock.force, summonBlock.effect)) {
 					summon->setDropLoot(false);
 					summon->setSkillLoss(false);
-					summon->setMaster(this);
+					summon->setMaster(getMonster());
 					if (summonBlock.masterEffect != CONST_ME_NONE) {
 						g_game.addMagicEffect(getPosition(), summonBlock.masterEffect);
 					}
-				} else {
-					delete summon;
 				}
 			}
 		}
@@ -1056,9 +1005,9 @@ void Monster::onThinkYell(uint32_t interval)
 			const voiceBlock_t& vb = mType->info.voiceVector[index];
 
 			if (vb.yellText) {
-				g_game.internalCreatureSay(this, TALKTYPE_MONSTER_YELL, vb.text, false);
+				g_game.internalCreatureSay(getMonster(), TALKTYPE_MONSTER_YELL, vb.text, false);
 			} else {
-				g_game.internalCreatureSay(this, TALKTYPE_MONSTER_SAY, vb.text, false);
+				g_game.internalCreatureSay(getMonster(), TALKTYPE_MONSTER_SAY, vb.text, false);
 			}
 		}
 	}
@@ -1085,8 +1034,6 @@ bool Monster::walkToSpawn()
 	return true;
 }
 
-void Monster::onWalk() { Creature::onWalk(); }
-
 void Monster::onWalkComplete()
 {
 	// Continue walking to spawn
@@ -1096,21 +1043,21 @@ void Monster::onWalkComplete()
 	}
 }
 
-bool Monster::pushItem(Item* item)
+static bool pushItem(const std::shared_ptr<Item>& item)
 {
 	const Position& centerPos = item->getPosition();
 
-	static std::vector<std::pair<int32_t, int32_t>> relList{{-1, -1}, {0, -1}, {1, -1}, {-1, 0},
-	                                                        {1, 0},   {-1, 1}, {0, 1},  {1, 1}};
+	static auto relList = std::vector{std::pair{-1, -1}, {0, -1}, {1, -1}, {-1, 0}, {1, 0}, {-1, 1}, {0, 1}, {1, 1}};
 
 	std::shuffle(relList.begin(), relList.end(), getRandomGenerator());
 
 	for (auto&& [dx, dy] : relList | std::views::as_const) {
 		Position tryPos(centerPos.x + dx, centerPos.y + dy, centerPos.z);
-		Tile* tile = g_game.map.getTile(tryPos);
-		if (tile && g_game.canThrowObjectTo(centerPos, tryPos, true, true)) {
-			if (g_game.internalMoveItem(item->getParent(), tile, INDEX_WHEREEVER, item, item->getItemCount(),
-			                            nullptr) == RETURNVALUE_NOERROR) {
+		if (const auto& tile = g_game.map.getTile(tryPos)) {
+			std::shared_ptr<Item> moveItem = nullptr;
+			if (g_game.canThrowObjectTo(centerPos, tryPos, true, true) &&
+			    g_game.internalMoveItem(item->getParent(), tile, INDEX_WHEREEVER, item, item->getItemCount(),
+			                            moveItem) == RETURNVALUE_NOERROR) {
 				return true;
 			}
 		}
@@ -1118,7 +1065,7 @@ bool Monster::pushItem(Item* item)
 	return false;
 }
 
-void Monster::pushItems(Tile* tile)
+static void pushItems(const std::shared_ptr<Tile>& tile)
 {
 	// We can not use iterators here since we can push the item to another tile which will invalidate the iterator.
 	// start from the end to minimize the amount of traffic
@@ -1128,13 +1075,14 @@ void Monster::pushItems(Tile* tile)
 
 		int32_t downItemSize = tile->getDownItemCount();
 		for (int32_t i = downItemSize; --i >= 0;) {
-			Item* item = items->at(i);
-			if (item && item->hasProperty(CONST_PROP_MOVEABLE) &&
-			    (item->hasProperty(CONST_PROP_BLOCKPATH) || item->hasProperty(CONST_PROP_BLOCKSOLID))) {
-				if (moveCount < 20 && Monster::pushItem(item)) {
-					++moveCount;
-				} else if (g_game.internalRemoveItem(item) == RETURNVALUE_NOERROR) {
-					++removeCount;
+			if (const auto item = items->at(i)) {
+				if (item->hasProperty(CONST_PROP_MOVEABLE) &&
+				    (item->hasProperty(CONST_PROP_BLOCKPATH) || item->hasProperty(CONST_PROP_BLOCKSOLID))) {
+					if (moveCount < 20 && pushItem(item)) {
+						++moveCount;
+					} else if (g_game.internalRemoveItem(item) == RETURNVALUE_NOERROR) {
+						++removeCount;
+					}
 				}
 			}
 		}
@@ -1145,16 +1093,13 @@ void Monster::pushItems(Tile* tile)
 	}
 }
 
-bool Monster::pushCreature(Creature* creature)
+static bool pushCreature(const std::shared_ptr<Creature>& creature)
 {
-	static std::vector<Direction> dirList{DIRECTION_NORTH, DIRECTION_WEST, DIRECTION_EAST, DIRECTION_SOUTH};
-	std::shuffle(dirList.begin(), dirList.end(), getRandomGenerator());
-
-	for (Direction dir : dirList) {
+	for (Direction dir : getShuffleDirections()) {
 		const Position& tryPos = Spells::getCasterPosition(creature, dir);
-		Tile* toTile = g_game.map.getTile(tryPos);
-		if (toTile && !toTile->hasFlag(TILESTATE_BLOCKPATH)) {
-			if (g_game.internalMoveCreature(creature, dir) == RETURNVALUE_NOERROR) {
+		if (const auto& toTile = g_game.map.getTile(tryPos)) {
+			if (!toTile->hasFlag(TILESTATE_BLOCKPATH) &&
+			    g_game.internalMoveCreature(creature, dir) == RETURNVALUE_NOERROR) {
 				return true;
 			}
 		}
@@ -1162,25 +1107,25 @@ bool Monster::pushCreature(Creature* creature)
 	return false;
 }
 
-void Monster::pushCreatures(Tile* tile)
+static void pushCreatures(const std::shared_ptr<Tile>& tile)
 {
 	// We can not use iterators here since we can push a creature to another tile which will invalidate the iterator.
 	if (CreatureVector* creatures = tile->getCreatures()) {
 		uint32_t removeCount = 0;
-		Monster* lastPushedMonster = nullptr;
+		std::shared_ptr<Monster> lastPushedMonster = nullptr;
 
 		for (size_t i = 0; i < creatures->size();) {
-			Monster* monster = creatures->at(i)->getMonster();
-			if (monster && monster->isPushable()) {
-				if (monster != lastPushedMonster && Monster::pushCreature(monster)) {
-					lastPushedMonster = monster;
-					continue;
+			if (const auto monster = creatures->at(i)->getMonster()) {
+				if (monster->isPushable()) {
+					if (monster != lastPushedMonster && pushCreature(monster)) {
+						lastPushedMonster = monster;
+						continue;
+					}
+
+					monster->changeHealth(-monster->getHealth());
+					removeCount++;
 				}
-
-				monster->changeHealth(-monster->getHealth());
-				removeCount++;
 			}
-
 			++i;
 		}
 
@@ -1199,13 +1144,13 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 	}
 
 	bool result = false;
-	if (!walkingToSpawn && (!followCreature || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
+	if (!walkingToSpawn && (!getFollowCreature() || !hasFollowPath) && (!isSummon() || !isMasterInRange)) {
 		if (getTimeSinceLastMove() >= 1000) {
 			randomStepping = true;
 			// choose a random direction
 			result = getRandomStep(getPosition(), direction);
 		}
-	} else if ((isSummon() && isMasterInRange) || followCreature || walkingToSpawn) {
+	} else if ((isSummon() && isMasterInRange) || getFollowCreature() || walkingToSpawn) {
 		if (!hasFollowPath && getMaster() && !getMaster()->getPlayer()) {
 			randomStepping = true;
 			result = getRandomStep(getPosition(), direction);
@@ -1219,7 +1164,8 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 					ignoreFieldDamage = false;
 				}
 				// target dancing
-				if (attackedCreature && attackedCreature == followCreature) {
+				if (const auto& attackedCreature = getAttackedCreature();
+				    attackedCreature && tfs::owner_equal(attackedCreature, getFollowCreature())) {
 					if (isFleeing()) {
 						result = getDanceStep(getPosition(), direction, false, false);
 					} else if (mType->info.staticAttackChance < static_cast<uint32_t>(uniform_random(1, 100))) {
@@ -1231,15 +1177,15 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 	}
 
 	if (result && (canPushItems() || canPushCreatures())) {
-		const Position& pos = Spells::getCasterPosition(this, direction);
-		Tile* tile = g_game.map.getTile(pos);
-		if (tile) {
+		const Position& pos = Spells::getCasterPosition(getMonster(), direction);
+
+		if (const auto& tile = g_game.map.getTile(pos)) {
 			if (canPushItems()) {
-				Monster::pushItems(tile);
+				pushItems(tile);
 			}
 
 			if (canPushCreatures()) {
-				Monster::pushCreatures(tile);
+				pushCreatures(tile);
 			}
 		}
 	}
@@ -1261,9 +1207,11 @@ bool Monster::getRandomStep(const Position& creaturePos, Direction& direction) c
 bool Monster::getDanceStep(const Position& creaturePos, Direction& direction, bool keepAttack /*= true*/,
                            bool keepDistance /*= true*/)
 {
+	const auto& attackedCreature = getAttackedCreature();
+	assert(attackedCreature);
+
 	bool canDoAttackNow = canUseAttack(creaturePos, attackedCreature);
 
-	assert(attackedCreature);
 	const Position& centerPos = attackedCreature->getPosition();
 
 	int32_t offset_x = creaturePos.getOffsetX(centerPos);
@@ -1377,9 +1325,8 @@ bool Monster::getDistanceStep(const Position& targetPos, Direction& direction, b
 	}
 
 	if (offsetx == 0 && offsety == 0) {
-		return getRandomStep(
-		    creaturePos,
-		    direction); // player is "on" the monster so let's get some random step and rest will be taken care later.
+		// player is "on" the monster so let's get some random step and rest will be taken care later.
+		return getRandomStep(creaturePos, direction);
 	}
 
 	if (dx == dy) {
@@ -1851,42 +1798,46 @@ bool Monster::canWalkTo(Position pos, Direction direction) const
 {
 	pos = getNextPosition(direction, pos);
 	if (isInSpawnRange(pos)) {
-		Tile* tile = g_game.map.getTile(pos);
-		if (tile && !tile->getTopVisibleCreature(this) &&
-		    tile->queryAdd(0, *this, 1, FLAG_PATHFINDING) == RETURNVALUE_NOERROR) {
-			return true;
+		if (const auto& tile = g_game.map.getTile(pos)) {
+			if (!tile->getTopVisibleCreature(getMonster()) &&
+			    tile->queryAdd(0, getMonster(), 1, FLAG_PATHFINDING) == RETURNVALUE_NOERROR) {
+				return true;
+			}
 		}
 	}
 	return false;
 }
 
-void Monster::death(Creature*)
+void Monster::death(const std::shared_ptr<Creature>&)
 {
 	removeAttackedCreature();
 
-	for (Creature* summon : summons) {
+	for (const auto& summon : getSummons() | tfs::views::lock_weak_ptrs) {
 		summon->changeHealth(-summon->getHealth());
 		summon->removeMaster();
 	}
-	summons.clear();
+	clearSummons();
 
 	clearTargetList();
 	clearFriendList();
 	onIdleStatus();
 }
 
-Item* Monster::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
+std::shared_ptr<Item> Monster::getCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+                                         const std::shared_ptr<Creature>& mostDamageCreature)
 {
-	Item* corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
-	if (corpse) {
-		if (mostDamageCreature) {
-			if (mostDamageCreature->getPlayer()) {
-				corpse->setCorpseOwner(mostDamageCreature->getID());
-			} else {
-				const Creature* mostDamageCreatureMaster = mostDamageCreature->getMaster();
-				if (mostDamageCreatureMaster && mostDamageCreatureMaster->getPlayer()) {
-					corpse->setCorpseOwner(mostDamageCreatureMaster->getID());
-				}
+	const auto& corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
+	if (!corpse) {
+		return nullptr;
+	}
+
+	if (mostDamageCreature) {
+		if (mostDamageCreature->getPlayer()) {
+			corpse->setCorpseOwner(mostDamageCreature->getID());
+		} else {
+			const auto& mostDamageCreatureMaster = mostDamageCreature->getMaster();
+			if (mostDamageCreatureMaster && mostDamageCreatureMaster->getPlayer()) {
+				corpse->setCorpseOwner(mostDamageCreatureMaster->getID());
 			}
 		}
 	}
@@ -1931,6 +1882,7 @@ bool Monster::getCombatValues(int32_t& min, int32_t& max)
 
 void Monster::updateLookDirection()
 {
+	const auto& attackedCreature = getAttackedCreature();
 	if (!attackedCreature) {
 		return;
 	}
@@ -1957,19 +1909,19 @@ void Monster::updateLookDirection()
 		lookDirection = (offsetX < 0) ? DIRECTION_WEST : DIRECTION_EAST;
 	}
 
-	g_game.internalCreatureTurn(this, lookDirection);
+	g_game.internalCreatureTurn(getMonster(), lookDirection);
 }
 
-void Monster::dropLoot(Container* corpse, Creature*)
+void Monster::dropLoot(const std::shared_ptr<Container>& corpse, const std::shared_ptr<Creature>&)
 {
 	if (corpse && lootDrop) {
-		tfs::events::monster::onDropLoot(this, corpse);
+		tfs::events::monster::onDropLoot(getMonster(), corpse);
 	}
 }
 
 void Monster::setNormalCreatureLight() { internalLight = mType->info.light; }
 
-void Monster::drainHealth(Creature* attacker, int32_t damage)
+void Monster::drainHealth(const std::shared_ptr<Creature>& attacker, int32_t damage)
 {
 	Creature::drainHealth(attacker, damage);
 
@@ -1989,7 +1941,7 @@ void Monster::changeHealth(int32_t healthChange, bool sendHealthChange /* = true
 	Creature::changeHealth(healthChange, sendHealthChange);
 }
 
-bool Monster::challengeCreature(Creature* creature, bool force /* = false*/)
+bool Monster::challengeCreature(const std::shared_ptr<Creature>& creature, bool force /* = false*/)
 {
 	if (isSummon()) {
 		return false;
@@ -2008,7 +1960,7 @@ bool Monster::challengeCreature(Creature* creature, bool force /* = false*/)
 	return result;
 }
 
-void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp) const
+void Monster::getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const
 {
 	Creature::getPathSearchParams(creature, fpp);
 
@@ -2016,7 +1968,7 @@ void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp)
 	fpp.maxTargetDist = mType->info.targetDistance;
 
 	if (isSummon()) {
-		if (followCreature && followCreature == getMaster()) {
+		if (const auto& followCreature = getFollowCreature(); followCreature && followCreature == getMaster()) {
 			fpp.summonTargetMaster = true;
 		}
 		if (getMaster() == creature) {
@@ -2042,10 +1994,10 @@ void Monster::getPathSearchParams(const Creature* creature, FindPathParams& fpp)
 
 bool Monster::canPushItems() const
 {
-	Monster* master = this->master ? this->master->getMonster() : nullptr;
-	if (master) {
-		return master->mType->info.canPushItems;
+	if (const auto& master = this->getMaster()) {
+		if (const auto& monster = master->getMonster()) {
+			return monster->mType->info.canPushItems;
+		}
 	}
-
 	return mType->info.canPushItems;
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -25,22 +25,23 @@ enum TargetSearchType_t
 class Monster final : public Creature
 {
 public:
-	static Monster* createMonster(const std::string& name);
-
-	using Creature::onWalk;
+	static std::shared_ptr<Monster> createMonster(const std::string& name);
 
 	static int32_t despawnRange;
 	static int32_t despawnRadius;
 
 	explicit Monster(MonsterType* mType);
-	~Monster();
+	~Monster() = default;
 
 	// non-copyable
 	Monster(const Monster&) = delete;
 	Monster& operator=(const Monster&) = delete;
 
-	Monster* getMonster() override { return this; }
-	const Monster* getMonster() const override { return this; }
+	std::shared_ptr<Monster> getMonster() override { return std::static_pointer_cast<Monster>(shared_from_this()); }
+	std::shared_ptr<const Monster> getMonster() const override
+	{
+		return std::static_pointer_cast<const Monster>(shared_from_this());
+	}
 
 	void setID() override
 	{
@@ -82,18 +83,18 @@ public:
 
 	void onAttackedCreatureDisappear(bool isLogout) override;
 
-	void onCreatureAppear(Creature* creature, bool, MagicEffectClasses) override;
-	void onRemoveCreature(Creature* creature, bool isLogout) override;
-	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
-	                    const Position& oldPos, bool teleport) override;
-	void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) override;
+	void onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, MagicEffectClasses) override;
+	void onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout) override;
+	void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+	                    const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
+	                    bool teleport) override;
+	void onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type, const std::string& text) override;
 
-	void drainHealth(Creature* attacker, int32_t damage) override;
+	void drainHealth(const std::shared_ptr<Creature>& attacker, int32_t damage) override;
 	void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
 
 	bool isWalkingToSpawn() const { return walkingToSpawn; }
 	bool walkToSpawn();
-	void onWalk() override;
 	void onWalkComplete() override;
 	bool getNextStep(Direction& direction, uint32_t& flags) override;
 	void goToFollowCreature() override;
@@ -101,7 +102,7 @@ public:
 
 	void onThink(uint32_t interval) override;
 
-	bool challengeCreature(Creature* creature, bool force = false) override;
+	bool challengeCreature(const std::shared_ptr<Creature>& creature, bool force = false) override;
 
 	void setNormalCreatureLight() override;
 	bool getCombatValues(int32_t& min, int32_t& max) override;
@@ -110,12 +111,12 @@ public:
 	bool hasExtraSwing() override { return lastMeleeAttack == 0; }
 
 	bool searchTarget(TargetSearchType_t searchType = TARGETSEARCH_DEFAULT);
-	bool selectTarget(Creature* creature);
+	bool selectTarget(const std::shared_ptr<Creature>& creature);
 
 	const auto& getTargetList() const { return targetList; }
 	const auto& getFriendList() const { return friendList; }
 
-	bool isTarget(const Creature* creature) const;
+	bool isTarget(const std::shared_ptr<const Creature>& creature) const;
 	bool isFleeing() const
 	{
 		return !isSummon() && getHealth() <= mType->info.runAwayHealth && challengeFocusDuration <= 0;
@@ -125,8 +126,9 @@ public:
 	bool isTargetNearby() const { return stepDuration >= 1; }
 	bool isIgnoringFieldDamage() const { return ignoreFieldDamage; }
 
-	BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage, bool checkDefense = false,
-	                     bool checkArmor = false, bool field = false, bool ignoreResistances = false) override;
+	BlockType_t blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,
+	                     bool checkDefense = false, bool checkArmor = false, bool field = false,
+	                     bool ignoreResistances = false) override;
 
 	// monster icons
 	MonsterIconHashMap& getSpecialIcons() { return monsterIcons; }
@@ -135,8 +137,8 @@ public:
 	static uint32_t monsterAutoID;
 
 private:
-	boost::container::flat_set<Creature*> friendList;
-	std::deque<Creature*> targetList;
+	boost::container::flat_set<std::weak_ptr<Creature>, std::owner_less<std::weak_ptr<Creature>>> friendList;
+	std::deque<std::weak_ptr<Creature>> targetList;
 	MonsterIconHashMap monsterIcons;
 
 	std::string name;
@@ -165,23 +167,28 @@ private:
 	bool randomStepping = false;
 	bool walkingToSpawn = false;
 
-	void onCreatureEnter(Creature* creature);
-	void onCreatureLeave(Creature* creature);
-	void onCreatureFound(Creature* creature, bool pushFront = false);
+	void onCreatureEnter(const std::shared_ptr<Creature>& creature);
+	void onCreatureLeave(const std::shared_ptr<Creature>& creature);
+	void onCreatureFound(const std::shared_ptr<Creature>& creature, bool pushFront = false);
 
 	void updateLookDirection();
 
-	void addFriend(Creature* creature);
-	void removeFriend(Creature* creature);
-	void addTarget(Creature* creature, bool pushFront = false);
-	void removeTarget(Creature* creature);
+	void addFriend(const std::shared_ptr<Creature>& creature)
+	{
+		assert(creature.get() != this);
+		friendList.emplace(creature);
+	}
+	void removeFriend(const std::shared_ptr<Creature>& creature) { friendList.erase(creature); }
+	void addTarget(const std::shared_ptr<Creature>& creature, bool pushFront = false);
+	void removeTarget(const std::shared_ptr<Creature>& creature);
 
 	void updateTargetList();
-	void clearTargetList();
-	void clearFriendList();
+	void clearTargetList() { targetList.clear(); }
+	void clearFriendList() { friendList.clear(); }
 
-	void death(Creature* lastHitCreature) override;
-	Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) override;
+	void death(const std::shared_ptr<Creature>& lastHitCreature) override;
+	std::shared_ptr<Item> getCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+	                                const std::shared_ptr<Creature>& mostDamageCreature) override;
 
 	void setIdle(bool idle);
 	void updateIdleStatus();
@@ -190,7 +197,7 @@ private:
 	void onAddCondition(ConditionType_t type) override;
 	void onEndCondition(ConditionType_t type) override;
 
-	bool canUseAttack(const Position& pos, const Creature* target) const;
+	bool canUseAttack(const Position& pos, const std::shared_ptr<const Creature>& target) const;
 	bool canUseSpell(const Position& pos, const Position& targetPos, const spellBlock_t& sb, uint32_t interval,
 	                 bool& inRange, bool& resetTicks);
 	bool getRandomStep(const Position& creaturePos, Direction& direction) const;
@@ -199,24 +206,19 @@ private:
 	bool isInSpawnRange(const Position& pos) const;
 	bool canWalkTo(Position pos, Direction direction) const;
 
-	static bool pushItem(Item* item);
-	static void pushItems(Tile* tile);
-	static bool pushCreature(Creature* creature);
-	static void pushCreatures(Tile* tile);
-
 	void onThinkTarget(uint32_t interval);
 	void onThinkYell(uint32_t interval);
 	void onThinkDefense(uint32_t interval);
 
-	bool isFriend(const Creature* creature) const;
-	bool isOpponent(const Creature* creature) const;
+	bool isFriend(const std::shared_ptr<const Creature>& creature) const;
+	bool isOpponent(const std::shared_ptr<const Creature>& creature) const;
 
 	uint64_t getLostExperience() const override { return skillLoss ? mType->info.experience : 0; }
 	uint16_t getLookCorpse() const override { return mType->info.lookcorpse; }
-	void dropLoot(Container* corpse, Creature* lastHitCreature) override;
+	void dropLoot(const std::shared_ptr<Container>& corpse, const std::shared_ptr<Creature>& lastHitCreature) override;
 	uint32_t getDamageImmunities() const override { return mType->info.damageImmunities; }
 	uint32_t getConditionImmunities() const override { return mType->info.conditionImmunities; }
-	void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
+	void getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const override;
 
 	friend class LuaScriptInterface;
 };

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -279,7 +279,7 @@ void MoveEvents::addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map)
 	}
 }
 
-MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, slots_t slot)
+MoveEvent* MoveEvents::getEvent(const std::shared_ptr<Item>& item, MoveEvent_t eventType, slots_t slot)
 {
 	uint32_t slotp;
 	switch (slot) {
@@ -330,7 +330,7 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, slots_t slot)
 	return nullptr;
 }
 
-MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType)
+MoveEvent* MoveEvents::getEvent(const std::shared_ptr<Item>& item, MoveEvent_t eventType)
 {
 	MoveListMap::iterator it;
 
@@ -381,7 +381,7 @@ void MoveEvents::addEvent(MoveEvent moveEvent, const Position& pos, MovePosListM
 	}
 }
 
-MoveEvent* MoveEvents::getEvent(const Tile* tile, MoveEvent_t eventType)
+MoveEvent* MoveEvents::getEvent(const std::shared_ptr<const Tile>& tile, MoveEvent_t eventType)
 {
 	auto it = positionMap.find(tile->getPosition());
 	if (it != positionMap.end()) {
@@ -393,7 +393,8 @@ MoveEvent* MoveEvents::getEvent(const Tile* tile, MoveEvent_t eventType)
 	return nullptr;
 }
 
-uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEvent_t eventType)
+uint32_t MoveEvents::onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& tile,
+                                    MoveEvent_t eventType)
 {
 	const Position& pos = tile->getPosition();
 
@@ -405,12 +406,12 @@ uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEv
 	}
 
 	for (size_t i = tile->getFirstIndex(), j = tile->getLastIndex(); i < j; ++i) {
-		Thing* thing = tile->getThing(i);
+		const auto& thing = tile->getThing(i);
 		if (!thing) {
 			continue;
 		}
 
-		Item* tileItem = thing->getItem();
+		const auto& tileItem = thing->getItem();
 		if (!tileItem) {
 			continue;
 		}
@@ -423,7 +424,8 @@ uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEv
 	return ret;
 }
 
-ReturnValue MoveEvents::onPlayerEquip(Player* player, Item* item, slots_t slot, bool isCheck)
+ReturnValue MoveEvents::onPlayerEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+                                      slots_t slot, bool isCheck)
 {
 	MoveEvent* moveEvent = getEvent(item, MOVE_EVENT_EQUIP, slot);
 	if (!moveEvent) {
@@ -432,7 +434,8 @@ ReturnValue MoveEvents::onPlayerEquip(Player* player, Item* item, slots_t slot, 
 	return moveEvent->fireEquip(player, item, slot, isCheck);
 }
 
-ReturnValue MoveEvents::onPlayerDeEquip(Player* player, Item* item, slots_t slot)
+ReturnValue MoveEvents::onPlayerDeEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+                                        slots_t slot)
 {
 	MoveEvent* moveEvent = getEvent(item, MOVE_EVENT_DEEQUIP, slot);
 	if (!moveEvent) {
@@ -444,7 +447,7 @@ ReturnValue MoveEvents::onPlayerDeEquip(Player* player, Item* item, slots_t slot
 	return moveEvent->fireEquip(player, item, slot, false);
 }
 
-uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
+uint32_t MoveEvents::onItemMove(const std::shared_ptr<Item>& item, const std::shared_ptr<Tile>& tile, bool isAdd)
 {
 	MoveEvent_t eventType1, eventType2;
 	if (isAdd) {
@@ -467,12 +470,12 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 	}
 
 	for (size_t i = tile->getFirstIndex(), j = tile->getLastIndex(); i < j; ++i) {
-		Thing* thing = tile->getThing(i);
+		const auto& thing = tile->getThing(i);
 		if (!thing) {
 			continue;
 		}
 
-		Item* tileItem = thing->getItem();
+		const auto& tileItem = thing->getItem();
 		if (!tileItem || tileItem == item) {
 			continue;
 		}
@@ -632,10 +635,10 @@ bool MoveEvent::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-uint32_t MoveEvent::StepInField(Creature* creature, Item* item, const Position&)
+uint32_t MoveEvent::StepInField(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
+                                const Position&)
 {
-	MagicField* field = item->getMagicField();
-	if (field) {
+	if (const auto& field = item->getMagicField()) {
 		field->onStepInField(creature);
 		return 1;
 	}
@@ -643,14 +646,17 @@ uint32_t MoveEvent::StepInField(Creature* creature, Item* item, const Position&)
 	return LUA_ERROR_ITEM_NOT_FOUND;
 }
 
-uint32_t MoveEvent::StepOutField(Creature*, Item*, const Position&) { return 1; }
-
-uint32_t MoveEvent::AddItemField(Item* item, Item*, const Position&)
+uint32_t MoveEvent::StepOutField(const std::shared_ptr<Creature>&, const std::shared_ptr<Item>&, const Position&)
 {
-	if (MagicField* field = item->getMagicField()) {
-		Tile* tile = item->getTile();
+	return 1;
+}
+
+uint32_t MoveEvent::AddItemField(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>&, const Position&)
+{
+	if (const auto& field = item->getMagicField()) {
+		const auto& tile = item->getTile();
 		if (CreatureVector* creatures = tile->getCreatures()) {
-			for (Creature* creature : *creatures) {
+			for (const auto& creature : *creatures) {
 				field->onStepInField(creature);
 			}
 		}
@@ -659,9 +665,13 @@ uint32_t MoveEvent::AddItemField(Item* item, Item*, const Position&)
 	return LUA_ERROR_ITEM_NOT_FOUND;
 }
 
-uint32_t MoveEvent::RemoveItemField(Item*, Item*, const Position&) { return 1; }
+uint32_t MoveEvent::RemoveItemField(const std::shared_ptr<Item>&, const std::shared_ptr<Item>&, const Position&)
+{
+	return 1;
+}
 
-ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool isCheck)
+ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, const std::shared_ptr<Player>& player,
+                                 const std::shared_ptr<Item>& item, slots_t slot, bool isCheck)
 {
 	if (!player->hasFlag(PlayerFlag_IgnoreWeaponCheck) && moveEvent->getWieldInfo() != 0) {
 		if (!moveEvent->hasVocationEquipSet(player->getVocationId())) {
@@ -691,8 +701,7 @@ ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* ite
 
 	const ItemType& it = Item::items[item->getID()];
 	if (it.transformEquipTo != 0) {
-		Item* newItem = g_game.transformItem(item, it.transformEquipTo);
-		g_game.startDecay(newItem);
+		g_game.startDecay(g_game.transformItem(item, it.transformEquipTo));
 	} else {
 		player->setItemAbility(slot, true);
 	}
@@ -796,7 +805,8 @@ ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, Player* player, Item* ite
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue MoveEvent::DeEquipItem(MoveEvent*, Player* player, Item* item, slots_t slot, bool)
+ReturnValue MoveEvent::DeEquipItem(MoveEvent*, const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+                                   slots_t slot, bool)
 {
 	if (!player->isItemAbilityEnabled(slot)) {
 		return RETURNVALUE_NOERROR;
@@ -920,7 +930,8 @@ MoveEvent_t MoveEvent::getEventType() const { return eventType; }
 
 void MoveEvent::setEventType(MoveEvent_t type) { eventType = type; }
 
-uint32_t MoveEvent::fireStepEvent(Creature* creature, Item* item, const Position& pos)
+uint32_t MoveEvent::fireStepEvent(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
+                                  const Position& pos)
 {
 	if (scripted) {
 		return executeStep(creature, item, pos);
@@ -928,7 +939,8 @@ uint32_t MoveEvent::fireStepEvent(Creature* creature, Item* item, const Position
 	return stepFunction(creature, item, pos);
 }
 
-bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos)
+bool MoveEvent::executeStep(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
+                            const Position& pos)
 {
 	// onStepIn(creature, item, pos, fromPosition)
 	// onStepOut(creature, item, pos, fromPosition)
@@ -943,7 +955,7 @@ bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(scriptId);
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 	tfs::lua::pushThing(L, item);
 	tfs::lua::pushPosition(L, pos);
@@ -952,7 +964,8 @@ bool MoveEvent::executeStep(Creature* creature, Item* item, const Position& pos)
 	return scriptInterface->callFunction(4);
 }
 
-ReturnValue MoveEvent::fireEquip(Player* player, Item* item, slots_t slot, bool isCheck)
+ReturnValue MoveEvent::fireEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+                                 bool isCheck)
 {
 	ReturnValue ret = RETURNVALUE_NOERROR;
 	if (equipFunction) {
@@ -964,7 +977,8 @@ ReturnValue MoveEvent::fireEquip(Player* player, Item* item, slots_t slot, bool 
 	return ret;
 }
 
-bool MoveEvent::executeEquip(Player* player, Item* item, slots_t slot, bool isCheck)
+bool MoveEvent::executeEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+                             bool isCheck)
 {
 	// onEquip(player, item, slot, isCheck)
 	// onDeEquip(player, item, slot, isCheck)
@@ -979,7 +993,7 @@ bool MoveEvent::executeEquip(Player* player, Item* item, slots_t slot, bool isCh
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(scriptId);
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 	tfs::lua::pushThing(L, item);
 	tfs::lua::pushNumber(L, slot);
@@ -988,7 +1002,8 @@ bool MoveEvent::executeEquip(Player* player, Item* item, slots_t slot, bool isCh
 	return scriptInterface->callFunction(4);
 }
 
-uint32_t MoveEvent::fireAddRemItem(Item* item, Item* tileItem, const Position& pos)
+uint32_t MoveEvent::fireAddRemItem(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+                                   const Position& pos)
 {
 	if (scripted) {
 		return executeAddRemItem(item, tileItem, pos);
@@ -996,7 +1011,8 @@ uint32_t MoveEvent::fireAddRemItem(Item* item, Item* tileItem, const Position& p
 	return moveFunction(item, tileItem, pos);
 }
 
-bool MoveEvent::executeAddRemItem(Item* item, Item* tileItem, const Position& pos)
+bool MoveEvent::executeAddRemItem(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+                                  const Position& pos)
 {
 	// onaddItem(moveitem, tileitem, pos)
 	// onRemoveItem(moveitem, tileitem, pos)

--- a/src/movement.h
+++ b/src/movement.h
@@ -45,12 +45,14 @@ public:
 	MoveEvents(const MoveEvents&) = delete;
 	MoveEvents& operator=(const MoveEvents&) = delete;
 
-	uint32_t onCreatureMove(Creature* creature, const Tile* tile, MoveEvent_t eventType);
-	ReturnValue onPlayerEquip(Player* player, Item* item, slots_t slot, bool isCheck);
-	ReturnValue onPlayerDeEquip(Player* player, Item* item, slots_t slot);
-	uint32_t onItemMove(Item* item, Tile* tile, bool isAdd);
+	uint32_t onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& tile,
+	                        MoveEvent_t eventType);
+	ReturnValue onPlayerEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+	                          bool isCheck);
+	ReturnValue onPlayerDeEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot);
+	uint32_t onItemMove(const std::shared_ptr<Item>& item, const std::shared_ptr<Tile>& tile, bool isAdd);
 
-	MoveEvent* getEvent(Item* item, MoveEvent_t eventType);
+	MoveEvent* getEvent(const std::shared_ptr<Item>& item, MoveEvent_t eventType);
 
 	bool registerLuaEvent(MoveEvent* event);
 	bool registerLuaFunction(MoveEvent* event);
@@ -94,9 +96,9 @@ private:
 	void addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map);
 
 	void addEvent(MoveEvent moveEvent, const Position& pos, MovePosListMap& map);
-	MoveEvent* getEvent(const Tile* tile, MoveEvent_t eventType);
+	MoveEvent* getEvent(const std::shared_ptr<const Tile>& tile, MoveEvent_t eventType);
 
-	MoveEvent* getEvent(Item* item, MoveEvent_t eventType, slots_t slot);
+	MoveEvent* getEvent(const std::shared_ptr<Item>& item, MoveEvent_t eventType, slots_t slot);
 
 	MoveListMap uniqueIdMap;
 	MoveListMap actionIdMap;
@@ -110,10 +112,12 @@ private:
 	LuaScriptInterface scriptInterface;
 };
 
-using StepFunction = std::function<uint32_t(Creature* creature, Item* item, const Position& pos)>;
-using MoveFunction = std::function<uint32_t(Item* item, Item* tileItem, const Position& pos)>;
-using EquipFunction =
-    std::function<ReturnValue(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool boolean)>;
+using StepFunction = std::function<uint32_t(const std::shared_ptr<Creature>& creature,
+                                            const std::shared_ptr<Item>& item, const Position& pos)>;
+using MoveFunction = std::function<uint32_t(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+                                            const Position& pos)>;
+using EquipFunction = std::function<ReturnValue(MoveEvent* moveEvent, const std::shared_ptr<Player>& player,
+                                                const std::shared_ptr<Item>& item, slots_t slot, bool boolean)>;
 
 class MoveEvent final : public Event
 {
@@ -126,16 +130,21 @@ public:
 	bool configureEvent(const pugi::xml_node& node) override;
 	bool loadFunction(const pugi::xml_attribute& attr, bool isScripted) override;
 
-	uint32_t fireStepEvent(Creature* creature, Item* item, const Position& pos);
-	uint32_t fireAddRemItem(Item* item, Item* tileItem, const Position& pos);
-	ReturnValue fireEquip(Player* player, Item* item, slots_t slot, bool isCheck);
+	uint32_t fireStepEvent(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
+	                       const Position& pos);
+	uint32_t fireAddRemItem(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+	                        const Position& pos);
+	ReturnValue fireEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+	                      bool isCheck);
 
 	uint32_t getSlot() const { return slot; }
 
 	// scripting
-	bool executeStep(Creature* creature, Item* item, const Position& pos);
-	bool executeEquip(Player* player, Item* item, slots_t slot, bool isCheck);
-	bool executeAddRemItem(Item* item, Item* tileItem, const Position& pos);
+	bool executeStep(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item, const Position& pos);
+	bool executeEquip(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
+	                  bool isCheck);
+	bool executeAddRemItem(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+	                       const Position& pos);
 	//
 
 	// onEquip information
@@ -170,14 +179,20 @@ public:
 	uint32_t getWieldInfo() { return wieldInfo; }
 	void setWieldInfo(WieldInfo_t info) { wieldInfo |= info; }
 
-	static uint32_t StepInField(Creature* creature, Item* item, const Position& pos);
-	static uint32_t StepOutField(Creature* creature, Item* item, const Position& pos);
+	static uint32_t StepInField(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
+	                            const Position& pos);
+	static uint32_t StepOutField(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
+	                             const Position& pos);
 
-	static uint32_t AddItemField(Item* item, Item* tileItem, const Position& pos);
-	static uint32_t RemoveItemField(Item* item, Item* tileItem, const Position& pos);
+	static uint32_t AddItemField(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+	                             const Position& pos);
+	static uint32_t RemoveItemField(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>& tileItem,
+	                                const Position& pos);
 
-	static ReturnValue EquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool isCheck);
-	static ReturnValue DeEquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool);
+	static ReturnValue EquipItem(MoveEvent* moveEvent, const std::shared_ptr<Player>& player,
+	                             const std::shared_ptr<Item>& item, slots_t slot, bool isCheck);
+	static ReturnValue DeEquipItem(MoveEvent* moveEvent, const std::shared_ptr<Player>& player,
+	                               const std::shared_ptr<Item>& item, slots_t slot, bool);
 
 	MoveEvent_t eventType = MOVE_EVENT_NONE;
 	StepFunction stepFunction;

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -116,7 +116,7 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count)
 	}
 }
 
-void NetworkMessage::addItem(const Item* item)
+void NetworkMessage::addItem(const std::shared_ptr<const Item>& item)
 {
 	const ItemType& it = Item::items[item->getID()];
 
@@ -141,7 +141,7 @@ void NetworkMessage::addItem(const Item* item)
 	if (it.isContainer()) {
 		addByte(0x00); // assigned loot container icon
 		// quiver ammo count
-		const Container* container = item->getContainer();
+		const auto& container = item->getContainer();
 		if (container && it.weaponType == WEAPON_QUIVER) {
 			addByte(0x01);
 			add<uint32_t>(container->getAmmoCount());
@@ -152,7 +152,7 @@ void NetworkMessage::addItem(const Item* item)
 
 	// display outfit on the podium
 	if (it.isPodium()) {
-		const Podium* podium = item->getPodium();
+		const auto& podium = item->getPodium();
 		const Outfit_t& outfit = podium->getOutfit();
 
 		// add outfit

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -112,7 +112,7 @@ public:
 	// write functions for complex types
 	void addPosition(const Position& pos);
 	void addItem(uint16_t id, uint8_t count);
-	void addItem(const Item* item);
+	void addItem(const std::shared_ptr<const Item>& item);
 	void addItemId(uint16_t itemId);
 
 	MsgSize_t getLength() const { return info.length; }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -15,23 +15,22 @@ uint32_t Npc::npcAutoID = 0x20000000;
 
 void Npcs::reload()
 {
-	const std::map<uint32_t, Npc*>& npcs = g_game.getNpcs();
-	for (auto&& npc : npcs | std::views::values | std::views::as_const) {
+	for (auto&& npc : g_game.getNpcs() | tfs::views::lock_weak_ptrs | std::views::as_const) {
 		npc->closeAllShopWindows();
 	}
 
-	for (auto&& npc : npcs | std::views::values | std::views::as_const) {
+	for (auto&& npc : g_game.getNpcs() | tfs::views::lock_weak_ptrs | std::views::as_const) {
 		npc->reload();
 	}
 }
 
-Npc* Npc::createNpc(const std::string& name)
+std::shared_ptr<Npc> Npc::createNpc(const std::string& name)
 {
-	std::unique_ptr<Npc> npc(new Npc(name));
+	const auto npc = std::make_shared<Npc>(name);
 	if (!npc->load()) {
 		return nullptr;
 	}
-	return npc.release();
+	return npc;
 }
 
 Npc::Npc(const std::string& name) : Creature(), filename("data/npc/" + name + ".xml"), masterRadius(-1), loaded(false)
@@ -39,11 +38,9 @@ Npc::Npc(const std::string& name) : Creature(), filename("data/npc/" + name + ".
 	reset();
 }
 
-Npc::~Npc() { reset(); }
+void Npc::addList() { g_game.addNpc(getNpc()); }
 
-void Npc::addList() { g_game.addNpc(this); }
-
-void Npc::removeList() { g_game.removeNpc(this); }
+void Npc::removeList() { g_game.removeNpc(getNpc()); }
 
 bool Npc::load()
 {
@@ -84,8 +81,8 @@ void Npc::reload()
 	SpectatorVec players;
 	g_game.map.getSpectators(players, getPosition(), true, true);
 	for (const auto& player : players) {
-		assert(dynamic_cast<Player*>(player) != nullptr);
-		spectators.insert(static_cast<Player*>(player));
+		assert(player->getPlayer() != nullptr);
+		spectators.insert(std::static_pointer_cast<Player>(player));
 	}
 
 	const bool hasSpectators = !spectators.empty();
@@ -97,7 +94,7 @@ void Npc::reload()
 
 	// Simulate that the creature is placed on the map again.
 	if (npcEventHandler) {
-		npcEventHandler->onCreatureAppear(this);
+		npcEventHandler->onCreatureAppear(getNpc());
 	}
 }
 
@@ -196,7 +193,7 @@ bool Npc::loadFromXml()
 
 	pugi::xml_attribute scriptFile = npcNode.attribute("script");
 	if (scriptFile) {
-		auto handler = std::make_unique<NpcEventsHandler>(scriptFile.as_string(), this);
+		auto handler = std::make_unique<NpcEventsHandler>(scriptFile.as_string(), getNpc());
 		if (!handler->isLoaded()) {
 			return false;
 		}
@@ -224,25 +221,23 @@ std::string Npc::getDescription(int32_t) const
 
 void Npc::goToFollowCreature()
 {
-	if (!followCreature) {
-		return;
+	if (const auto& followCreature = getFollowCreature()) {
+		FindPathParams fpp;
+		getPathSearchParams(followCreature, fpp);
+		updateFollowCreaturePath(fpp);
 	}
-
-	FindPathParams fpp;
-	getPathSearchParams(followCreature, fpp);
-	updateFollowCreaturePath(fpp);
 }
 
-void Npc::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
+void Npc::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, MagicEffectClasses)
 {
-	if (creature == this) {
+	if (creature.get() == this) {
 		setLastPosition(getPosition());
 
 		SpectatorVec players;
 		g_game.map.getSpectators(players, getPosition(), true, true);
 		for (const auto& player : players) {
-			assert(dynamic_cast<Player*>(player) != nullptr);
-			spectators.insert(static_cast<Player*>(player));
+			assert(player->getPlayer() != nullptr);
+			spectators.insert(std::static_pointer_cast<Player>(player));
 		}
 
 		const bool hasSpectators = !spectators.empty();
@@ -255,7 +250,7 @@ void Npc::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureAppear(creature);
 		}
-	} else if (Player* player = creature->getPlayer()) {
+	} else if (const auto& player = creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureAppear(creature);
 		}
@@ -265,16 +260,16 @@ void Npc::onCreatureAppear(Creature* creature, bool, MagicEffectClasses)
 	}
 }
 
-void Npc::onRemoveCreature(Creature* creature, bool isLogout)
+void Npc::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
-	if (creature == this) {
+	if (creature.get() == this) {
 		closeAllShopWindows();
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureDisappear(creature);
 		}
-	} else if (Player* player = creature->getPlayer()) {
+	} else if (const auto& player = creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureDisappear(creature);
 		}
@@ -284,18 +279,19 @@ void Npc::onRemoveCreature(Creature* creature, bool isLogout)
 	}
 }
 
-void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
-                         const Position& oldPos, bool teleport)
+void Npc::onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+                         const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
+                         bool teleport)
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
-	if (creature == this || creature->getPlayer()) {
+	if (creature.get() == this || creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureMove(creature, oldPos, newPos);
 		}
 
-		if (creature != this) {
-			Player* player = creature->getPlayer();
+		if (creature.get() != this) {
+			const auto& player = creature->getPlayer();
 
 			// if player is now in range, add to spectators list, otherwise erase
 			if (player->canSee(position)) {
@@ -309,22 +305,21 @@ void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position
 	}
 }
 
-void Npc::onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text)
+void Npc::onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type, const std::string& text)
 {
-	if (creature == this) {
+	if (creature.get() == this) {
 		return;
 	}
 
 	// only players for script events
-	Player* player = creature->getPlayer();
-	if (player) {
+	if (const auto& player = creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureSay(player, type, text);
 		}
 	}
 }
 
-void Npc::onPlayerCloseChannel(Player* player)
+void Npc::onPlayerCloseChannel(const std::shared_ptr<Player>& player)
 {
 	if (npcEventHandler) {
 		npcEventHandler->onPlayerCloseChannel(player);
@@ -344,18 +339,18 @@ void Npc::onThink(uint32_t interval)
 	}
 }
 
-void Npc::doSay(const std::string& text) { g_game.internalCreatureSay(this, TALKTYPE_SAY, text, false); }
+void Npc::doSay(const std::string& text) { g_game.internalCreatureSay(getNpc(), TALKTYPE_SAY, text, false); }
 
-void Npc::doSayToPlayer(Player* player, const std::string& text)
+void Npc::doSayToPlayer(const std::shared_ptr<Player>& player, const std::string& text)
 {
 	if (player) {
-		player->sendCreatureSay(this, TALKTYPE_PRIVATE_NP, text);
-		player->onCreatureSay(this, TALKTYPE_PRIVATE_NP, text);
+		player->sendCreatureSay(getNpc(), TALKTYPE_PRIVATE_NP, text);
+		player->onCreatureSay(getNpc(), TALKTYPE_PRIVATE_NP, text);
 	}
 }
 
-void Npc::onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8_t count, uint16_t amount,
-                        bool ignore /* = false*/, bool inBackpacks /* = false*/)
+void Npc::onPlayerTrade(const std::shared_ptr<Player>& player, int32_t callback, uint16_t itemId, uint8_t count,
+                        uint16_t amount, bool ignore /* = false*/, bool inBackpacks /* = false*/)
 {
 	if (npcEventHandler) {
 		npcEventHandler->onPlayerTrade(player, callback, itemId, count, amount, ignore, inBackpacks);
@@ -363,7 +358,7 @@ void Npc::onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8
 	player->sendSaleItemList();
 }
 
-void Npc::onPlayerEndTrade(Player* player, int32_t buyCallback, int32_t sellCallback)
+void Npc::onPlayerEndTrade(const std::shared_ptr<Player>& player, int32_t buyCallback, int32_t sellCallback)
 {
 	lua_State* L = getScriptInterface()->getLuaState();
 
@@ -431,8 +426,8 @@ bool Npc::canWalkTo(const Position& fromPos, Direction dir) const
 		return false;
 	}
 
-	Tile* tile = g_game.map.getTile(toPos);
-	if (!tile || tile->queryAdd(0, *this, 1, 0) != RETURNVALUE_NOERROR) {
+	const auto& tile = g_game.map.getTile(toPos);
+	if (!tile || tile->queryAdd(0, getNpc(), 1, 0) != RETURNVALUE_NOERROR) {
 		return false;
 	}
 
@@ -470,7 +465,7 @@ bool Npc::doMoveTo(const Position& pos, int32_t minTargetDist /* = 1*/, int32_t 
 	return false;
 }
 
-void Npc::turnToCreature(Creature* creature)
+void Npc::turnToCreature(const std::shared_ptr<Creature>& creature)
 {
 	const Position& creaturePos = creature->getPosition();
 	const Position& myPos = getPosition();
@@ -498,10 +493,10 @@ void Npc::turnToCreature(Creature* creature)
 			dir = DIRECTION_SOUTH;
 		}
 	}
-	g_game.internalCreatureTurn(this, dir);
+	g_game.internalCreatureTurn(getNpc(), dir);
 }
 
-void Npc::setCreatureFocus(Creature* creature)
+void Npc::setCreatureFocus(const std::shared_ptr<Creature>& creature)
 {
 	if (creature) {
 		focusCreature = creature->getID();
@@ -511,14 +506,14 @@ void Npc::setCreatureFocus(Creature* creature)
 	}
 }
 
-void Npc::addShopPlayer(Player* player) { shopPlayerSet.insert(player); }
+void Npc::addShopPlayer(const std::shared_ptr<Player>& player) { shopPlayerSet.insert(player); }
 
-void Npc::removeShopPlayer(Player* player) { shopPlayerSet.erase(player); }
+void Npc::removeShopPlayer(const std::shared_ptr<Player>& player) { shopPlayerSet.erase(player); }
 
 void Npc::closeAllShopWindows()
 {
 	while (!shopPlayerSet.empty()) {
-		Player* player = *shopPlayerSet.begin();
+		const auto player = *shopPlayerSet.begin();
 		if (!player->closeShopWindow()) {
 			removeShopPlayer(player);
 		}
@@ -595,15 +590,14 @@ void NpcScriptInterface::registerFunctions()
 int NpcScriptInterface::luaActionSay(lua_State* L)
 {
 	// selfSay(words[, target])
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (!npc) {
 		return 0;
 	}
 
 	const std::string& text = tfs::lua::getString(L, 1);
 	if (lua_gettop(L) >= 2) {
-		Player* target = tfs::lua::getPlayer(L, 2);
-		if (target) {
+		if (const auto& target = tfs::lua::getPlayer(L, 2)) {
 			npc->doSayToPlayer(target, text);
 			return 0;
 		}
@@ -616,8 +610,7 @@ int NpcScriptInterface::luaActionSay(lua_State* L)
 int NpcScriptInterface::luaActionMove(lua_State* L)
 {
 	// selfMove(direction)
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
-	if (npc) {
+	if (const auto& npc = tfs::lua::getScriptEnv()->getNpc()) {
 		g_game.internalMoveCreature(npc, tfs::lua::getNumber<Direction>(L, 1));
 	}
 	return 0;
@@ -628,7 +621,7 @@ int NpcScriptInterface::luaActionMoveTo(lua_State* L)
 	// selfMoveTo(x, y, z[, minTargetDist = 1[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[,
 	// maxSearchDist = 0]]]]]) selfMoveTo(position[, minTargetDist = 1[, maxTargetDist = 1[, fullPathSearch = true[,
 	// clearSight = true[, maxSearchDist = 0]]]]])
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (!npc) {
 		return 0;
 	}
@@ -655,7 +648,7 @@ int NpcScriptInterface::luaActionMoveTo(lua_State* L)
 int NpcScriptInterface::luaActionTurn(lua_State* L)
 {
 	// selfTurn(direction)
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (npc) {
 		g_game.internalCreatureTurn(npc, tfs::lua::getNumber<Direction>(L, 1));
 	}
@@ -665,13 +658,13 @@ int NpcScriptInterface::luaActionTurn(lua_State* L)
 int NpcScriptInterface::luaActionFollow(lua_State* L)
 {
 	// selfFollow(player)
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (!npc) {
 		tfs::lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	auto followedPlayer = tfs::lua::getPlayer(L, 1);
+	const auto& followedPlayer = tfs::lua::getPlayer(L, 1);
 	if (followedPlayer) {
 		npc->setFollowCreature(followedPlayer);
 		tfs::lua::pushBoolean(L, npc->canFollowCreature(followedPlayer));
@@ -687,7 +680,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 	// getDistanceTo(uid)
 	ScriptEnvironment* env = tfs::lua::getScriptEnv();
 
-	Npc* npc = env->getNpc();
+	const auto& npc = env->getNpc();
 	if (!npc) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_THING_NOT_FOUND));
 		lua_pushnil(L);
@@ -696,7 +689,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 
 	uint32_t uid = tfs::lua::getNumber<uint32_t>(L, -1);
 
-	Thing* thing = env->getThingByUID(uid);
+	const auto& thing = env->getThingByUID(uid);
 	if (!thing) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_THING_NOT_FOUND));
 		lua_pushnil(L);
@@ -716,8 +709,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 int NpcScriptInterface::luaSetNpcFocus(lua_State* L)
 {
 	// doNpcSetCreatureFocus(cid)
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
-	if (npc) {
+	if (const auto& npc = tfs::lua::getScriptEnv()->getNpc()) {
 		npc->setCreatureFocus(tfs::lua::getCreature(L, -1));
 	}
 	return 0;
@@ -726,8 +718,7 @@ int NpcScriptInterface::luaSetNpcFocus(lua_State* L)
 int NpcScriptInterface::luaGetNpcCid(lua_State* L)
 {
 	// getNpcCid()
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
-	if (npc) {
+	if (const auto& npc = tfs::lua::getScriptEnv()->getNpc()) {
 		tfs::lua::pushNumber(L, npc->getID());
 	} else {
 		lua_pushnil(L);
@@ -738,7 +729,7 @@ int NpcScriptInterface::luaGetNpcCid(lua_State* L)
 int NpcScriptInterface::luaGetNpcParameter(lua_State* L)
 {
 	// getNpcParameter(paramKey)
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
@@ -802,7 +793,7 @@ int NpcScriptInterface::luaOpenShopWindow(lua_State* L)
 	}
 	lua_pop(L, 1);
 
-	Player* player = tfs::lua::getPlayer(L, -1);
+	const auto& player = tfs::lua::getPlayer(L, -1);
 	if (!player) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
@@ -812,7 +803,7 @@ int NpcScriptInterface::luaOpenShopWindow(lua_State* L)
 	// Close any eventual other shop window currently open.
 	player->closeShopWindow(false);
 
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (!npc) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
@@ -830,14 +821,14 @@ int NpcScriptInterface::luaOpenShopWindow(lua_State* L)
 int NpcScriptInterface::luaCloseShopWindow(lua_State* L)
 {
 	// closeShopWindow(cid)
-	Npc* npc = tfs::lua::getScriptEnv()->getNpc();
+	const auto& npc = tfs::lua::getScriptEnv()->getNpc();
 	if (!npc) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	Player* player = tfs::lua::getPlayer(L, 1);
+	const auto& player = tfs::lua::getPlayer(L, 1);
 	if (!player) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
@@ -847,10 +838,8 @@ int NpcScriptInterface::luaCloseShopWindow(lua_State* L)
 	int32_t buyCallback;
 	int32_t sellCallback;
 
-	Npc* merchant = player->getShopOwner(buyCallback, sellCallback);
-
 	// Check if we actually have a shop window with this player.
-	if (merchant == npc) {
+	if (const auto& merchant = player->getShopOwner(buyCallback, sellCallback); merchant == npc) {
 		player->sendCloseShop();
 
 		if (buyCallback != -1) {
@@ -872,7 +861,7 @@ int NpcScriptInterface::luaCloseShopWindow(lua_State* L)
 int NpcScriptInterface::luaDoSellItem(lua_State* L)
 {
 	// doSellItem(cid, itemid, amount, <optional> subtype, <optional> actionid, <optional: default: 1> canDropOnMap)
-	Player* player = tfs::lua::getPlayer(L, 1);
+	const auto& player = tfs::lua::getPlayer(L, 1);
 	if (!player) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
@@ -899,13 +888,12 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 	if (it.stackable) {
 		while (amount > 0) {
 			int32_t stackCount = std::min<int32_t>(ITEM_STACK_SIZE, amount);
-			Item* item = Item::CreateItem(it.id, stackCount);
+			const auto item = Item::CreateItem(it.id, stackCount);
 			if (item && actionId != 0) {
 				item->setActionId(actionId);
 			}
 
 			if (g_game.internalPlayerAddItem(player, item, canDropOnMap) != RETURNVALUE_NOERROR) {
-				delete item;
 				tfs::lua::pushNumber(L, sellCount);
 				return 1;
 			}
@@ -915,13 +903,12 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 		}
 	} else {
 		for (uint32_t i = 0; i < amount; ++i) {
-			Item* item = Item::CreateItem(it.id, subType);
+			const auto item = Item::CreateItem(it.id, subType);
 			if (item && actionId != 0) {
 				item->setActionId(actionId);
 			}
 
 			if (g_game.internalPlayerAddItem(player, item, canDropOnMap) != RETURNVALUE_NOERROR) {
-				delete item;
 				tfs::lua::pushNumber(L, sellCount);
 				return 1;
 			}
@@ -938,8 +925,7 @@ int NpcScriptInterface::luaNpcGetParameter(lua_State* L)
 {
 	// npc:getParameter(key)
 	const std::string& key = tfs::lua::getString(L, 2);
-	Npc* npc = tfs::lua::getUserdata<Npc>(L, 1);
-	if (npc) {
+	if (const auto& npc = tfs::lua::getSharedPtr<Npc>(L, 1)) {
 		auto it = npc->parameters.find(key);
 		if (it != npc->parameters.end()) {
 			tfs::lua::pushString(L, it->second);
@@ -955,9 +941,8 @@ int NpcScriptInterface::luaNpcGetParameter(lua_State* L)
 int NpcScriptInterface::luaNpcSetFocus(lua_State* L)
 {
 	// npc:setFocus(creature)
-	Creature* creature = tfs::lua::getCreature(L, 2);
-	Npc* npc = tfs::lua::getUserdata<Npc>(L, 1);
-	if (npc) {
+	const auto& creature = tfs::lua::getCreature(L, 2);
+	if (const auto& npc = tfs::lua::getSharedPtr<Npc>(L, 1)) {
 		npc->setCreatureFocus(creature);
 		tfs::lua::pushBoolean(L, true);
 	} else {
@@ -975,14 +960,14 @@ int NpcScriptInterface::luaNpcOpenShopWindow(lua_State* L)
 		return 1;
 	}
 
-	Player* player = tfs::lua::getPlayer(L, 2);
+	const auto& player = tfs::lua::getPlayer(L, 2);
 	if (!player) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	Npc* npc = tfs::lua::getUserdata<Npc>(L, 1);
+	const auto& npc = tfs::lua::getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
@@ -1035,14 +1020,14 @@ int NpcScriptInterface::luaNpcOpenShopWindow(lua_State* L)
 int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 {
 	// npc:closeShopWindow(player)
-	Player* player = tfs::lua::getPlayer(L, 2);
+	const auto& player = tfs::lua::getPlayer(L, 2);
 	if (!player) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
 		return 1;
 	}
 
-	Npc* npc = tfs::lua::getUserdata<Npc>(L, 1);
+	const auto& npc = tfs::lua::getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		tfs::lua::pushBoolean(L, false);
@@ -1052,8 +1037,7 @@ int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 	int32_t buyCallback;
 	int32_t sellCallback;
 
-	Npc* merchant = player->getShopOwner(buyCallback, sellCallback);
-	if (merchant == npc) {
+	if (const auto& merchant = player->getShopOwner(buyCallback, sellCallback); merchant == npc) {
 		player->sendCloseShop();
 		if (buyCallback != -1) {
 			luaL_unref(L, LUA_REGISTRYINDEX, buyCallback);
@@ -1071,8 +1055,8 @@ int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 	return 1;
 }
 
-NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc) :
-    scriptInterface(std::make_unique<NpcScriptInterface>()), npc(npc)
+NpcEventsHandler::NpcEventsHandler(const std::string& file, std::shared_ptr<Npc> npc) :
+    scriptInterface{std::make_unique<NpcScriptInterface>()}, npc{std::move(npc)}
 {
 	if (!scriptInterface->loadNpcLib("data/npc/lib/npc.lua")) {
 		std::cout << "[Warning - NpcLib::NpcLib] Can not load lib: " << file << std::endl;
@@ -1080,7 +1064,7 @@ NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc) :
 		return;
 	}
 
-	loaded = scriptInterface->loadFile("data/npc/scripts/" + file, npc) == 0;
+	loaded = scriptInterface->loadFile("data/npc/scripts/" + file, this->npc) == 0;
 	if (!loaded) {
 		std::cout << "[Warning - NpcScript::NpcScript] Can not load script: " << file << std::endl;
 		std::cout << scriptInterface->getLastLuaError() << std::endl;
@@ -1097,7 +1081,7 @@ NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc) :
 
 bool NpcEventsHandler::isLoaded() const { return loaded; }
 
-void NpcEventsHandler::onCreatureAppear(Creature* creature)
+void NpcEventsHandler::onCreatureAppear(const std::shared_ptr<Creature>& creature)
 {
 	if (creatureAppearEvent == -1) {
 		return;
@@ -1115,12 +1099,12 @@ void NpcEventsHandler::onCreatureAppear(Creature* creature)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureAppearEvent);
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 	scriptInterface->callFunction(1);
 }
 
-void NpcEventsHandler::onCreatureDisappear(Creature* creature)
+void NpcEventsHandler::onCreatureDisappear(const std::shared_ptr<Creature>& creature)
 {
 	if (creatureDisappearEvent == -1) {
 		return;
@@ -1138,12 +1122,13 @@ void NpcEventsHandler::onCreatureDisappear(Creature* creature)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureDisappearEvent);
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 	scriptInterface->callFunction(1);
 }
 
-void NpcEventsHandler::onCreatureMove(Creature* creature, const Position& oldPos, const Position& newPos)
+void NpcEventsHandler::onCreatureMove(const std::shared_ptr<Creature>& creature, const Position& oldPos,
+                                      const Position& newPos)
 {
 	if (creatureMoveEvent == -1) {
 		return;
@@ -1161,14 +1146,15 @@ void NpcEventsHandler::onCreatureMove(Creature* creature, const Position& oldPos
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureMoveEvent);
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 	tfs::lua::pushPosition(L, oldPos);
 	tfs::lua::pushPosition(L, newPos);
 	scriptInterface->callFunction(3);
 }
 
-void NpcEventsHandler::onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text)
+void NpcEventsHandler::onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type,
+                                     const std::string& text)
 {
 	if (creatureSayEvent == -1) {
 		return;
@@ -1186,15 +1172,15 @@ void NpcEventsHandler::onCreatureSay(Creature* creature, SpeakClasses type, cons
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureSayEvent);
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 	tfs::lua::pushNumber(L, type);
 	tfs::lua::pushString(L, text);
 	scriptInterface->callFunction(3);
 }
 
-void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8_t count, uint16_t amount,
-                                     bool ignore, bool inBackpacks)
+void NpcEventsHandler::onPlayerTrade(const std::shared_ptr<Player>& player, int32_t callback, uint16_t itemId,
+                                     uint8_t count, uint16_t amount, bool ignore, bool inBackpacks)
 {
 	if (callback == -1) {
 		return;
@@ -1212,7 +1198,7 @@ void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t 
 
 	lua_State* L = scriptInterface->getLuaState();
 	tfs::lua::pushCallback(L, callback);
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 	tfs::lua::pushNumber(L, itemId);
 	tfs::lua::pushNumber(L, count);
@@ -1222,7 +1208,7 @@ void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t 
 	scriptInterface->callFunction(6);
 }
 
-void NpcEventsHandler::onPlayerCloseChannel(Player* player)
+void NpcEventsHandler::onPlayerCloseChannel(const std::shared_ptr<Player>& player)
 {
 	if (playerCloseChannelEvent == -1) {
 		return;
@@ -1240,12 +1226,12 @@ void NpcEventsHandler::onPlayerCloseChannel(Player* player)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(playerCloseChannelEvent);
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 	scriptInterface->callFunction(1);
 }
 
-void NpcEventsHandler::onPlayerEndTrade(Player* player)
+void NpcEventsHandler::onPlayerEndTrade(const std::shared_ptr<Player>& player)
 {
 	if (playerEndTradeEvent == -1) {
 		return;
@@ -1263,7 +1249,7 @@ void NpcEventsHandler::onPlayerEndTrade(Player* player)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(playerEndTradeEvent);
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 	scriptInterface->callFunction(1);
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -56,16 +56,16 @@ private:
 class NpcEventsHandler
 {
 public:
-	NpcEventsHandler(const std::string& file, Npc* npc);
+	NpcEventsHandler(const std::string& file, std::shared_ptr<Npc> npc);
 
-	void onCreatureAppear(Creature* creature);
-	void onCreatureDisappear(Creature* creature);
-	void onCreatureMove(Creature* creature, const Position& oldPos, const Position& newPos);
-	void onCreatureSay(Creature* creature, SpeakClasses, const std::string& text);
-	void onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8_t count, uint16_t amount,
-	                   bool ignore = false, bool inBackpacks = false);
-	void onPlayerCloseChannel(Player* player);
-	void onPlayerEndTrade(Player* player);
+	void onCreatureAppear(const std::shared_ptr<Creature>& creature);
+	void onCreatureDisappear(const std::shared_ptr<Creature>& creature);
+	void onCreatureMove(const std::shared_ptr<Creature>& creature, const Position& oldPos, const Position& newPos);
+	void onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses, const std::string& text);
+	void onPlayerTrade(const std::shared_ptr<Player>& player, int32_t callback, uint16_t itemId, uint8_t count,
+	                   uint16_t amount, bool ignore = false, bool inBackpacks = false);
+	void onPlayerCloseChannel(const std::shared_ptr<Player>& player);
+	void onPlayerEndTrade(const std::shared_ptr<Player>& player);
 	void onThink();
 
 	bool isLoaded() const;
@@ -73,7 +73,7 @@ public:
 	std::unique_ptr<NpcScriptInterface> scriptInterface;
 
 private:
-	Npc* npc;
+	std::shared_ptr<Npc> npc;
 
 	int32_t creatureAppearEvent = -1;
 	int32_t creatureDisappearEvent = -1;
@@ -88,16 +88,18 @@ private:
 class Npc final : public Creature
 {
 public:
-	~Npc();
+	explicit Npc(const std::string& name);
+	~Npc() = default;
 
 	// non-copyable
 	Npc(const Npc&) = delete;
 	Npc& operator=(const Npc&) = delete;
 
-	using Creature::onWalk;
-
-	Npc* getNpc() override { return this; }
-	const Npc* getNpc() const override { return this; }
+	std::shared_ptr<Npc> getNpc() override { return std::static_pointer_cast<Npc>(shared_from_this()); }
+	std::shared_ptr<const Npc> getNpc() const override
+	{
+		return std::static_pointer_cast<const Npc>(shared_from_this());
+	}
 
 	bool isPushable() const override { return pushable && walkTicks != 0; }
 
@@ -111,7 +113,7 @@ public:
 	void removeList() override;
 	void addList() override;
 
-	static Npc* createNpc(const std::string& name);
+	static std::shared_ptr<Npc> createNpc(const std::string& name);
 
 	bool canSee(const Position& pos) const override;
 
@@ -127,7 +129,7 @@ public:
 	void setSpeechBubble(const uint8_t bubble) { speechBubble = bubble; }
 
 	void doSay(const std::string& text);
-	void doSayToPlayer(Player* player, const std::string& text);
+	void doSayToPlayer(const std::shared_ptr<Player>& player, const std::string& text);
 
 	bool doMoveTo(const Position& pos, int32_t minTargetDist = 1, int32_t maxTargetDist = 1, bool fullPathSearch = true,
 	              bool clearSight = true, int32_t maxSearchDist = 0);
@@ -142,13 +144,13 @@ public:
 		}
 	}
 
-	void onPlayerCloseChannel(Player* player);
-	void onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8_t count, uint16_t amount,
-	                   bool ignore = false, bool inBackpacks = false);
-	void onPlayerEndTrade(Player* player, int32_t buyCallback, int32_t sellCallback);
+	void onPlayerCloseChannel(const std::shared_ptr<Player>& player);
+	void onPlayerTrade(const std::shared_ptr<Player>& player, int32_t callback, uint16_t itemId, uint8_t count,
+	                   uint16_t amount, bool ignore = false, bool inBackpacks = false);
+	void onPlayerEndTrade(const std::shared_ptr<Player>& player, int32_t buyCallback, int32_t sellCallback);
 
-	void turnToCreature(Creature* creature);
-	void setCreatureFocus(Creature* creature);
+	void turnToCreature(const std::shared_ptr<Creature>& creature);
+	void setCreatureFocus(const std::shared_ptr<Creature>& creature);
 
 	auto& getScriptInterface() { return npcEventHandler->scriptInterface; }
 
@@ -159,14 +161,14 @@ public:
 	void goToFollowCreature() override;
 
 private:
-	explicit Npc(const std::string& name);
+	void onCreatureAppear(const std::shared_ptr<Creature>& creature, bool isLogin,
+	                      MagicEffectClasses magicEffect) override;
+	void onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout) override;
+	void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+	                    const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
+	                    bool teleport) override;
 
-	void onCreatureAppear(Creature* creature, bool, MagicEffectClasses) override;
-	void onRemoveCreature(Creature* creature, bool isLogout) override;
-	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
-	                    const Position& oldPos, bool teleport) override;
-
-	void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) override;
+	void onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type, const std::string& text) override;
 	void onThink(uint32_t interval) override;
 	std::string getDescription(int32_t lookDistance) const override;
 
@@ -183,14 +185,14 @@ private:
 	void reset();
 	bool loadFromXml();
 
-	void addShopPlayer(Player* player);
-	void removeShopPlayer(Player* player);
+	void addShopPlayer(const std::shared_ptr<Player>& player);
+	void removeShopPlayer(const std::shared_ptr<Player>& player);
 	void closeAllShopWindows();
 
 	std::map<std::string, std::string> parameters;
 
-	std::set<Player*> shopPlayerSet;
-	std::set<Player*> spectators;
+	std::set<std::shared_ptr<Player>> shopPlayerSet;
+	std::set<std::shared_ptr<Player>> spectators;
 
 	std::string name;
 	std::string filename;

--- a/src/party.cpp
+++ b/src/party.cpp
@@ -11,7 +11,7 @@
 
 extern Game g_game;
 
-Party::Party(Player* leader) : leader(leader) { leader->setParty(this); }
+Party::Party(const std::shared_ptr<Player>& leader) : leader{leader} { leader->setParty(this); }
 
 void Party::disband()
 {
@@ -19,8 +19,8 @@ void Party::disband()
 		return;
 	}
 
-	Player* currentLeader = leader;
-	leader = nullptr;
+	const auto currentLeader = leader.lock();
+	leader.reset();
 
 	currentLeader->setParty(nullptr);
 	currentLeader->sendClosePrivate(CHANNEL_PARTY);
@@ -28,22 +28,22 @@ void Party::disband()
 	currentLeader->sendCreatureSkull(currentLeader);
 	currentLeader->sendTextMessage(MESSAGE_INFO_DESCR, "Your party has been disbanded.");
 
-	for (Player* invitee : inviteList) {
+	for (const auto& invitee : inviteList | tfs::views::lock_weak_ptrs) {
 		invitee->removePartyInvitation(this);
 		currentLeader->sendCreatureShield(invitee);
 	}
 	inviteList.clear();
 
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		member->setParty(nullptr);
 		member->sendClosePrivate(CHANNEL_PARTY);
 		member->sendTextMessage(MESSAGE_INFO_DESCR, "Your party has been disbanded.");
 	}
 
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		g_game.updatePlayerShield(member);
 
-		for (Player* otherMember : memberList) {
+		for (const auto& otherMember : memberList | tfs::views::lock_weak_ptrs) {
 			otherMember->sendCreatureSkull(member);
 		}
 
@@ -54,13 +54,13 @@ void Party::disband()
 	delete this;
 }
 
-bool Party::leaveParty(Player* player, bool forceRemove /* = false */)
+bool Party::leaveParty(const std::shared_ptr<Player>& player, bool forceRemove /* = false */)
 {
 	if (!player) {
 		return false;
 	}
 
-	if (player->getParty() != this && leader != player) {
+	if (player->getParty() != this && !tfs::owner_equal(leader, player)) {
 		return false;
 	}
 
@@ -70,12 +70,12 @@ bool Party::leaveParty(Player* player, bool forceRemove /* = false */)
 	}
 
 	bool missingLeader = false;
-	if (leader == player) {
+	if (tfs::owner_equal(leader, player)) {
 		if (!memberList.empty()) {
 			if (memberList.size() == 1 && inviteList.empty()) {
 				missingLeader = true;
 			} else {
-				passPartyLeadership(*memberList.begin(), true);
+				passPartyLeadership(memberList.begin()->lock(), true);
 			}
 		} else {
 			missingLeader = true;
@@ -83,26 +83,24 @@ bool Party::leaveParty(Player* player, bool forceRemove /* = false */)
 	}
 
 	// since we already passed the leadership, we remove the player from the list
-	auto it = std::find(memberList.begin(), memberList.end(), player);
-	if (it != memberList.end()) {
-		memberList.erase(it);
-	}
+	memberList.erase(player);
 
 	player->setParty(nullptr);
 	player->sendClosePrivate(CHANNEL_PARTY);
 	g_game.updatePlayerShield(player);
 
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		member->sendCreatureSkull(player);
 		player->sendPlayerPartyIcons(member);
 	}
 
+	const auto& leader = getLeader();
 	leader->sendCreatureSkull(player);
 	player->sendCreatureSkull(player);
 	player->sendPlayerPartyIcons(leader);
 
 	// remove pending invitation icons from the screen
-	for (Player* invitee : inviteList) {
+	for (const auto& invitee : inviteList | tfs::views::lock_weak_ptrs) {
 		player->sendCreatureShield(invitee);
 	}
 
@@ -121,9 +119,9 @@ bool Party::leaveParty(Player* player, bool forceRemove /* = false */)
 	return true;
 }
 
-bool Party::passPartyLeadership(Player* player, bool forceRemove /* = false*/)
+bool Party::passPartyLeadership(const std::shared_ptr<Player>& player, bool forceRemove /* = false*/)
 {
-	if (!player || leader == player || player->getParty() != this) {
+	if (!player || getLeader() == player || player->getParty() != this) {
 		return false;
 	}
 
@@ -132,104 +130,101 @@ bool Party::passPartyLeadership(Player* player, bool forceRemove /* = false*/)
 	}
 
 	// Remove it before to broadcast the message correctly
-	auto it = std::find(memberList.begin(), memberList.end(), player);
-	if (it != memberList.end()) {
-		memberList.erase(it);
-	}
+	memberList.erase(player);
 
 	broadcastPartyMessage(MESSAGE_INFO_DESCR, std::format("{:s} is now the leader of the party.", player->getName()),
 	                      true);
 
-	Player* oldLeader = leader;
+	const auto oldLeader = getLeader();
 	leader = player;
 
-	memberList.insert(memberList.begin(), oldLeader);
+	memberList.emplace(oldLeader);
 
 	updateSharedExperience();
 
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		member->sendCreatureShield(oldLeader);
-		member->sendCreatureShield(leader);
+		member->sendCreatureShield(player);
 	}
 
-	for (Player* invitee : inviteList) {
+	for (const auto& invitee : inviteList | tfs::views::lock_weak_ptrs) {
 		invitee->sendCreatureShield(oldLeader);
-		invitee->sendCreatureShield(leader);
+		invitee->sendCreatureShield(player);
 	}
 
-	leader->sendCreatureShield(oldLeader);
-	leader->sendCreatureShield(leader);
+	player->sendCreatureShield(oldLeader);
+	player->sendCreatureShield(player);
 
 	player->sendTextMessage(MESSAGE_INFO_DESCR, "You are now the leader of the party.");
 	return true;
 }
 
-bool Party::joinParty(Player& player)
+bool Party::joinParty(const std::shared_ptr<Player>& player)
 {
 	// check if lua scripts allow the player to join
-	if (!tfs::events::party::onJoin(this, &player)) {
+	if (!tfs::events::party::onJoin(this, player)) {
 		return false;
 	}
 
 	// first player accepted the invitation the party gets officially formed the leader can no longer take invitations
 	// from others
+	const auto& leader = getLeader();
 	if (memberList.empty()) {
 		leader->clearPartyInvitations();
 	}
 
 	// add player to the party
-	memberList.insert(&player);
-	player.setParty(this);
-	broadcastPartyMessage(MESSAGE_INFO_DESCR, std::format("{:s} has joined the party.", player.getName()));
+	memberList.emplace(player);
+	player->setParty(this);
+	broadcastPartyMessage(MESSAGE_INFO_DESCR, std::format("{:s} has joined the party.", player->getName()));
 
 	// remove player pending invitations to this and other parties
-	player.clearPartyInvitations();
+	player->clearPartyInvitations();
 
 	// update player icon on the screen
-	g_game.updatePlayerShield(&player);
+	g_game.updatePlayerShield(player);
 
 	// update player-member party icons
-	for (Player* member : memberList) {
-		member->sendCreatureSkull(&player);
-		player.sendPlayerPartyIcons(member);
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
+		member->sendCreatureSkull(player);
+		player->sendPlayerPartyIcons(member);
 	}
 
 	// update player-leader party icons
-	leader->sendCreatureSkull(&player);
-	player.sendPlayerPartyIcons(leader);
+	leader->sendCreatureSkull(player);
+	player->sendPlayerPartyIcons(leader);
 	// update player own skull
-	player.sendCreatureSkull(&player);
+	player->sendCreatureSkull(player);
 
 	// show the new member who else is invited
-	for (Player* invitee : inviteList) {
-		player.sendCreatureShield(invitee);
+	for (const auto& invitee : inviteList | tfs::views::lock_weak_ptrs) {
+		player->sendCreatureShield(invitee);
 	}
 
 	// check the party eligibility for shared experience
 	updateSharedExperience();
 
 	const std::string& leaderName = leader->getName();
-	player.sendTextMessage(
+	player->sendTextMessage(
 	    MESSAGE_INFO_DESCR,
 	    std::format("You have joined {:s}'{:s} party. Open the party channel to communicate with your companions.",
 	                leaderName, leaderName.back() == 's' ? "" : "s"));
 	return true;
 }
 
-bool Party::removeInvite(Player& player, bool removeFromPlayer /* = true*/)
+bool Party::removeInvite(const std::shared_ptr<Player>& player, bool removeFromPlayer /* = true*/)
 {
-	auto it = std::find(inviteList.begin(), inviteList.end(), &player);
-	if (it == inviteList.end()) {
+	const auto erased = inviteList.erase(player);
+	if (erased == 0) {
 		return false;
 	}
 
-	inviteList.erase(it);
-
-	leader->sendCreatureShield(&player);
-	player.sendCreatureShield(leader);
+	const auto& leader = getLeader();
+	leader->sendCreatureShield(player);
+	player->sendCreatureShield(leader);
 
 	if (removeFromPlayer) {
-		player.removePartyInvitation(this);
+		player->removePartyInvitation(this);
 	}
 
 	if (empty()) {
@@ -239,62 +234,68 @@ bool Party::removeInvite(Player& player, bool removeFromPlayer /* = true*/)
 	return true;
 }
 
-void Party::revokeInvitation(Player& player)
+void Party::revokeInvitation(const std::shared_ptr<Player>& player)
 {
-	if (!tfs::events::party::onRevokeInvitation(this, &player)) {
+	if (!tfs::events::party::onRevokeInvitation(this, player)) {
 		return;
 	}
 
-	player.sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has revoked {:s} invitation.", leader->getName(),
-	                                                       leader->getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
-	leader->sendTextMessage(MESSAGE_INFO_DESCR, std::format("Invitation for {:s} has been revoked.", player.getName()));
+	const auto& leader = getLeader();
+	player->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has revoked {:s} invitation.", leader->getName(),
+	                                                        leader->getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
+	leader->sendTextMessage(MESSAGE_INFO_DESCR,
+	                        std::format("Invitation for {:s} has been revoked.", player->getName()));
 	removeInvite(player);
 }
 
-bool Party::invitePlayer(Player& player)
+bool Party::invitePlayer(const std::shared_ptr<Player>& player)
 {
-	if (isPlayerInvited(&player)) {
+	if (isPlayerInvited(player)) {
 		return false;
 	}
 
+	const auto& leader = getLeader();
 	if (empty()) {
 		leader->sendTextMessage(
 		    MESSAGE_INFO_DESCR,
 		    std::format("{:s} has been invited. Open the party channel to communicate with your members.",
-		                player.getName()));
+		                player->getName()));
 		g_game.updatePlayerShield(leader);
 		leader->sendCreatureSkull(leader);
 	} else {
-		leader->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been invited.", player.getName()));
+		leader->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been invited.", player->getName()));
 	}
 
 	// add player to invite lists
-	inviteList.insert(&player);
-	player.addPartyInvitation(this);
+	inviteList.emplace(player);
+	player->addPartyInvitation(this);
 
 	// update leader-invitee party status
-	leader->sendCreatureShield(&player);
-	player.sendCreatureShield(leader);
+	leader->sendCreatureShield(player);
+	player->sendCreatureShield(leader);
 
 	// update the invitation status for other members
-	for (Player* member : memberList) {
-		member->sendCreatureShield(&player);
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
+		member->sendCreatureShield(player);
 	}
 
-	player.sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has invited you to {:s} party.", leader->getName(),
-	                                                       leader->getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
+	player->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has invited you to {:s} party.", leader->getName(),
+	                                                        leader->getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
 	return true;
 }
 
-bool Party::isPlayerInvited(const Player* player) const
+bool Party::isPlayerInvited(const std::shared_ptr<const Player>& player) const
 {
-	return std::find(inviteList.begin(), inviteList.end(), player) != inviteList.end();
+	return std::ranges::find_if(inviteList, [&player](const auto& invitee) {
+		       return tfs::owner_equal(invitee, player);
+	       }) != inviteList.end();
 }
 
 void Party::updateAllPartyIcons()
 {
-	for (Player* member : memberList) {
-		for (Player* otherMember : memberList) {
+	const auto& leader = getLeader();
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
+		for (const auto& otherMember : memberList | tfs::views::lock_weak_ptrs) {
 			member->sendCreatureShield(otherMember);
 		}
 
@@ -306,14 +307,14 @@ void Party::updateAllPartyIcons()
 
 void Party::broadcastPartyMessage(MessageClasses msgClass, const std::string& msg, bool sendToInvitations /*= false*/)
 {
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		member->sendTextMessage(msgClass, msg);
 	}
 
-	leader->sendTextMessage(msgClass, msg);
+	getLeader()->sendTextMessage(msgClass, msg);
 
 	if (sendToInvitations) {
-		for (Player* invitee : inviteList) {
+		for (const auto& invitee : inviteList | tfs::views::lock_weak_ptrs) {
 			invitee->sendTextMessage(msgClass, msg);
 		}
 	}
@@ -352,8 +353,9 @@ const char* getSharedExpReturnMessage(SharedExpStatus_t value)
 
 } // namespace
 
-bool Party::setSharedExperience(Player* player, bool sharedExpActive)
+bool Party::setSharedExperience(const std::shared_ptr<Player>& player, bool sharedExpActive)
 {
+	const auto& leader = getLeader();
 	if (!player || leader != player) {
 		return false;
 	}
@@ -376,30 +378,31 @@ bool Party::setSharedExperience(Player* player, bool sharedExpActive)
 	return true;
 }
 
-void Party::shareExperience(uint64_t experience, Creature* source /* = nullptr*/)
+void Party::shareExperience(uint64_t experience, const std::shared_ptr<Creature>& source /* = nullptr*/)
 {
 	uint64_t shareExperience = experience;
 	tfs::events::party::onShareExperience(this, shareExperience);
 
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		member->onGainSharedExperience(shareExperience, source);
 	}
-	leader->onGainSharedExperience(shareExperience, source);
+	getLeader()->onGainSharedExperience(shareExperience, source);
 }
 
-bool Party::canUseSharedExperience(const Player* player) const
+bool Party::canUseSharedExperience(const std::shared_ptr<const Player>& player) const
 {
 	return getMemberSharedExperienceStatus(player) == SHAREDEXP_OK;
 }
 
-SharedExpStatus_t Party::getMemberSharedExperienceStatus(const Player* player) const
+SharedExpStatus_t Party::getMemberSharedExperienceStatus(const std::shared_ptr<const Player>& player) const
 {
 	if (memberList.empty()) {
 		return SHAREDEXP_EMPTYPARTY;
 	}
 
+	const auto& leader = getLeader();
 	uint32_t highestLevel = leader->getLevel();
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		if (member->getLevel() > highestLevel) {
 			highestLevel = member->getLevel();
 		}
@@ -432,12 +435,12 @@ SharedExpStatus_t Party::getMemberSharedExperienceStatus(const Player* player) c
 
 SharedExpStatus_t Party::getSharedExperienceStatus()
 {
-	SharedExpStatus_t leaderStatus = getMemberSharedExperienceStatus(leader);
+	SharedExpStatus_t leaderStatus = getMemberSharedExperienceStatus(getLeader());
 	if (leaderStatus != SHAREDEXP_OK) {
 		return leaderStatus;
 	}
 
-	for (Player* member : memberList) {
+	for (const auto& member : memberList | tfs::views::lock_weak_ptrs) {
 		SharedExpStatus_t memberStatus = getMemberSharedExperienceStatus(member);
 		if (memberStatus != SHAREDEXP_OK) {
 			return memberStatus;
@@ -446,7 +449,7 @@ SharedExpStatus_t Party::getSharedExperienceStatus()
 	return SHAREDEXP_OK;
 }
 
-void Party::updatePlayerTicks(Player* player, uint32_t points)
+void Party::updatePlayerTicks(const std::shared_ptr<Player>& player, uint32_t points)
 {
 	if (points != 0 && !player->hasFlag(PlayerFlag_NotGainInFight)) {
 		ticksMap[player->getID()] = OTSYS_TIME();
@@ -454,7 +457,7 @@ void Party::updatePlayerTicks(Player* player, uint32_t points)
 	}
 }
 
-void Party::clearPlayerPoints(Player* player)
+void Party::clearPlayerPoints(const std::shared_ptr<Player>& player)
 {
 	auto it = ticksMap.find(player->getID());
 	if (it != ticksMap.end()) {
@@ -465,8 +468,8 @@ void Party::clearPlayerPoints(Player* player)
 
 bool Party::canOpenCorpse(uint32_t ownerId) const
 {
-	if (Player* player = g_game.getPlayerByID(ownerId)) {
-		return leader->getID() == ownerId || player->getParty() == this;
+	if (const auto& player = g_game.getPlayerByID(ownerId)) {
+		return getLeader()->getID() == ownerId || player->getParty() == this;
 	}
 	return false;
 }

--- a/src/party.h
+++ b/src/party.h
@@ -24,49 +24,47 @@ enum SharedExpStatus_t : uint8_t
 class Party
 {
 public:
-	explicit Party(Player* leader);
+	explicit Party(const std::shared_ptr<Player>& leader);
 
-	Player* getLeader() const { return leader; }
+	auto getLeader() const { return leader.lock(); }
 	const auto& getMembers() const { return memberList; }
 	const auto& getInvitees() const { return inviteList; }
-	size_t getMemberCount() const { return memberList.size(); }
-	size_t getInvitationCount() const { return inviteList.size(); }
 
 	void disband();
-	bool invitePlayer(Player& player);
-	bool joinParty(Player& player);
-	void revokeInvitation(Player& player);
-	bool passPartyLeadership(Player* player, bool forceRemove = false);
-	bool leaveParty(Player* player, bool forceRemove = false);
+	bool invitePlayer(const std::shared_ptr<Player>& player);
+	bool joinParty(const std::shared_ptr<Player>& player);
+	void revokeInvitation(const std::shared_ptr<Player>& player);
+	bool passPartyLeadership(const std::shared_ptr<Player>& player, bool forceRemove = false);
+	bool leaveParty(const std::shared_ptr<Player>& player, bool forceRemove = false);
 
-	bool removeInvite(Player& player, bool removeFromPlayer = true);
+	bool removeInvite(const std::shared_ptr<Player>& player, bool removeFromPlayer = true);
 
-	bool isPlayerInvited(const Player* player) const;
+	bool isPlayerInvited(const std::shared_ptr<const Player>& player) const;
 	void updateAllPartyIcons();
 	void broadcastPartyMessage(MessageClasses msgClass, const std::string& msg, bool sendToInvitations = false);
 	bool empty() const { return memberList.empty() && inviteList.empty(); }
 	bool canOpenCorpse(uint32_t ownerId) const;
 
-	void shareExperience(uint64_t experience, Creature* source = nullptr);
-	bool setSharedExperience(Player* player, bool sharedExpActive);
+	void shareExperience(uint64_t experience, const std::shared_ptr<Creature>& source = nullptr);
+	bool setSharedExperience(const std::shared_ptr<Player>& player, bool sharedExpActive);
 	bool isSharedExperienceActive() const { return sharedExpActive; }
 	bool isSharedExperienceEnabled() const { return sharedExpEnabled; }
-	bool canUseSharedExperience(const Player* player) const;
-	SharedExpStatus_t getMemberSharedExperienceStatus(const Player* player) const;
+	bool canUseSharedExperience(const std::shared_ptr<const Player>& player) const;
+	SharedExpStatus_t getMemberSharedExperienceStatus(const std::shared_ptr<const Player>& player) const;
 	void updateSharedExperience();
 
-	void updatePlayerTicks(Player* player, uint32_t points);
-	void clearPlayerPoints(Player* player);
+	void updatePlayerTicks(const std::shared_ptr<Player>& player, uint32_t points);
+	void clearPlayerPoints(const std::shared_ptr<Player>& player);
 
 private:
 	SharedExpStatus_t getSharedExperienceStatus();
 
 	std::map<uint32_t, int64_t> ticksMap;
 
-	boost::container::flat_set<Player*> memberList;
-	boost::container::flat_set<Player*> inviteList;
+	boost::container::flat_set<std::weak_ptr<Player>, std::owner_less<std::weak_ptr<const Player>>> memberList;
+	boost::container::flat_set<std::weak_ptr<Player>, std::owner_less<std::weak_ptr<const Player>>> inviteList;
 
-	Player* leader;
+	std::weak_ptr<Player> leader;
 
 	bool sharedExpActive = false;
 	bool sharedExpEnabled = false;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -15,13 +15,10 @@
 #include "game.h"
 #include "house.h"
 #include "iologindata.h"
-#include "monster.h"
 #include "movement.h"
-#include "npc.h"
 #include "outfit.h"
 #include "party.h"
 #include "scheduler.h"
-#include "storeinbox.h"
 #include "tools.h"
 #include "weapons.h"
 
@@ -37,44 +34,7 @@ MuteCountMap Player::muteCountMap;
 uint32_t Player::playerAutoID = 0x10000000;
 uint32_t Player::playerIDLimit = 0x20000000;
 
-Player::Player(ProtocolGame_ptr p) :
-    Creature(),
-    lastPing(OTSYS_TIME()),
-    lastPong(lastPing),
-    client(std::move(p)),
-    storeInbox(new StoreInbox(ITEM_STORE_INBOX))
-{
-	storeInbox->setParent(this);
-	storeInbox->incrementReferenceCounter();
-}
-
-Player::~Player()
-{
-	for (Item* item : inventory) {
-		if (item) {
-			item->setParent(nullptr);
-			item->decrementReferenceCounter();
-		}
-	}
-
-	for (const auto& [_, depot] : depotChests) {
-		if (const auto parent = depot->getRealParent()) {
-			// remove chest from depot locker, because of possible double free when shared_ptr decides to free up the
-			// resource
-			parent->internalRemoveThing(depot.get());
-		}
-	}
-
-	if (depotLocker) {
-		depotLocker->removeInbox(inbox.get());
-	}
-
-	storeInbox->setParent(nullptr);
-	storeInbox->decrementReferenceCounter();
-
-	setWriteItem(nullptr);
-	setEditHouse(nullptr);
-}
+Player::Player(ProtocolGame_ptr p) : Creature{}, lastPing{OTSYS_TIME()}, lastPong{lastPing}, client{std::move(p)} {}
 
 void Player::setID()
 {
@@ -103,7 +63,7 @@ bool Player::setVocation(uint16_t vocId)
 	updateRegeneration();
 	setBaseSpeed(voc->getBaseSpeed());
 	updateBaseSpeed();
-	g_game.changeSpeed(this, 0);
+	g_game.changeSpeed(getPlayer(), 0);
 	return true;
 }
 
@@ -160,14 +120,16 @@ std::string Player::getDescription(int32_t lookDistance) const
 			s << " He is in a party with ";
 		}
 
-		size_t memberCount = party->getMemberCount() + 1;
+		size_t memberCount =
+		    std::ranges::count_if(party->getMembers(), [](const auto& member) { return !member.expired(); }) + 1;
 		if (memberCount == 1) {
 			s << "1 member and ";
 		} else {
 			s << memberCount << " members and ";
 		}
 
-		size_t invitationCount = party->getInvitationCount();
+		size_t invitationCount =
+		    std::ranges::count_if(party->getInvitees(), [](const auto& invitee) { return !invitee.expired(); });
 		if (invitationCount == 1) {
 			s << "1 pending invitation.";
 		} else {
@@ -175,6 +137,8 @@ std::string Player::getDescription(int32_t lookDistance) const
 		}
 	}
 
+	const auto& guild = getGuild();
+	const auto& guildRank = getGuildRank();
 	if (!guild || !guildRank) {
 		return s.str();
 	}
@@ -201,7 +165,7 @@ std::string Player::getDescription(int32_t lookDistance) const
 	return s.str();
 }
 
-Item* Player::getInventoryItem(slots_t slot) const
+std::shared_ptr<Item> Player::getInventoryItem(slots_t slot) const
 {
 	if (slot < CONST_SLOT_FIRST || slot > CONST_SLOT_LAST) {
 		return nullptr;
@@ -209,13 +173,9 @@ Item* Player::getInventoryItem(slots_t slot) const
 	return inventory[slot];
 }
 
-void Player::addConditionSuppressions(uint32_t conditions) { conditionSuppressions |= conditions; }
-
-void Player::removeConditionSuppressions(uint32_t conditions) { conditionSuppressions &= ~conditions; }
-
-Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
+std::shared_ptr<Item> Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 {
-	Item* item = inventory[slot];
+	auto item = inventory[slot];
 	if (!item) {
 		return nullptr;
 	}
@@ -229,10 +189,11 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 	if (!ignoreAmmo && weaponType == WEAPON_DISTANCE) {
 		const ItemType& itemType = Item::items[item->getID()];
 		if (itemType.ammoType != AMMO_NONE) {
-			Item* ammoItem = inventory[CONST_SLOT_AMMO];
+			const auto& ammoItem = inventory[CONST_SLOT_AMMO];
 			if (!ammoItem || ammoItem->getAmmoType() != itemType.ammoType) {
 				// no ammo item was found, search for quiver instead
-				Container* quiver = inventory[CONST_SLOT_RIGHT] ? inventory[CONST_SLOT_RIGHT]->getContainer() : nullptr;
+				const auto& quiver =
+				    inventory[CONST_SLOT_RIGHT] ? inventory[CONST_SLOT_RIGHT]->getContainer() : nullptr;
 				if (!quiver || quiver->getWeaponType() != WEAPON_QUIVER) {
 					// no quiver equipped
 					return nullptr;
@@ -241,9 +202,10 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 				for (ContainerIterator containerItem = quiver->iterator(); containerItem.hasNext();
 				     containerItem.advance()) {
 					if (itemType.ammoType == (*containerItem)->getAmmoType()) {
-						const Weapon* weapon = g_weapons->getWeapon(*containerItem);
-						if (weapon && weapon->ammoCheck(this)) {
-							return *containerItem;
+						if (const auto& weapon = g_weapons->getWeapon(*containerItem)) {
+							if (weapon->ammoCheck(getPlayer())) {
+								return *containerItem;
+							}
 						}
 					}
 				}
@@ -257,30 +219,28 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 	return item;
 }
 
-Item* Player::getWeapon(bool ignoreAmmo /* = false*/) const
+std::shared_ptr<Item> Player::getWeapon(bool ignoreAmmo /* = false*/) const
 {
-	Item* item = getWeapon(CONST_SLOT_LEFT, ignoreAmmo);
-	if (item) {
-		return item;
+	if (const auto& weapon = getWeapon(CONST_SLOT_LEFT, ignoreAmmo)) {
+		return weapon;
 	}
 
-	item = getWeapon(CONST_SLOT_RIGHT, ignoreAmmo);
-	if (item) {
-		return item;
+	if (const auto& weapon = getWeapon(CONST_SLOT_RIGHT, ignoreAmmo)) {
+		return weapon;
 	}
+
 	return nullptr;
 }
 
 WeaponType_t Player::getWeaponType() const
 {
-	Item* item = getWeapon();
-	if (!item) {
-		return WEAPON_NONE;
+	if (const auto& weapon = getWeapon()) {
+		return weapon->getWeaponType();
 	}
-	return item->getWeaponType();
+	return WEAPON_NONE;
 }
 
-int32_t Player::getWeaponSkill(const Item* item) const
+int32_t Player::getWeaponSkill(const std::shared_ptr<const Item>& item) const
 {
 	if (!item) {
 		return getSkillLevel(SKILL_FIST);
@@ -322,24 +282,23 @@ int32_t Player::getArmor() const
 {
 	int32_t armor = 0;
 
-	static const slots_t armorSlots[] = {CONST_SLOT_HEAD, CONST_SLOT_NECKLACE, CONST_SLOT_ARMOR,
-	                                     CONST_SLOT_LEGS, CONST_SLOT_FEET,     CONST_SLOT_RING};
+	static constexpr auto armorSlots = std::array{CONST_SLOT_HEAD, CONST_SLOT_NECKLACE, CONST_SLOT_ARMOR,
+	                                              CONST_SLOT_LEGS, CONST_SLOT_FEET,     CONST_SLOT_RING};
 	for (slots_t slot : armorSlots) {
-		Item* inventoryItem = inventory[slot];
-		if (inventoryItem) {
+		if (const auto& inventoryItem = inventory[slot]) {
 			armor += inventoryItem->getArmor();
 		}
 	}
 	return static_cast<int32_t>(armor * vocation->armorMultiplier);
 }
 
-void Player::getShieldAndWeapon(const Item*& shield, const Item*& weapon) const
+std::pair<std::shared_ptr<const Item>, std::shared_ptr<const Item>> Player::getShieldAndWeapon() const
 {
-	shield = nullptr;
-	weapon = nullptr;
+	std::shared_ptr<const Item> shield = nullptr;
+	std::shared_ptr<const Item> weapon = nullptr;
 
 	for (uint32_t slot = CONST_SLOT_RIGHT; slot <= CONST_SLOT_LEFT; slot++) {
-		Item* item = inventory[slot];
+		const auto& item = inventory[slot];
 		if (!item) {
 			continue;
 		}
@@ -362,15 +321,15 @@ void Player::getShieldAndWeapon(const Item*& shield, const Item*& weapon) const
 			}
 		}
 	}
+
+	return std::make_pair(shield, weapon);
 }
 
 int32_t Player::getDefense() const
 {
 	int32_t defenseSkill = getSkillLevel(SKILL_FIST);
 	int32_t defenseValue = 7;
-	const Item* weapon;
-	const Item* shield;
-	getShieldAndWeapon(shield, weapon);
+	const auto& [shield, weapon] = getShieldAndWeapon();
 
 	if (weapon) {
 		defenseValue = weapon->getDefense() + weapon->getExtraDefense();
@@ -398,12 +357,12 @@ int32_t Player::getDefense() const
 
 uint32_t Player::getAttackSpeed() const
 {
-	const Item* weapon = getWeapon(true);
-	if (!weapon || weapon->getAttackSpeed() == 0) {
-		return vocation->getAttackSpeed();
+	if (const auto& weapon = getWeapon(true)) {
+		if (weapon->getAttackSpeed() != 0) {
+			return weapon->getAttackSpeed();
+		}
 	}
-
-	return weapon->getAttackSpeed();
+	return vocation->getAttackSpeed();
 }
 
 float Player::getAttackFactor() const
@@ -447,7 +406,7 @@ uint32_t Player::getClientIcons() const
 		icons |= ICON_REDSWORDS;
 	}
 
-	if (tile && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (const auto& tile = getTile(); tile && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		icons |= ICON_PIGEON;
 
 		// Don't show ICON_SWORDS if player is in protection zone.
@@ -465,13 +424,12 @@ void Player::updateInventoryWeight()
 
 	inventoryWeight = 0;
 	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
-		const Item* item = inventory[i];
-		if (item) {
+		if (const auto& item = inventory[i]) {
 			inventoryWeight += item->getWeight();
 		}
 	}
 
-	if (StoreInbox* storeInbox = getStoreInbox()) {
+	if (const auto& storeInbox = getStoreInbox()) {
 		inventoryWeight += storeInbox->getWeight();
 	}
 }
@@ -485,7 +443,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count)
 		return;
 	}
 
-	tfs::events::player::onGainSkillTries(this, skill, count);
+	tfs::events::player::onGainSkillTries(getPlayer(), skill, count);
 	if (count == 0) {
 		return;
 	}
@@ -500,7 +458,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count)
 		sendTextMessage(MESSAGE_EVENT_ADVANCE,
 		                std::format("You advanced to {:s} level {:d}.", getSkillName(skill), skills[skill].level));
 
-		g_creatureEvents->playerAdvance(this, skill, (skills[skill].level - 1), skills[skill].level);
+		g_creatureEvents->playerAdvance(getPlayer(), skill, (skills[skill].level - 1), skills[skill].level);
 
 		sendUpdateSkills = true;
 		currReqTries = nextReqTries;
@@ -576,7 +534,7 @@ void Player::setVarStats(stats_t stat, int32_t modifier)
 			if (getHealth() > getMaxHealth()) {
 				Creature::changeHealth(getMaxHealth() - getHealth());
 			} else {
-				g_game.addCreatureHealth(this);
+				g_game.addCreatureHealth(getPlayer());
 			}
 			break;
 		}
@@ -608,48 +566,13 @@ int32_t Player::getDefaultStats(stats_t stat) const
 	}
 }
 
-void Player::addContainer(uint8_t cid, Container* container)
+void Player::addContainer(uint8_t cid, std::shared_ptr<Container> container)
 {
 	if (cid > 0xF) {
 		return;
 	}
 
-	if (container->getID() == ITEM_BROWSEFIELD) {
-		container->incrementReferenceCounter();
-	}
-
-	auto it = openContainers.find(cid);
-	if (it != openContainers.end()) {
-		OpenContainer& openContainer = it->second;
-		Container* oldContainer = openContainer.container;
-		if (oldContainer->getID() == ITEM_BROWSEFIELD) {
-			oldContainer->decrementReferenceCounter();
-		}
-
-		openContainer.container = container;
-		openContainer.index = 0;
-	} else {
-		OpenContainer openContainer;
-		openContainer.container = container;
-		openContainer.index = 0;
-		openContainers[cid] = openContainer;
-	}
-}
-
-void Player::closeContainer(uint8_t cid)
-{
-	auto it = openContainers.find(cid);
-	if (it == openContainers.end()) {
-		return;
-	}
-
-	OpenContainer openContainer = it->second;
-	Container* container = openContainer.container;
-	openContainers.erase(it);
-
-	if (container && container->getID() == ITEM_BROWSEFIELD) {
-		container->decrementReferenceCounter();
-	}
+	openContainers[cid] = {.container = std::move(container), .index = 0};
 }
 
 void Player::setContainerIndex(uint8_t cid, uint16_t index)
@@ -661,7 +584,7 @@ void Player::setContainerIndex(uint8_t cid, uint16_t index)
 	it->second.index = index;
 }
 
-Container* Player::getContainerByID(uint8_t cid)
+std::shared_ptr<Container> Player::getContainerByID(uint8_t cid)
 {
 	auto it = openContainers.find(cid);
 	if (it == openContainers.end()) {
@@ -670,7 +593,7 @@ Container* Player::getContainerByID(uint8_t cid)
 	return it->second.container;
 }
 
-int8_t Player::getContainerID(const Container* container) const
+int8_t Player::getContainerID(const std::shared_ptr<const Container>& container) const
 {
 	for (auto&& [cid, openContainer] : openContainers | std::views::as_const) {
 		if (openContainer.container == container) {
@@ -720,9 +643,9 @@ bool Player::canSee(const Position& pos) const
 	return client->canSee(pos);
 }
 
-bool Player::canSeeCreature(const Creature* creature) const
+bool Player::canSeeCreature(const std::shared_ptr<const Creature>& creature) const
 {
-	if (creature == this) {
+	if (creature.get() == this) {
 		return true;
 	}
 
@@ -736,31 +659,31 @@ bool Player::canSeeCreature(const Creature* creature) const
 	return true;
 }
 
-bool Player::canSeeGhostMode(const Creature*) const { return group->access; }
+bool Player::canSeeGhostMode(const std::shared_ptr<const Creature>&) const { return group->access; }
 
-bool Player::canWalkthrough(const Creature* creature) const
+bool Player::canWalkthrough(const std::shared_ptr<const Creature>& creature) const
 {
 	if (group->access || creature->isInGhostMode()) {
 		return true;
 	}
 
-	const Player* player = creature->getPlayer();
+	const auto& player = creature->getPlayer();
 	if (!player || !getBoolean(ConfigManager::ALLOW_WALKTHROUGH)) {
 		return false;
 	}
 
-	const Tile* playerTile = player->getTile();
+	const auto& playerTile = player->getTile();
 	if (!playerTile || (!playerTile->hasFlag(TILESTATE_PROTECTIONZONE) &&
 	                    player->getLevel() > static_cast<uint32_t>(getNumber(ConfigManager::PROTECTION_LEVEL)))) {
 		return false;
 	}
 
-	const Item* playerTileGround = playerTile->getGround();
+	const auto& playerTileGround = playerTile->getGround();
 	if (!playerTileGround || !playerTileGround->hasWalkStack()) {
 		return false;
 	}
 
-	Player* thisPlayer = const_cast<Player*>(this);
+	const auto& thisPlayer = const_cast<Player*>(this);
 	if ((OTSYS_TIME() - lastWalkthroughAttempt) > 2000) {
 		thisPlayer->setLastWalkthroughAttempt(OTSYS_TIME());
 		return false;
@@ -775,18 +698,18 @@ bool Player::canWalkthrough(const Creature* creature) const
 	return true;
 }
 
-bool Player::canWalkthroughEx(const Creature* creature) const
+bool Player::canWalkthroughEx(const std::shared_ptr<const Creature>& creature) const
 {
 	if (group->access) {
 		return true;
 	}
 
-	const Player* player = creature->getPlayer();
+	const auto& player = creature->getPlayer();
 	if (!player || !getBoolean(ConfigManager::ALLOW_WALKTHROUGH)) {
 		return false;
 	}
 
-	const Tile* playerTile = player->getTile();
+	const auto& playerTile = player->getTile();
 	return playerTile && (playerTile->hasFlag(TILESTATE_PROTECTIONZONE) ||
 	                      player->getLevel() <= static_cast<uint32_t>(getNumber(ConfigManager::PROTECTION_LEVEL)));
 }
@@ -803,20 +726,17 @@ bool Player::isNearDepotBox() const
 	const Position& pos = getPosition();
 	for (int32_t cx = -NOTIFY_DEPOT_BOX_RANGE; cx <= NOTIFY_DEPOT_BOX_RANGE; ++cx) {
 		for (int32_t cy = -NOTIFY_DEPOT_BOX_RANGE; cy <= NOTIFY_DEPOT_BOX_RANGE; ++cy) {
-			Tile* tile = g_game.map.getTile(pos.x + cx, pos.y + cy, pos.z);
-			if (!tile) {
-				continue;
-			}
-
-			if (tile->hasFlag(TILESTATE_DEPOT)) {
-				return true;
+			if (const auto& tile = g_game.map.getTile(pos.x + cx, pos.y + cy, pos.z)) {
+				if (tile->hasFlag(TILESTATE_DEPOT)) {
+					return true;
+				}
 			}
 		}
 	}
 	return false;
 }
 
-DepotChest_ptr Player::getDepotChest(uint32_t depotId, bool autoCreate)
+std::shared_ptr<DepotChest> Player::getDepotChest(uint32_t depotId, bool autoCreate)
 {
 	auto it = depotChests.find(depotId);
 	if (it != depotChests.end()) {
@@ -832,30 +752,30 @@ DepotChest_ptr Player::getDepotChest(uint32_t depotId, bool autoCreate)
 		return nullptr;
 	}
 
-	const DepotChest_ptr& depotChest =
-	    depotChests.emplace(depotId, std::make_shared<DepotChest>(depotItemId)).first->second;
+	auto depotChest = std::make_shared<DepotChest>(depotItemId);
+	depotChests[depotId] = depotChest;
 	depotChest->setMaxDepotItems(getMaxDepotItems());
 	return depotChest;
 }
 
-DepotLocker& Player::getDepotLocker()
+std::shared_ptr<DepotLocker> Player::getDepotLocker()
 {
 	if (!depotLocker) {
 		depotLocker = std::make_shared<DepotLocker>(ITEM_LOCKER);
 		depotLocker->internalAddThing(Item::CreateItem(ITEM_MARKET));
-		depotLocker->internalAddThing(getInbox().get());
+		depotLocker->internalAddThing(getInbox());
 
-		DepotChest* depotChest = new DepotChest(ITEM_DEPOT, false);
+		auto depotChest = std::make_shared<DepotChest>(ITEM_DEPOT, false);
 		// adding in reverse to align them from first to last
 		for (int16_t depotId = depotChest->capacity(); depotId >= 0; --depotId) {
 			if (const auto& box = getDepotChest(depotId, true)) {
-				depotChest->internalAddThing(box.get());
+				depotChest->internalAddThing(box);
 			}
 		}
 
 		depotLocker->internalAddThing(depotChest);
 	}
-	return *depotLocker;
+	return depotLocker;
 }
 
 void Player::sendCancelMessage(ReturnValue message) const { sendCancelMessage(getReturnMessage(message)); }
@@ -883,8 +803,10 @@ void Player::sendPing()
 	}
 
 	int64_t noPongTime = timeNow - lastPong;
-	if ((hasLostConnection || noPongTime >= 7000) && attackedCreature && attackedCreature->getPlayer()) {
-		removeAttackedCreature();
+	if (const auto& attackedCreature = getAttackedCreature()) {
+		if ((hasLostConnection || noPongTime >= 7000) && attackedCreature->getPlayer()) {
+			removeAttackedCreature();
+		}
 	}
 
 	int32_t noPongKickTime = vocation->getNoPongKickTime();
@@ -897,41 +819,35 @@ void Player::sendPing()
 			return;
 		}
 
-		if (!g_creatureEvents->playerLogout(this)) {
+		if (!g_creatureEvents->playerLogout(getPlayer())) {
 			return;
 		}
 
 		if (client) {
 			client->logout(true, true);
 		} else {
-			g_game.removeCreature(this, true);
+			g_game.removeCreature(getPlayer(), true);
 		}
 	}
 }
 
-Item* Player::getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen)
+std::shared_ptr<Item> Player::getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen)
 {
 	windowTextId = this->windowTextId;
 	maxWriteLen = this->maxWriteLen;
-	return writeItem;
+	return writeItem.lock();
 }
 
-void Player::setWriteItem(Item* item, uint16_t maxWriteLen /*= 0*/)
+uint32_t Player::setWriteItem(const std::shared_ptr<Item>& item, uint16_t maxWriteLen /*= 0*/)
 {
-	windowTextId++;
-
-	if (writeItem) {
-		writeItem->decrementReferenceCounter();
-	}
-
 	if (item) {
 		writeItem = item;
 		this->maxWriteLen = maxWriteLen;
-		writeItem->incrementReferenceCounter();
 	} else {
-		writeItem = nullptr;
+		writeItem.reset();
 		this->maxWriteLen = 0;
 	}
+	return ++windowTextId;
 }
 
 House* Player::getEditHouse(uint32_t& windowTextId, uint32_t& listId)
@@ -961,12 +877,14 @@ void Player::sendHouseWindow(House* house, uint32_t listId) const
 }
 
 // container
-void Player::sendAddContainerItem(const Container* container, const Item* item)
+void Player::sendAddContainerItem(const std::shared_ptr<const Container>& container,
+                                  const std::shared_ptr<const Item>& item)
 {
 	if (!client) {
 		return;
 	}
 
+	auto slotItem = item;
 	for (auto&& [cid, openContainer] : openContainers | std::views::as_const) {
 		if (openContainer.container != container) {
 			continue;
@@ -978,21 +896,22 @@ void Player::sendAddContainerItem(const Container* container, const Item* item)
 			uint16_t pageEnd = openContainer.index + container->capacity() - 1;
 			if (containerSize > pageEnd) {
 				slot = pageEnd;
-				item = container->getItemByIndex(pageEnd);
+				slotItem = container->getItemByIndex(pageEnd);
 			} else {
 				slot = containerSize;
 			}
 		} else if (openContainer.index >= container->capacity()) {
-			item = container->getItemByIndex(openContainer.index);
+			slotItem = container->getItemByIndex(openContainer.index);
 		}
 
-		if (item) {
-			client->sendAddContainerItem(cid, slot, item);
+		if (slotItem) {
+			client->sendAddContainerItem(cid, slot, slotItem);
 		}
 	}
 }
 
-void Player::sendUpdateContainerItem(const Container* container, uint16_t slot, const Item* newItem)
+void Player::sendUpdateContainerItem(const std::shared_ptr<const Container>& container, uint16_t slot,
+                                     const std::shared_ptr<const Item>& newItem)
 {
 	if (!client) {
 		return;
@@ -1016,7 +935,7 @@ void Player::sendUpdateContainerItem(const Container* container, uint16_t slot, 
 	}
 }
 
-void Player::sendRemoveContainerItem(const Container* container, uint16_t slot)
+void Player::sendRemoveContainerItem(const std::shared_ptr<const Container>& container, uint16_t slot)
 {
 	if (!client) {
 		return;
@@ -1040,24 +959,22 @@ void Player::sendRemoveContainerItem(const Container* container, uint16_t slot)
 
 void Player::openSavedContainers()
 {
-	std::map<uint8_t, Container*> openContainersList;
+	std::map<uint8_t, std::shared_ptr<Container>> openContainersList;
 
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
 
-		Container* itemContainer = item->getContainer();
-		if (itemContainer) {
+		if (const auto& itemContainer = item->getContainer()) {
 			uint8_t cid = item->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
 			if (cid > 0) {
 				openContainersList.emplace(cid, itemContainer);
 			}
-			for (ContainerIterator it = itemContainer->iterator(); it.hasNext(); it.advance()) {
-				Container* subContainer = (*it)->getContainer();
-				if (subContainer) {
-					uint8_t subcid = (*it)->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
+			for (auto it = itemContainer->iterator(); it.hasNext(); it.advance()) {
+				if (const auto& subContainer = (*it)->getContainer()) {
+					uint8_t subcid = subContainer->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
 					if (subcid > 0) {
 						openContainersList.emplace(subcid, subContainer);
 					}
@@ -1079,8 +996,9 @@ void Player::openSavedContainers()
 	}
 }
 
-void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
-                              const Item* newItem, const ItemType& newType)
+void Player::onUpdateTileItem(const std::shared_ptr<const Tile>& tile, const Position& pos,
+                              const std::shared_ptr<const Item>& oldItem, const ItemType& oldType,
+                              const std::shared_ptr<const Item>& newItem, const ItemType& newType)
 {
 	Creature::onUpdateTileItem(tile, pos, oldItem, oldType, newItem, newType);
 
@@ -1089,31 +1007,33 @@ void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*
 	}
 
 	if (tradeState != TRADE_TRANSFER) {
-		if (tradeItem && oldItem == tradeItem) {
-			g_game.internalCloseTrade(this);
+		if (!tradeItem.expired() && tfs::owner_equal(oldItem, tradeItem)) {
+			g_game.internalCloseTrade(getPlayer());
 		}
 	}
 }
 
-void Player::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item)
+void Player::onRemoveTileItem(const std::shared_ptr<const Tile>& tile, const Position& pos, const ItemType& iType,
+                              const std::shared_ptr<const Item>& item)
 {
 	Creature::onRemoveTileItem(tile, pos, iType, item);
 
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
-		if (tradeItem) {
-			const Container* container = item->getContainer();
-			if (container && container->isHoldingItem(tradeItem)) {
-				g_game.internalCloseTrade(this);
+		if (const auto& tradeItem = getTradeItem()) {
+			if (const auto& container = item->getContainer()) {
+				if (container->isHoldingItem(tradeItem)) {
+					g_game.internalCloseTrade(getPlayer());
+				}
 			}
 		}
 	}
 }
 
-void Player::onCreatureAppear(Creature* creature, bool isLogin, MagicEffectClasses magicEffect)
+void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool isLogin, MagicEffectClasses magicEffect)
 {
-	if (creature != this) {
+	if (creature.get() != this) {
 		sendAddCreature(creature, creature->getPosition(), magicEffect);
 		return;
 	}
@@ -1148,10 +1068,10 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin, MagicEffectClass
 		if (currentMountId != 0) {
 			if (Mount* currentMount = g_game.mounts.getMountByClientID(currentMountId)) {
 				if (hasMount(currentMount)) {
-					g_game.changeSpeed(this, currentMount->speed);
+					g_game.changeSpeed(getPlayer(), currentMount->speed);
 				} else {
 					defaultOutfit.lookMount = 0;
-					g_game.internalCreatureChangeOutfit(this, defaultOutfit);
+					g_game.internalCreatureChangeOutfit(getPlayer(), defaultOutfit);
 				}
 			}
 		}
@@ -1160,23 +1080,23 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin, MagicEffectClass
 
 		IOLoginData::updateOnlineStatus(guid, true);
 
-		if (BedItem* bed = g_game.getBedBySleeper(guid)) {
-			bed->wakeUp(this);
+		if (const auto& bed = g_game.getBedBySleeper(guid)) {
+			bed->wakeUp(getPlayer());
 		}
 
-		if (guild) {
-			guild->addMember(this);
+		if (const auto& guild = getGuild()) {
+			guild->addMember(getPlayer());
 		}
 
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
 			if (const auto item = inventory[slot]) {
 				item->startDecaying();
-				g_moveEvents->onPlayerEquip(this, item, static_cast<slots_t>(slot), false);
-				tfs::events::player::onInventoryUpdate(this, item, static_cast<slots_t>(slot), true);
+				g_moveEvents->onPlayerEquip(getPlayer(), item, static_cast<slots_t>(slot), false);
+				tfs::events::player::onInventoryUpdate(getPlayer(), item, static_cast<slots_t>(slot), true);
 			}
 		}
 
-		if (!g_creatureEvents->playerLogin(this)) {
+		if (!g_creatureEvents->playerLogin(getPlayer())) {
 			kickPlayer(true);
 			return;
 		}
@@ -1229,24 +1149,24 @@ void Player::onFollowCreatureDisappear(bool isLogout)
 void Player::onChangeZone(ZoneType_t zone)
 {
 	if (zone == ZONE_PROTECTION) {
-		if (attackedCreature && !hasFlag(PlayerFlag_IgnoreProtectionZone)) {
+		if (getAttackedCreature() && !hasFlag(PlayerFlag_IgnoreProtectionZone)) {
 			removeAttackedCreature();
 			onAttackedCreatureDisappear(false);
 		}
 
 		if (!group->access && isMounted()) {
 			dismount();
-			g_game.internalCreatureChangeOutfit(this, defaultOutfit);
-			wasMounted = true;
+			g_game.internalCreatureChangeOutfit(getPlayer(), defaultOutfit);
+			wasMounted_ = true;
 		}
 	} else {
-		if (wasMounted) {
+		if (wasMounted_) {
 			toggleMount(true);
-			wasMounted = false;
+			wasMounted_ = false;
 		}
 	}
 
-	g_game.updateCreatureWalkthrough(this);
+	g_game.updateCreatureWalkthrough(getPlayer());
 	sendIcons();
 }
 
@@ -1258,7 +1178,7 @@ void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
 			onAttackedCreatureDisappear(false);
 		}
 	} else if (zone == ZONE_NOPVP) {
-		if (attackedCreature->getPlayer()) {
+		if (const auto& attackedCreature = getAttackedCreature(); attackedCreature->getPlayer()) {
 			if (!hasFlag(PlayerFlag_IgnoreProtectionZone)) {
 				removeAttackedCreature();
 				onAttackedCreatureDisappear(false);
@@ -1267,7 +1187,7 @@ void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
 	} else if (zone == ZONE_NORMAL) {
 		// attackedCreature can leave a pvp zone if not pzlocked
 		if (g_game.getWorldType() == WORLD_TYPE_NO_PVP) {
-			if (attackedCreature->getPlayer()) {
+			if (const auto& attackedCreature = getAttackedCreature(); attackedCreature->getPlayer()) {
 				removeAttackedCreature();
 				onAttackedCreatureDisappear(false);
 			}
@@ -1275,11 +1195,11 @@ void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
 	}
 }
 
-void Player::onRemoveCreature(Creature* creature, bool isLogout)
+void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
-	if (creature == this) {
+	if (creature.get() == this) {
 		if (isLogout) {
 			loginPosition = getPosition();
 		}
@@ -1290,8 +1210,8 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 			removeFollowCreature();
 		}
 
-		if (tradePartner) {
-			g_game.internalCloseTrade(this);
+		if (!tradePartner.expired()) {
+			g_game.internalCloseTrade(getPlayer());
 		}
 
 		closeShopWindow();
@@ -1299,27 +1219,27 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 		clearPartyInvitations();
 
 		if (party) {
-			party->leaveParty(this, true);
+			party->leaveParty(getPlayer(), true);
 		}
 
-		g_chat->removeUserFromAllChannels(*this);
+		g_chat->removeUserFromAllChannels(getPlayer());
 
-		if (guild) {
-			guild->removeMember(this);
+		if (const auto& guild = getGuild()) {
+			guild->removeMember(getPlayer());
 		}
 
 		IOLoginData::updateOnlineStatus(guid, false);
 
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
 			if (const auto item = inventory[slot]) {
-				g_moveEvents->onPlayerDeEquip(this, item, static_cast<slots_t>(slot));
-				tfs::events::player::onInventoryUpdate(this, item, static_cast<slots_t>(slot), false);
+				g_moveEvents->onPlayerDeEquip(getPlayer(), item, static_cast<slots_t>(slot));
+				tfs::events::player::onInventoryUpdate(getPlayer(), item, static_cast<slots_t>(slot), false);
 			}
 		}
 
 		bool saved = false;
 		for (uint32_t tries = 0; tries < 3; ++tries) {
-			if (IOLoginData::savePlayer(this)) {
+			if (IOLoginData::savePlayer(getPlayer())) {
 				saved = true;
 				break;
 			}
@@ -1331,7 +1251,7 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 	}
 }
 
-void Player::openShopWindow(Npc* npc, const std::list<ShopInfo>& shop)
+void Player::openShopWindow(const std::shared_ptr<Npc>& npc, const std::list<ShopInfo>& shop)
 {
 	shopItemList = shop;
 	sendShop(npc);
@@ -1344,14 +1264,14 @@ bool Player::closeShopWindow(bool sendCloseShopWindow /*= true*/)
 	int32_t onBuy;
 	int32_t onSell;
 
-	Npc* npc = getShopOwner(onBuy, onSell);
+	const auto& npc = getShopOwner(onBuy, onSell);
 	if (!npc) {
 		shopItemList.clear();
 		return false;
 	}
 
 	setShopOwner(nullptr, -1, -1);
-	npc->onPlayerEndTrade(this, onBuy, onSell);
+	npc->onPlayerEndTrade(getPlayer(), onBuy, onSell);
 
 	if (sendCloseShopWindow) {
 		sendCloseShop();
@@ -1368,27 +1288,31 @@ void Player::onWalk(Direction& dir)
 	setNextAction(OTSYS_TIME() + getStepDuration(dir));
 }
 
-void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
-                            const Position& oldPos, bool teleport)
+void Player::onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+                            const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
+                            bool teleport)
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
-	if (hasFollowPath && (creature == followCreature || (creature == this && followCreature))) {
+	if (const auto& followCreature = getFollowCreature();
+	    hasFollowPath && (creature == followCreature || (creature.get() == this && followCreature))) {
 		g_dispatcher.addTask([id = getID()]() { g_game.updateCreatureWalk(id); });
 	}
 
-	if (creature != this) {
+	if (creature.get() != this) {
 		return;
 	}
 
 	if (tradeState != TRADE_TRANSFER) {
 		// check if we should close trade
-		if (tradeItem && !tradeItem->getPosition().isInRange(getPosition(), 1, 1, 0)) {
-			g_game.internalCloseTrade(this);
+		if (const auto& tradeItem = getTradeItem();
+		    tradeItem && !tradeItem->getPosition().isInRange(getPosition(), 1, 1, 0)) {
+			g_game.internalCloseTrade(getPlayer());
 		}
 
-		if (tradePartner && !tradePartner->getPosition().isInRange(getPosition(), 2, 2, 0)) {
-			g_game.internalCloseTrade(this);
+		if (const auto& tradePartner = getTradePartner();
+		    tradePartner && !tradePartner->getPosition().isInRange(getPosition(), 2, 2, 0)) {
+			g_game.internalCloseTrade(getPlayer());
 		}
 	}
 
@@ -1424,9 +1348,11 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 }
 
 // container
-void Player::onAddContainerItem(const Item* item) { checkTradeState(item); }
+void Player::onAddContainerItem(const std::shared_ptr<const Item>& item) { checkTradeState(item); }
 
-void Player::onUpdateContainerItem(const Container* container, const Item* oldItem, const Item* newItem)
+void Player::onUpdateContainerItem(const std::shared_ptr<const Container>& container,
+                                   const std::shared_ptr<const Item>& oldItem,
+                                   const std::shared_ptr<const Item>& newItem)
 {
 	if (oldItem != newItem) {
 		onRemoveContainerItem(container, oldItem);
@@ -1437,20 +1363,21 @@ void Player::onUpdateContainerItem(const Container* container, const Item* oldIt
 	}
 }
 
-void Player::onRemoveContainerItem(const Container* container, const Item* item)
+void Player::onRemoveContainerItem(const std::shared_ptr<const Container>& container,
+                                   const std::shared_ptr<const Item>& item)
 {
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
-		if (tradeItem) {
+		if (const auto& tradeItem = getTradeItem()) {
 			if (tradeItem->getParent() != container && container->isHoldingItem(tradeItem)) {
-				g_game.internalCloseTrade(this);
+				g_game.internalCloseTrade(getPlayer());
 			}
 		}
 	}
 }
 
-void Player::onCloseContainer(const Container* container)
+void Player::onCloseContainer(const std::shared_ptr<const Container>& container)
 {
 	if (!client) {
 		return;
@@ -1463,7 +1390,7 @@ void Player::onCloseContainer(const Container* container)
 	}
 }
 
-void Player::onSendContainer(const Container* container)
+void Player::onSendContainer(const std::shared_ptr<const Container>& container)
 {
 	if (!client) {
 		return;
@@ -1477,7 +1404,7 @@ void Player::onSendContainer(const Container* container)
 }
 
 // inventory
-void Player::onUpdateInventoryItem(Item* oldItem, Item* newItem)
+void Player::onUpdateInventoryItem(const std::shared_ptr<Item>& oldItem, const std::shared_ptr<Item>& newItem)
 {
 	if (oldItem != newItem) {
 		onRemoveInventoryItem(oldItem);
@@ -1488,37 +1415,39 @@ void Player::onUpdateInventoryItem(Item* oldItem, Item* newItem)
 	}
 }
 
-void Player::onRemoveInventoryItem(Item* item)
+void Player::onRemoveInventoryItem(const std::shared_ptr<Item>& item)
 {
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
-		if (tradeItem) {
-			const Container* container = item->getContainer();
-			if (container && container->isHoldingItem(tradeItem)) {
-				g_game.internalCloseTrade(this);
+		if (const auto& tradeItem = getTradeItem()) {
+			if (const auto& container = item->getContainer()) {
+				if (container->isHoldingItem(tradeItem)) {
+					g_game.internalCloseTrade(getPlayer());
+				}
 			}
 		}
 	}
 }
 
-void Player::checkTradeState(const Item* item)
+void Player::checkTradeState(const std::shared_ptr<const Item>& item)
 {
-	if (!tradeItem || tradeState == TRADE_TRANSFER) {
+	if (tradeItem.expired() || tradeState == TRADE_TRANSFER) {
 		return;
 	}
 
-	if (tradeItem == item) {
-		g_game.internalCloseTrade(this);
-	} else {
-		const Container* container = dynamic_cast<const Container*>(item->getParent());
+	if (tfs::owner_equal(tradeItem, item)) {
+		g_game.internalCloseTrade(getPlayer());
+	} else if (auto parent = item->getParent()) {
+		auto container = std::dynamic_pointer_cast<Container>(parent);
 		while (container) {
-			if (container == tradeItem) {
-				g_game.internalCloseTrade(this);
+			if (tfs::owner_equal(container, tradeItem)) {
+				g_game.internalCloseTrade(getPlayer());
 				break;
 			}
 
-			container = dynamic_cast<const Container*>(container->getParent());
+			parent = container->getParent();
+			container = parent ? std::dynamic_pointer_cast<Container>(parent) : nullptr;
 		}
 	}
 }
@@ -1635,13 +1564,13 @@ void Player::removeMessageBuffer()
 	}
 }
 
-void Player::drainHealth(Creature* attacker, int32_t damage)
+void Player::drainHealth(const std::shared_ptr<Creature>& attacker, int32_t damage)
 {
 	Creature::drainHealth(attacker, damage);
 	sendStats();
 }
 
-void Player::drainMana(Creature* attacker, int32_t manaLoss)
+void Player::drainMana(const std::shared_ptr<Creature>& attacker, int32_t manaLoss)
 {
 	onAttacked();
 	changeMana(-manaLoss);
@@ -1666,7 +1595,7 @@ void Player::addManaSpent(uint64_t amount)
 		return;
 	}
 
-	tfs::events::player::onGainSkillTries(this, SKILL_MAGLEVEL, amount);
+	tfs::events::player::onGainSkillTries(getPlayer(), SKILL_MAGLEVEL, amount);
 	if (amount == 0) {
 		return;
 	}
@@ -1680,7 +1609,7 @@ void Player::addManaSpent(uint64_t amount)
 
 		sendTextMessage(MESSAGE_EVENT_ADVANCE, std::format("You advanced to magic level {:d}.", magLevel));
 
-		g_creatureEvents->playerAdvance(this, SKILL_MAGLEVEL, magLevel - 1, magLevel);
+		g_creatureEvents->playerAdvance(getPlayer(), SKILL_MAGLEVEL, magLevel - 1, magLevel);
 
 		sendUpdateStats = true;
 		currReqMana = nextReqMana;
@@ -1747,7 +1676,7 @@ void Player::removeManaSpent(uint64_t amount, bool notify /* = false*/)
 	}
 }
 
-void Player::addExperience(Creature* source, uint64_t exp, bool sendText /* = false*/)
+void Player::addExperience(const std::shared_ptr<Creature>& source, uint64_t exp, bool sendText /* = false*/)
 {
 	uint64_t currLevelExp = Player::getExpForLevel(level);
 	uint64_t nextLevelExp = Player::getExpForLevel(level + 1);
@@ -1759,7 +1688,7 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText /* = fa
 		return;
 	}
 
-	tfs::events::player::onGainExperience(this, source, exp, rawExp, sendText);
+	tfs::events::player::onGainExperience(getPlayer(), source, exp, rawExp, sendText);
 	if (exp == 0) {
 		return;
 	}
@@ -1790,19 +1719,19 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText /* = fa
 		updateBaseSpeed();
 		setBaseSpeed(getBaseSpeed());
 
-		g_game.changeSpeed(this, 0);
-		g_game.addCreatureHealth(this);
+		g_game.changeSpeed(getPlayer(), 0);
+		g_game.addCreatureHealth(getPlayer());
 
 		const uint32_t protectionLevel = static_cast<uint32_t>(getNumber(ConfigManager::PROTECTION_LEVEL));
 		if (prevLevel < protectionLevel && level >= protectionLevel) {
-			g_game.updateCreatureWalkthrough(this);
+			g_game.updateCreatureWalkthrough(getPlayer());
 		}
 
 		if (party) {
 			party->updateSharedExperience();
 		}
 
-		g_creatureEvents->playerAdvance(this, SKILL_LEVEL, prevLevel, level);
+		g_creatureEvents->playerAdvance(getPlayer(), SKILL_LEVEL, prevLevel, level);
 
 		sendTextMessage(MESSAGE_EVENT_ADVANCE,
 		                std::format("You advanced from Level {:d} to Level {:d}.", prevLevel, level));
@@ -1824,7 +1753,7 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 		return;
 	}
 
-	tfs::events::player::onLoseExperience(this, exp);
+	tfs::events::player::onLoseExperience(getPlayer(), exp);
 	if (exp == 0) {
 		return;
 	}
@@ -1845,13 +1774,13 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 
 		SpectatorVec spectators;
 		g_game.map.getSpectators(spectators, position, false, true);
-		spectators.erase(this);
+		spectators.erase(getPlayer());
 		if (!spectators.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
 			message.text = getName() + " lost " + expString;
-			for (Creature* spectator : spectators) {
-				assert(dynamic_cast<Player*>(spectator) != nullptr);
-				static_cast<Player*>(spectator)->sendTextMessage(message);
+			for (const auto& spectator : spectators) {
+				assert(spectator->getPlayer() != nullptr);
+				std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 			}
 		}
 	}
@@ -1874,12 +1803,12 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 		updateBaseSpeed();
 		setBaseSpeed(getBaseSpeed());
 
-		g_game.changeSpeed(this, 0);
-		g_game.addCreatureHealth(this);
+		g_game.changeSpeed(getPlayer(), 0);
+		g_game.addCreatureHealth(getPlayer());
 
 		const uint32_t protectionLevel = static_cast<uint32_t>(getNumber(ConfigManager::PROTECTION_LEVEL));
 		if (oldLevel >= protectionLevel && level < protectionLevel) {
-			g_game.updateCreatureWalkthrough(this);
+			g_game.updateCreatureWalkthrough(getPlayer());
 		}
 
 		if (party) {
@@ -1958,19 +1887,22 @@ void Player::onAttackedCreatureBlockHit(BlockType_t blockType)
 
 bool Player::hasShield() const
 {
-	Item* item = inventory[CONST_SLOT_LEFT];
-	if (item && item->getWeaponType() == WEAPON_SHIELD) {
-		return true;
+	if (const auto& leftItem = inventory[CONST_SLOT_LEFT]) {
+		if (leftItem->getWeaponType() == WEAPON_SHIELD) {
+			return true;
+		}
 	}
 
-	item = inventory[CONST_SLOT_RIGHT];
-	if (item && item->getWeaponType() == WEAPON_SHIELD) {
-		return true;
+	if (const auto& rightItem = inventory[CONST_SLOT_RIGHT]) {
+		if (rightItem->getWeaponType() == WEAPON_SHIELD) {
+			return true;
+		}
 	}
+
 	return false;
 }
 
-BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
+BlockType_t Player::blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,
                              bool checkDefense /* = false*/, bool checkArmor /* = false*/, bool field /* = false*/,
                              bool ignoreResistances /* = false*/)
 {
@@ -1999,7 +1931,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 				continue;
 			}
 
-			Item* item = inventory[slot];
+			const auto& item = inventory[slot];
 			if (!item) {
 				continue;
 			}
@@ -2044,7 +1976,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 			reflectDamage.primary.type = combatType;
 			reflectDamage.primary.value = -std::round(damage * (reflect.percent / 100.));
 			reflectDamage.origin = ORIGIN_REFLECT;
-			g_game.combatChangeHealth(this, attacker, reflectDamage);
+			g_game.combatChangeHealth(getPlayer(), attacker, reflectDamage);
 		}
 	}
 
@@ -2064,7 +1996,7 @@ Connection::Address Player::getIP() const
 	return {};
 }
 
-void Player::death(Creature* lastHitCreature)
+void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 {
 	loginPosition = town->templePosition;
 
@@ -2075,10 +2007,9 @@ void Player::death(Creature* lastHitCreature)
 		if (lastHitPlayer) {
 			uint32_t sumLevels = 0;
 			uint32_t inFightTicks = getNumber(ConfigManager::PZ_LOCKED);
-			for (const auto& [id, cb] : damageMap | std::views::as_const) {
+			for (auto&& [id, cb] : getDamageMap()) {
 				if ((OTSYS_TIME() - cb.ticks) <= inFightTicks) {
-					Player* damageDealer = g_game.getPlayerByID(id);
-					if (damageDealer) {
+					if (const auto& damageDealer = g_game.getPlayerByID(id)) {
 						sumLevels += damageDealer->getLevel();
 					}
 				}
@@ -2114,7 +2045,7 @@ void Player::death(Creature* lastHitCreature)
 
 		// Level loss
 		uint64_t expLoss = static_cast<uint64_t>(experience * deathLossPercent);
-		tfs::events::player::onLoseExperience(this, expLoss);
+		tfs::events::player::onLoseExperience(getPlayer(), expLoss);
 		if (expLoss != 0) {
 			uint32_t oldLevel = level;
 
@@ -2172,7 +2103,7 @@ void Player::death(Creature* lastHitCreature)
 			if (condition->isPersistent()) {
 				it = conditions.erase(it);
 
-				condition->endCondition(this);
+				condition->endCondition(getPlayer());
 				onEndCondition(condition->getType());
 				delete condition;
 			} else {
@@ -2188,7 +2119,7 @@ void Player::death(Creature* lastHitCreature)
 			if (condition->isPersistent()) {
 				it = conditions.erase(it);
 
-				condition->endCondition(this);
+				condition->endCondition(getPlayer());
 				onEndCondition(condition->getType());
 				delete condition;
 			} else {
@@ -2197,15 +2128,16 @@ void Player::death(Creature* lastHitCreature)
 		}
 
 		health = healthMax;
-		g_game.internalTeleport(this, getTemplePosition(), true);
-		g_game.addCreatureHealth(this);
+		g_game.internalTeleport(getCreature(), getTemplePosition(), true);
+		g_game.addCreatureHealth(getPlayer());
 		onThink(EVENT_CREATURE_THINK_INTERVAL);
 		onIdleStatus();
 		sendStats();
 	}
 }
 
-bool Player::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified,
+bool Player::dropCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+                        const std::shared_ptr<Creature>& mostDamageCreature, bool lastHitUnjustified,
                         bool mostDamageUnjustified)
 {
 	if (getZone() != ZONE_PVP || !Player::lastHitIsPlayer(lastHitCreature)) {
@@ -2216,15 +2148,16 @@ bool Player::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature,
 	return false;
 }
 
-Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
+std::shared_ptr<Item> Player::getCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+                                        const std::shared_ptr<Creature>& mostDamageCreature)
 {
-	Item* corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
+	const auto& corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
 	if (corpse && corpse->getContainer()) {
 		auto killers = std::ranges::count_if(
-		    damageMap,
+		    getDamageMap(),
 		    [this, now = OTSYS_TIME(), inFightTicks = getNumber(ConfigManager::PZ_LOCKED)](const auto& pair) {
 			    const auto& attacker = g_game.getCreatureByID(pair.first);
-			    return attacker && attacker != this && (now - pair.second.ticks <= inFightTicks);
+			    return attacker && attacker.get() != this && (now - pair.second.ticks <= inFightTicks);
 		    });
 
 		if (lastHitCreature) {
@@ -2279,33 +2212,33 @@ void Player::addInFightTicks(bool pzlock /*= false*/)
 
 void Player::removeList()
 {
-	g_game.removePlayer(this);
+	g_game.removePlayer(getPlayer());
 
-	for (auto&& player : g_game.getPlayers() | std::views::values | std::views::as_const) {
-		player->notifyStatusChange(this, VIPSTATUS_OFFLINE);
+	for (auto&& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		player->notifyStatusChange(getPlayer(), VIPSTATUS_OFFLINE);
 	}
 }
 
 void Player::addList()
 {
-	for (auto&& player : g_game.getPlayers() | std::views::values | std::views::as_const) {
-		player->notifyStatusChange(this, VIPSTATUS_ONLINE);
+	for (auto&& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		player->notifyStatusChange(getPlayer(), VIPSTATUS_ONLINE);
 	}
 
-	g_game.addPlayer(this);
+	g_game.addPlayer(getPlayer());
 }
 
 void Player::kickPlayer(bool displayEffect)
 {
-	g_creatureEvents->playerLogout(this);
+	g_creatureEvents->playerLogout(getPlayer());
 	if (client) {
 		client->logout(displayEffect, true);
 	} else {
-		g_game.removeCreature(this);
+		g_game.removeCreature(getPlayer());
 	}
 }
 
-void Player::notifyStatusChange(Player* loginPlayer, VipStatus_t status)
+void Player::notifyStatusChange(const std::shared_ptr<Player>& loginPlayer, VipStatus_t status)
 {
 	if (!client) {
 		return;
@@ -2376,18 +2309,18 @@ bool Player::editVIP(uint32_t vipGuid, const std::string& description, uint32_t 
 }
 
 // close container and its child containers
-void Player::autoCloseContainers(const Container* container)
+void Player::autoCloseContainers(const std::shared_ptr<const Container>& container)
 {
 	std::vector<uint32_t> closeList;
 	for (auto&& [cid, openContainer] : openContainers | std::views::as_const) {
-		Container* tmpContainer = openContainer.container;
+		auto tmpContainer = openContainer.container;
 		while (tmpContainer) {
 			if (tmpContainer->isRemoved() || tmpContainer == container) {
 				closeList.push_back(cid);
 				break;
 			}
 
-			tmpContainer = dynamic_cast<Container*>(tmpContainer->getParent());
+			tmpContainer = std::dynamic_pointer_cast<Container>(tmpContainer->getParent());
 		}
 	}
 
@@ -2399,13 +2332,13 @@ void Player::autoCloseContainers(const Container* container)
 	}
 }
 
-bool Player::hasCapacity(const Item* item, uint32_t count) const
+bool Player::hasCapacity(const std::shared_ptr<const Item>& item, uint32_t count) const
 {
 	if (hasFlag(PlayerFlag_CannotPickupItem)) {
 		return false;
 	}
 
-	if (hasFlag(PlayerFlag_HasInfiniteCapacity) || item->getTopParent() == this) {
+	if (hasFlag(PlayerFlag_HasInfiniteCapacity) || item->getTopParent().get() == this) {
 		return true;
 	}
 
@@ -2416,9 +2349,10 @@ bool Player::hasCapacity(const Item* item, uint32_t count) const
 	return itemWeight <= getFreeCapacity();
 }
 
-ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags, Creature*) const
+ReturnValue Player::queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+                             const std::shared_ptr<Creature>&) const
 {
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -2492,32 +2426,29 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 				if (!getBoolean(ConfigManager::CLASSIC_EQUIPMENT_SLOTS)) {
 					if (item->getWeaponType() != WEAPON_SHIELD && item->getWeaponType() != WEAPON_QUIVER) {
 						ret = RETURNVALUE_CANNOTBEDRESSED;
-					} else {
-						const Item* leftItem = inventory[CONST_SLOT_LEFT];
-						if (leftItem) {
-							if ((leftItem->getSlotPosition() | slotPosition) & SLOTP_TWO_HAND) {
-								if (leftItem->getWeaponType() != WEAPON_DISTANCE ||
-								    item->getWeaponType() != WEAPON_QUIVER) {
-									ret = RETURNVALUE_BOTHHANDSNEEDTOBEFREE;
-								} else {
-									ret = RETURNVALUE_NOERROR;
-								}
+					} else if (const auto& leftItem = inventory[CONST_SLOT_LEFT]) {
+						if ((leftItem->getSlotPosition() | slotPosition) & SLOTP_TWO_HAND) {
+							if (leftItem->getWeaponType() != WEAPON_DISTANCE ||
+							    item->getWeaponType() != WEAPON_QUIVER) {
+								ret = RETURNVALUE_BOTHHANDSNEEDTOBEFREE;
 							} else {
 								ret = RETURNVALUE_NOERROR;
 							}
 						} else {
 							ret = RETURNVALUE_NOERROR;
 						}
+					} else {
+						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (slotPosition & SLOTP_TWO_HAND) {
-					const Item* leftItem = inventory[CONST_SLOT_LEFT];
+					const auto& leftItem = inventory[CONST_SLOT_LEFT];
 					if (leftItem && leftItem != item) {
 						ret = RETURNVALUE_BOTHHANDSNEEDTOBEFREE;
 					} else {
 						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (inventory[CONST_SLOT_LEFT]) {
-					const Item* leftItem = inventory[CONST_SLOT_LEFT];
+					const auto& leftItem = inventory[CONST_SLOT_LEFT];
 					WeaponType_t type = item->getWeaponType(), leftType = leftItem->getWeaponType();
 
 					if (leftItem->getSlotPosition() & SLOTP_TWO_HAND) {
@@ -2548,7 +2479,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 			if (slotPosition & SLOTP_LEFT) {
 				if (!getBoolean(ConfigManager::CLASSIC_EQUIPMENT_SLOTS)) {
 					WeaponType_t type = item->getWeaponType();
-					const Item* rightItem = inventory[CONST_SLOT_RIGHT];
+					const auto& rightItem = inventory[CONST_SLOT_RIGHT];
 					if (type == WEAPON_NONE || type == WEAPON_SHIELD || type == WEAPON_AMMO || type == WEAPON_QUIVER) {
 						ret = RETURNVALUE_CANNOTBEDRESSED;
 					} else if (rightItem && (slotPosition & SLOTP_TWO_HAND)) {
@@ -2561,7 +2492,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (slotPosition & SLOTP_TWO_HAND) {
-					const Item* rightItem = inventory[CONST_SLOT_RIGHT];
+					const auto& rightItem = inventory[CONST_SLOT_RIGHT];
 					if (rightItem && rightItem != item) {
 						if (item->getWeaponType() != WEAPON_DISTANCE || rightItem->getWeaponType() != WEAPON_QUIVER) {
 							ret = RETURNVALUE_BOTHHANDSNEEDTOBEFREE;
@@ -2572,7 +2503,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (inventory[CONST_SLOT_RIGHT]) {
-					const Item* rightItem = inventory[CONST_SLOT_RIGHT];
+					const auto& rightItem = inventory[CONST_SLOT_RIGHT];
 					WeaponType_t type = item->getWeaponType(), rightType = rightItem->getWeaponType();
 
 					if (rightItem->getSlotPosition() & SLOTP_TWO_HAND) {
@@ -2647,34 +2578,35 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 	}
 
 	if (index != CONST_SLOT_WHEREEVER && index != -1) { // we don't try to equip whereever call
-		ret = g_moveEvents->onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item),
-		                                  static_cast<slots_t>(index), true);
+		ret = g_moveEvents->onPlayerEquip(std::const_pointer_cast<Player>(getPlayer()),
+		                                  std::const_pointer_cast<Item>(item), static_cast<slots_t>(index), true);
 		if (ret != RETURNVALUE_NOERROR) {
 			return ret;
 		}
 	}
 
 	// need an exchange with source? (destination item is swapped with currently moved item)
-	const Item* inventoryItem = getInventoryItem(static_cast<slots_t>(index));
-	if (inventoryItem && (!inventoryItem->isStackable() || inventoryItem->getID() != item->getID())) {
-		if (!getBoolean(ConfigManager::CLASSIC_EQUIPMENT_SLOTS)) {
-			if (const auto topParent = item->getTopParent()) {
-				if (dynamic_cast<const DepotChest*>(topParent) || dynamic_cast<const Player*>(topParent)) {
-					return RETURNVALUE_NEEDEXCHANGE;
+	if (const auto& inventoryItem = getInventoryItem(static_cast<slots_t>(index))) {
+		if (!inventoryItem->isStackable() || inventoryItem->getID() != item->getID()) {
+			if (!getBoolean(ConfigManager::CLASSIC_EQUIPMENT_SLOTS)) {
+				if (const auto topParent = item->getTopParent()) {
+					if (std::dynamic_pointer_cast<const DepotChest>(topParent) ||
+					    std::dynamic_pointer_cast<const Player>(topParent)) {
+						return RETURNVALUE_NEEDEXCHANGE;
+					}
 				}
-			}
-			return RETURNVALUE_NOTENOUGHROOM;
-		}
 
-		return RETURNVALUE_NEEDEXCHANGE;
+				return RETURNVALUE_NEEDEXCHANGE;
+			}
+		}
 	}
 	return ret;
 }
 
-ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-                                  uint32_t flags) const
+ReturnValue Player::queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+                                  uint32_t& maxQueryCount, uint32_t flags) const
 {
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		maxQueryCount = 0;
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -2683,31 +2615,29 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 	if (index == INDEX_WHEREEVER) {
 		uint32_t n = 0;
 		for (int32_t slotIndex = CONST_SLOT_FIRST; slotIndex <= CONST_SLOT_LAST; ++slotIndex) {
-			Item* inventoryItem = inventory[slotIndex];
-			if (inventoryItem) {
-				if (Container* subContainer = inventoryItem->getContainer()) {
+			if (const auto& inventoryItem = inventory[slotIndex]) {
+				if (const auto& subContainer = inventoryItem->getContainer()) {
 					uint32_t queryCount = 0;
-					subContainer->queryMaxCount(INDEX_WHEREEVER, *item, item->getItemCount(), queryCount, flags);
+					subContainer->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), queryCount, flags);
 					n += queryCount;
 
 					// iterate through all items, including sub-containers (deep search)
 					for (ContainerIterator it = subContainer->iterator(); it.hasNext(); it.advance()) {
-						if (Container* tmpContainer = (*it)->getContainer()) {
+						if (const auto& tmpContainer = (*it)->getContainer()) {
 							queryCount = 0;
-							tmpContainer->queryMaxCount(INDEX_WHEREEVER, *item, item->getItemCount(), queryCount,
-							                            flags);
+							tmpContainer->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), queryCount, flags);
 							n += queryCount;
 						}
 					}
-				} else if (inventoryItem->isStackable() && item->equals(inventoryItem) &&
+				} else if (inventoryItem->isStackable() && *item == *inventoryItem &&
 				           inventoryItem->getItemCount() < ITEM_STACK_SIZE) {
 					uint32_t remainder = (100 - inventoryItem->getItemCount());
 
-					if (queryAdd(slotIndex, *item, remainder, flags) == RETURNVALUE_NOERROR) {
+					if (queryAdd(slotIndex, item, remainder, flags) == RETURNVALUE_NOERROR) {
 						n += remainder;
 					}
 				}
-			} else if (queryAdd(slotIndex, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { // empty slot
+			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { // empty slot
 				if (item->isStackable()) {
 					n += 100;
 				} else {
@@ -2718,20 +2648,19 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 
 		maxQueryCount = n;
 	} else {
-		const Item* destItem = nullptr;
+		std::shared_ptr<Item> destItem = nullptr;
 
-		const Thing* destThing = getThing(index);
-		if (destThing) {
+		if (const auto& destThing = getThing(index)) {
 			destItem = destThing->getItem();
 		}
 
 		if (destItem) {
-			if (destItem->isStackable() && item->equals(destItem) && destItem->getItemCount() < ITEM_STACK_SIZE) {
+			if (destItem->isStackable() && *item == *destItem && destItem->getItemCount() < ITEM_STACK_SIZE) {
 				maxQueryCount = 100 - destItem->getItemCount();
 			} else {
 				maxQueryCount = 0;
 			}
-		} else if (queryAdd(index, *item, count, flags) == RETURNVALUE_NOERROR) { // empty slot
+		} else if (queryAdd(index, item, count, flags) == RETURNVALUE_NOERROR) { // empty slot
 			if (item->isStackable()) {
 				maxQueryCount = 100;
 			} else {
@@ -2748,14 +2677,15 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Player::queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* /*= nullptr*/) const
+ReturnValue Player::queryRemove(const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+                                const std::shared_ptr<Creature>& /*= nullptr*/) const
 {
-	int32_t index = getThingIndex(&thing);
+	int32_t index = getThingIndex(thing);
 	if (index == -1) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -2771,25 +2701,25 @@ ReturnValue Player::queryRemove(const Thing& thing, uint32_t count, uint32_t fla
 	return RETURNVALUE_NOERROR;
 }
 
-Thing* Player::queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags)
+std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::shared_ptr<const Thing>& thing,
+                                                std::shared_ptr<Item>& destItem, uint32_t& flags)
 {
-	*destItem = nullptr;
+	destItem = nullptr;
 
 	if (index == 0 /*drop to capacity window*/ || index == INDEX_WHEREEVER) {
-		const Item* item = thing.getItem();
+		const auto& item = thing->getItem();
 		if (!item) {
-			return this;
+			return getPlayer();
 		}
 
 		bool autoStack = !((flags & FLAG_IGNOREAUTOSTACK) == FLAG_IGNOREAUTOSTACK);
 		bool isStackable = item->isStackable();
 
-		std::vector<Container*> containers;
+		std::vector<std::shared_ptr<Container>> containers;
 
 		for (uint32_t slotIndex = CONST_SLOT_FIRST; slotIndex <= CONST_SLOT_LAST; ++slotIndex) {
-			Item* inventoryItem = inventory[slotIndex];
-			if (inventoryItem) {
-				if (inventoryItem == tradeItem) {
+			if (const auto& inventoryItem = inventory[slotIndex]) {
+				if (tfs::owner_equal(inventoryItem, tradeItem)) {
 					continue;
 				}
 
@@ -2799,47 +2729,47 @@ Thing* Player::queryDestination(int32_t& index, const Thing& thing, Item** destI
 
 				if (autoStack && isStackable) {
 					// try find an already existing item to stack with
-					if (queryAdd(slotIndex, *item, item->getItemCount(), 0) == RETURNVALUE_NOERROR) {
-						if (inventoryItem->equals(item) && inventoryItem->getItemCount() < ITEM_STACK_SIZE) {
+					if (queryAdd(slotIndex, item, item->getItemCount(), 0) == RETURNVALUE_NOERROR) {
+						if (*inventoryItem == *item && inventoryItem->getItemCount() < ITEM_STACK_SIZE) {
 							index = slotIndex;
-							*destItem = inventoryItem;
-							return this;
+							destItem = inventoryItem;
+							return getPlayer();
 						}
 					}
 
-					if (Container* subContainer = inventoryItem->getContainer()) {
+					if (const auto& subContainer = inventoryItem->getContainer()) {
 						containers.push_back(subContainer);
 					}
-				} else if (Container* subContainer = inventoryItem->getContainer()) {
+				} else if (const auto& subContainer = inventoryItem->getContainer()) {
 					containers.push_back(subContainer);
 				}
-			} else if (queryAdd(slotIndex, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { // empty slot
+			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { // empty slot
 				index = slotIndex;
-				*destItem = nullptr;
-				return this;
+				destItem = nullptr;
+				return getPlayer();
 			}
 		}
 
 		size_t i = 0;
 		while (i < containers.size()) {
-			Container* tmpContainer = containers[i++];
+			const auto tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
 				// we need to find first empty container as fast as we can for non-stackable items
 				uint32_t n = tmpContainer->capacity() -
 				             std::min(tmpContainer->capacity(), static_cast<uint32_t>(tmpContainer->size()));
 				while (n) {
-					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) ==
+					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, item, item->getItemCount(), flags) ==
 					    RETURNVALUE_NOERROR) {
 						index = tmpContainer->capacity() - n;
-						*destItem = nullptr;
+						destItem = nullptr;
 						return tmpContainer;
 					}
 
 					--n;
 				}
 
-				for (Item* tmpContainerItem : tmpContainer->getItemList()) {
-					if (Container* subContainer = tmpContainerItem->getContainer()) {
+				for (const auto& tmpContainerItem : tmpContainer->getItemList()) {
+					if (const auto& subContainer = tmpContainerItem->getContainer()) {
 						containers.push_back(subContainer);
 					}
 				}
@@ -2849,8 +2779,8 @@ Thing* Player::queryDestination(int32_t& index, const Thing& thing, Item** destI
 
 			uint32_t n = 0;
 
-			for (Item* tmpItem : tmpContainer->getItemList()) {
-				if (tmpItem == tradeItem) {
+			for (const auto& tmpItem : tmpContainer->getItemList()) {
+				if (tfs::owner_equal(tmpItem, tradeItem)) {
 					continue;
 				}
 
@@ -2859,13 +2789,13 @@ Thing* Player::queryDestination(int32_t& index, const Thing& thing, Item** destI
 				}
 
 				// try find an already existing item to stack with
-				if (tmpItem->equals(item) && tmpItem->getItemCount() < ITEM_STACK_SIZE) {
+				if (*tmpItem == *item && tmpItem->getItemCount() < ITEM_STACK_SIZE) {
 					index = n;
-					*destItem = tmpItem;
+					destItem = tmpItem;
 					return tmpContainer;
 				}
 
-				if (Container* subContainer = tmpItem->getContainer()) {
+				if (const auto& subContainer = tmpItem->getContainer()) {
 					containers.push_back(subContainer);
 				}
 
@@ -2873,62 +2803,62 @@ Thing* Player::queryDestination(int32_t& index, const Thing& thing, Item** destI
 			}
 
 			if (n < tmpContainer->capacity() &&
-			    tmpContainer->queryAdd(n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
+			    tmpContainer->queryAdd(n, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
 				index = n;
-				*destItem = nullptr;
+				destItem = nullptr;
 				return tmpContainer;
 			}
 		}
 
-		return this;
+		return getPlayer();
 	}
 
-	const auto destThing = getThing(index);
+	const auto& destThing = getThing(index);
 	if (!destThing) {
-		return this;
+		return getPlayer();
 	}
 
-	const auto item = destThing->getItem();
+	const auto& item = destThing->getItem();
 	if (!item) {
-		return this;
+		return getPlayer();
 	}
 
-	const auto receiver = item->getReceiver();
+	const auto& receiver = item->getReceiver();
 	if (!receiver) {
-		*destItem = item;
-		return this;
+		destItem = item;
+		return getPlayer();
 	}
 
 	index = INDEX_WHEREEVER;
 	return receiver;
 }
 
-void Player::addThing(int32_t index, Thing* thing)
+void Player::addThing(int32_t index, const std::shared_ptr<Thing>& thing)
 {
 	if (index < CONST_SLOT_FIRST || index > CONST_SLOT_LAST) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	item->setParent(this);
+	item->setParent(getPlayer());
 	inventory[index] = item;
 
 	// send to client
 	sendInventoryItem(static_cast<slots_t>(index), item);
 }
 
-void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
+void Player::updateThing(const std::shared_ptr<Thing>& thing, uint16_t itemId, uint32_t count)
 {
 	int32_t index = getThingIndex(thing);
 	if (index == -1) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -2943,18 +2873,18 @@ void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	onUpdateInventoryItem(item, item);
 }
 
-void Player::replaceThing(uint32_t index, Thing* thing)
+void Player::replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing)
 {
 	if (index > CONST_SLOT_LAST) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* oldItem = getInventoryItem(static_cast<slots_t>(index));
+	const auto& oldItem = getInventoryItem(static_cast<slots_t>(index));
 	if (!oldItem) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -2965,14 +2895,14 @@ void Player::replaceThing(uint32_t index, Thing* thing)
 	// event methods
 	onUpdateInventoryItem(oldItem, item);
 
-	item->setParent(this);
+	item->setParent(getPlayer());
 
 	inventory[index] = item;
 }
 
-void Player::removeThing(Thing* thing, uint32_t count)
+void Player::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 {
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -3014,7 +2944,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 	}
 }
 
-int32_t Player::getThingIndex(const Thing* thing) const
+int32_t Player::getThingIndex(const std::shared_ptr<const Thing>& thing) const
 {
 	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
 		if (inventory[i] == thing) {
@@ -3028,7 +2958,7 @@ uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) con
 {
 	uint32_t count = 0;
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
@@ -3037,7 +2967,7 @@ uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) con
 			count += Item::countByType(item, subType);
 		}
 
-		if (Container* container = item->getContainer()) {
+		if (const auto& container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				if ((*it)->getID() == itemId) {
 					count += Item::countByType(*it, subType);
@@ -3054,11 +2984,11 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 		return true;
 	}
 
-	std::vector<Item*> itemList;
+	std::vector<std::shared_ptr<Item>> itemList;
 
 	uint32_t count = 0;
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
@@ -3073,13 +3003,12 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 
 			count += itemCount;
 			if (count >= amount) {
-				g_game.internalRemoveItems(std::move(itemList), amount, Item::items[itemId].stackable);
+				g_game.internalRemoveItems(itemList, amount, Item::items[itemId].stackable);
 				return true;
 			}
-		} else if (Container* container = item->getContainer()) {
+		} else if (const auto& container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-				Item* containerItem = *it;
-				if (containerItem->getID() == itemId) {
+				if (const auto& containerItem = *it; containerItem->getID() == itemId) {
 					uint32_t itemCount = Item::countByType(containerItem, subType);
 					if (itemCount == 0) {
 						continue;
@@ -3089,7 +3018,7 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 
 					count += itemCount;
 					if (count >= amount) {
-						g_game.internalRemoveItems(std::move(itemList), amount, Item::items[itemId].stackable);
+						g_game.internalRemoveItems(itemList, amount, Item::items[itemId].stackable);
 						return true;
 					}
 				}
@@ -3102,14 +3031,14 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 std::map<uint32_t, uint32_t>& Player::getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const
 {
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
 
 		countMap[item->getID()] += Item::countByType(item, -1);
 
-		if (Container* container = item->getContainer()) {
+		if (const auto& container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				countMap[(*it)->getID()] += Item::countByType(*it, -1);
 			}
@@ -3118,7 +3047,7 @@ std::map<uint32_t, uint32_t>& Player::getAllItemTypeCount(std::map<uint32_t, uin
 	return countMap;
 }
 
-Thing* Player::getThing(size_t index) const
+std::shared_ptr<Thing> Player::getThing(size_t index) const
 {
 	if (index >= CONST_SLOT_FIRST && index <= CONST_SLOT_LAST) {
 		return inventory[index];
@@ -3126,28 +3055,28 @@ Thing* Player::getThing(size_t index) const
 	return nullptr;
 }
 
-void Player::postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-                                 ReceiverLink_t link /*= LINK_OWNER*/)
+void Player::postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+                                 int32_t index, ReceiverLink_t link /*= LINK_OWNER*/)
 {
 	if (link == LINK_OWNER) {
 		// calling movement scripts
-		g_moveEvents->onPlayerEquip(this, thing->getItem(), static_cast<slots_t>(index), false);
-		tfs::events::player::onInventoryUpdate(this, thing->getItem(), static_cast<slots_t>(index), true);
+		g_moveEvents->onPlayerEquip(getPlayer(), thing->getItem(), static_cast<slots_t>(index), false);
+		tfs::events::player::onInventoryUpdate(getPlayer(), thing->getItem(), static_cast<slots_t>(index), true);
 	}
 
 	bool requireListUpdate = false;
 
 	if (link == LINK_OWNER || link == LINK_TOPPARENT) {
-		const Item* i = (oldParent ? oldParent->getItem() : nullptr);
+		const auto& i = (oldParent ? oldParent->getItem() : nullptr);
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
 		assert(i ? i->getContainer() != nullptr : true);
 
 		if (i) {
-			requireListUpdate = static_cast<const Container*>(i)->getHoldingPlayer() != this;
+			requireListUpdate = std::static_pointer_cast<const Container>(i)->getHoldingPlayer().get() != this;
 		} else {
-			requireListUpdate = oldParent != this;
+			requireListUpdate = oldParent.get() != this;
 		}
 
 		updateInventoryWeight();
@@ -3156,18 +3085,18 @@ void Player::postAddNotification(Thing* thing, const Thing* oldParent, int32_t i
 		sendItems();
 	}
 
-	if (const Item* item = thing->getItem()) {
-		if (const Container* container = item->getContainer()) {
+	if (const auto& item = thing->getItem()) {
+		if (const auto& container = item->getContainer()) {
 			onSendContainer(container);
 		}
 
-		if (shopOwner && requireListUpdate) {
+		if (!shopOwner.expired() && requireListUpdate) {
 			updateSaleShopList(item);
 		}
-	} else if (const Creature* creature = thing->getCreature()) {
-		if (creature == this) {
+	} else if (const auto& creature = thing->getCreature()) {
+		if (creature.get() == this) {
 			// check containers
-			std::vector<Container*> containers;
+			std::vector<std::shared_ptr<Container>> containers;
 
 			for (auto&& openContainer : openContainers | std::views::values | std::views::as_const) {
 				if (!openContainer.container->getPosition().isInRange(getPosition(), 1, 1, 0)) {
@@ -3175,35 +3104,35 @@ void Player::postAddNotification(Thing* thing, const Thing* oldParent, int32_t i
 				}
 			}
 
-			for (const Container* container : containers) {
+			for (const auto& container : containers) {
 				autoCloseContainers(container);
 			}
 		}
 	}
 }
 
-void Player::postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-                                    ReceiverLink_t link /*= LINK_OWNER*/)
+void Player::postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+                                    int32_t index, ReceiverLink_t link /*= LINK_OWNER*/)
 {
 	if (link == LINK_OWNER) {
 		// calling movement scripts
-		g_moveEvents->onPlayerDeEquip(this, thing->getItem(), static_cast<slots_t>(index));
-		tfs::events::player::onInventoryUpdate(this, thing->getItem(), static_cast<slots_t>(index), false);
+		g_moveEvents->onPlayerDeEquip(getPlayer(), thing->getItem(), static_cast<slots_t>(index));
+		tfs::events::player::onInventoryUpdate(getPlayer(), thing->getItem(), static_cast<slots_t>(index), false);
 	}
 
 	bool requireListUpdate = false;
 
 	if (link == LINK_OWNER || link == LINK_TOPPARENT) {
-		const Item* i = (newParent ? newParent->getItem() : nullptr);
+		const auto& i = (newParent ? newParent->getItem() : nullptr);
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
 		assert(i ? i->getContainer() != nullptr : true);
 
 		if (i) {
-			requireListUpdate = static_cast<const Container*>(i)->getHoldingPlayer() != this;
+			requireListUpdate = std::static_pointer_cast<const Container>(i)->getHoldingPlayer().get() != this;
 		} else {
-			requireListUpdate = newParent != this;
+			requireListUpdate = newParent.get() != this;
 		}
 
 		updateInventoryWeight();
@@ -3212,24 +3141,24 @@ void Player::postRemoveNotification(Thing* thing, const Thing* newParent, int32_
 		sendItems();
 	}
 
-	if (const Item* item = thing->getItem()) {
+	if (const auto& item = thing->getItem()) {
 		if (item->isSupply()) {
-			if (const Player* player = item->getHoldingPlayer()) {
+			if (const auto& player = item->getHoldingPlayer()) {
 				player->sendSupplyUsed(item->getClientID());
 			}
 		}
 
-		if (const Container* container = item->getContainer()) {
+		if (const auto& container = item->getContainer()) {
 			if (container->isRemoved() || !getPosition().isInRange(container->getPosition(), 1, 1, 0)) {
 				autoCloseContainers(container);
-			} else if (container->getTopParent() == this) {
+			} else if (container->getTopParent().get() == this) {
 				onSendContainer(container);
-			} else if (const Container* topContainer = dynamic_cast<const Container*>(container->getTopParent())) {
-				if (const DepotChest* depotChest = dynamic_cast<const DepotChest*>(topContainer)) {
+			} else if (const auto& topContainer = container->getTopParent()) {
+				if (const auto& depotChest = std::dynamic_pointer_cast<const DepotChest>(topContainer)) {
 					bool isOwner = false;
 
 					for (auto&& chest : depotChests | std::views::values | std::views::as_const) {
-						if (chest.get() == depotChest) {
+						if (tfs::owner_equal(chest, depotChest)) {
 							isOwner = true;
 							onSendContainer(container);
 						}
@@ -3238,8 +3167,8 @@ void Player::postRemoveNotification(Thing* thing, const Thing* newParent, int32_
 					if (!isOwner) {
 						autoCloseContainers(container);
 					}
-				} else if (const Inbox* inboxContainer = dynamic_cast<const Inbox*>(topContainer)) {
-					if (inboxContainer == inbox.get()) {
+				} else if (const auto& inboxContainer = std::dynamic_pointer_cast<const Inbox>(topContainer)) {
+					if (inboxContainer == inbox) {
 						onSendContainer(container);
 					} else {
 						autoCloseContainers(container);
@@ -3252,13 +3181,13 @@ void Player::postRemoveNotification(Thing* thing, const Thing* newParent, int32_
 			}
 		}
 
-		if (shopOwner && requireListUpdate) {
+		if (!shopOwner.expired() && requireListUpdate) {
 			updateSaleShopList(item);
 		}
 	}
 }
 
-bool Player::updateSaleShopList(const Item* item)
+bool Player::updateSaleShopList(const std::shared_ptr<const Item>& item)
 {
 	uint16_t itemId = item->getID();
 	bool isCurrency = false;
@@ -3274,14 +3203,14 @@ bool Player::updateSaleShopList(const Item* item)
 			return shopInfo.itemId == itemId && shopInfo.sellPrice != 0;
 		});
 		if (it == shopItemList.end()) {
-			const Container* container = item->getContainer();
+			const auto& container = item->getContainer();
 			if (!container) {
 				return false;
 			}
 
 			const auto& items = container->getItemList();
 			return std::any_of(items.begin(), items.end(),
-			                   [this](const Item* containerItem) { return updateSaleShopList(containerItem); });
+			                   [this](const auto& containerItem) { return updateSaleShopList(containerItem); });
 		}
 	}
 
@@ -3300,9 +3229,9 @@ bool Player::hasShopItemForSale(uint32_t itemId, uint8_t subType) const
 	});
 }
 
-void Player::internalAddThing(uint32_t index, Thing* thing)
+void Player::internalAddThing(uint32_t index, const std::shared_ptr<Thing>& thing)
 {
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return;
 	}
@@ -3314,11 +3243,11 @@ void Player::internalAddThing(uint32_t index, Thing* thing)
 		}
 
 		inventory[index] = item;
-		item->setParent(this);
+		item->setParent(getPlayer());
 	}
 }
 
-void Player::setFollowCreature(Creature* creature)
+void Player::setFollowCreature(const std::shared_ptr<Creature>& creature)
 {
 	if (isFollowingCreature(creature)) {
 		return;
@@ -3336,7 +3265,7 @@ void Player::setFollowCreature(Creature* creature)
 	Creature::setFollowCreature(creature);
 }
 
-void Player::setAttackedCreature(Creature* creature)
+void Player::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 {
 	if (isAttackingCreature(creature)) {
 		return;
@@ -3350,6 +3279,7 @@ void Player::setAttackedCreature(Creature* creature)
 
 	Creature::setAttackedCreature(creature);
 
+	const auto& followCreature = getFollowCreature();
 	if (chaseMode) {
 		if (followCreature != creature) {
 			// chase opponent
@@ -3366,13 +3296,14 @@ void Player::removeAttackedCreature()
 {
 	Creature::removeAttackedCreature();
 
-	if (followCreature) {
+	if (getFollowCreature()) {
 		removeFollowCreature();
 	}
 }
 
 void Player::goToFollowCreature()
 {
+	const auto& followCreature = getFollowCreature();
 	if (walkTask || !followCreature) {
 		return;
 	}
@@ -3390,7 +3321,7 @@ void Player::goToFollowCreature()
 	}
 }
 
-void Player::getPathSearchParams(const Creature* creature, FindPathParams& fpp) const
+void Player::getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const
 {
 	Creature::getPathSearchParams(creature, fpp);
 	fpp.fullPathSearch = true;
@@ -3409,21 +3340,20 @@ void Player::doAttacking(uint32_t)
 	if ((OTSYS_TIME() - lastAttack) >= getAttackSpeed()) {
 		bool result = false;
 
-		Item* tool = getWeapon();
-		const Weapon* weapon = g_weapons->getWeapon(tool);
+		const auto& tool = getWeapon();
 		uint32_t delay = getAttackSpeed();
 		bool classicSpeed = getBoolean(ConfigManager::CLASSIC_ATTACK_SPEED);
 
-		if (weapon) {
+		if (const Weapon* weapon = g_weapons->getWeapon(tool)) {
 			if (!weapon->interruptSwing()) {
-				result = weapon->useWeapon(this, tool, attackedCreature);
+				result = weapon->useWeapon(getPlayer(), tool, getAttackedCreature());
 			} else if (!classicSpeed && !canDoAction()) {
 				delay = getNextActionTime();
 			} else {
-				result = weapon->useWeapon(this, tool, attackedCreature);
+				result = weapon->useWeapon(getPlayer(), tool, getAttackedCreature());
 			}
 		} else {
-			result = Weapon::useFist(this, attackedCreature);
+			result = Weapon::useFist(getPlayer(), getAttackedCreature());
 		}
 
 		SchedulerTask* task = createSchedulerTask(std::max<uint32_t>(SCHEDULER_MINTICKS, delay),
@@ -3441,14 +3371,15 @@ void Player::doAttacking(uint32_t)
 	}
 }
 
-uint64_t Player::getGainedExperience(Creature* attacker) const
+uint64_t Player::getGainedExperience(const std::shared_ptr<Creature>& attacker) const
 {
 	if (getBoolean(ConfigManager::EXPERIENCE_FROM_PLAYERS)) {
-		Player* attackerPlayer = attacker->getPlayer();
-		if (attackerPlayer && attackerPlayer != this && skillLoss &&
-		    std::abs(static_cast<int32_t>(attackerPlayer->getLevel() - level)) <=
-		        getNumber(ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)) {
-			return std::max<uint64_t>(0, std::floor(getLostExperience() * getDamageRatio(attacker) * 0.75));
+		if (const auto& attackerPlayer = attacker->getPlayer()) {
+			if (attackerPlayer.get() != this && skillLoss &&
+			    std::abs(static_cast<int32_t>(attackerPlayer->getLevel() - level)) <=
+			        getNumber(ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)) {
+				return std::max<uint64_t>(0, std::floor(getLostExperience() * getDamageRatio(attacker) * 0.75));
+			}
 		}
 	}
 	return 0;
@@ -3466,13 +3397,13 @@ void Player::setChaseMode(bool mode)
 	bool prevChaseMode = chaseMode;
 	chaseMode = mode;
 
-	if (prevChaseMode != chaseMode) {
+	if (const auto& attackedCreature = getAttackedCreature(); attackedCreature && prevChaseMode != chaseMode) {
 		if (chaseMode) {
-			if (!followCreature && attackedCreature) {
+			if (!getFollowCreature()) {
 				// chase opponent
 				setFollowCreature(attackedCreature);
 			}
-		} else if (attackedCreature) {
+		} else {
 			removeFollowCreature();
 			cancelNextWalk = true;
 		}
@@ -3508,8 +3439,7 @@ void Player::updateItemsLight(bool internal /*=false*/)
 	LightInfo maxLight;
 
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
-		Item* item = inventory[i];
-		if (item) {
+		if (const auto& item = inventory[i]) {
 			LightInfo curLight = item->getLightInfo();
 
 			if (curLight.level > maxLight.level) {
@@ -3522,7 +3452,7 @@ void Player::updateItemsLight(bool internal /*=false*/)
 		itemsLight = maxLight;
 
 		if (!internal) {
-			g_game.changeLight(this);
+			g_game.changeLight(getPlayer());
 		}
 	}
 }
@@ -3605,7 +3535,7 @@ void Player::onCombatRemoveCondition(Condition* condition)
 	if (condition->getId() > 0) {
 		// Means the condition is from an item, id == slot
 		if (g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
-			Item* item = getInventoryItem(static_cast<slots_t>(condition->getId()));
+			const auto& item = getInventoryItem(static_cast<slots_t>(condition->getId()));
 			if (item) {
 				// 25% chance to destroy the item
 				if (25 >= uniform_random(1, 100)) {
@@ -3628,7 +3558,7 @@ void Player::onCombatRemoveCondition(Condition* condition)
 	}
 }
 
-void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true */)
+void Player::onAttackedCreature(const std::shared_ptr<Creature>& target, bool addFightTicks /* = true */)
 {
 	Creature::onAttackedCreature(target);
 
@@ -3636,7 +3566,7 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 		return;
 	}
 
-	if (target == this) {
+	if (target.get() == this) {
 		if (addFightTicks) {
 			addInFightTicks();
 		}
@@ -3647,7 +3577,7 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 		return;
 	}
 
-	Player* targetPlayer = target->getPlayer();
+	const auto& targetPlayer = target->getPlayer();
 	if (targetPlayer && !isPartner(targetPlayer) && !isGuildMate(targetPlayer)) {
 		if (!pzLocked && g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
 			pzLocked = true;
@@ -3658,14 +3588,14 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 
 		if (getSkull() == SKULL_NONE && getSkullClient(targetPlayer) == SKULL_YELLOW) {
 			addAttacked(targetPlayer);
-			targetPlayer->sendCreatureSkull(this);
-		} else if (!targetPlayer->hasAttacked(this)) {
+			targetPlayer->sendCreatureSkull(getPlayer());
+		} else if (!targetPlayer->hasAttacked(getPlayer())) {
 			if (!pzLocked) {
 				pzLocked = true;
 				sendIcons();
 			}
 
-			if (!Combat::isInPvpZone(this, targetPlayer) && !isInWar(targetPlayer)) {
+			if (!Combat::isInPvpZone(getPlayer(), targetPlayer) && !isInWar(targetPlayer)) {
 				addAttacked(targetPlayer);
 
 				if (targetPlayer->getSkull() == SKULL_NONE && getSkull() == SKULL_NONE) {
@@ -3673,7 +3603,7 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 				}
 
 				if (getSkull() == SKULL_NONE) {
-					targetPlayer->sendCreatureSkull(this);
+					targetPlayer->sendCreatureSkull(getPlayer());
 				}
 			}
 		}
@@ -3696,45 +3626,44 @@ void Player::onIdleStatus()
 	Creature::onIdleStatus();
 
 	if (party) {
-		party->clearPlayerPoints(this);
+		party->clearPlayerPoints(getPlayer());
 	}
 }
 
-void Player::onAttackedCreatureDrainHealth(Creature* target, int32_t points)
+void Player::onAttackedCreatureDrainHealth(const std::shared_ptr<Creature>& target, int32_t points)
 {
 	Creature::onAttackedCreatureDrainHealth(target, points);
 
-	if (target) {
-		if (party && !Combat::isPlayerCombat(target)) {
-			Monster* tmpMonster = target->getMonster();
+	if (target && party && !Combat::isPlayerCombat(target)) {
+		if (const auto& tmpMonster = target->getMonster()) {
 			if (tmpMonster && tmpMonster->isHostile()) {
 				// We have fulfilled a requirement for shared experience
-				party->updatePlayerTicks(this, points);
+				party->updatePlayerTicks(getPlayer(), points);
 			}
 		}
 	}
 }
 
-void Player::onTargetCreatureGainHealth(Creature* target, int32_t points)
+void Player::onTargetCreatureGainHealth(const std::shared_ptr<Creature>& target, int32_t points)
 {
 	if (target && party) {
-		Player* tmpPlayer = nullptr;
+		std::shared_ptr<Player> tmpPlayer = nullptr;
 
 		if (target->getPlayer()) {
 			tmpPlayer = target->getPlayer();
-		} else if (Creature* targetMaster = target->getMaster()) {
-			if (Player* targetMasterPlayer = targetMaster->getPlayer()) {
+		} else if (const auto& targetMaster = target->getMaster()) {
+			if (const auto& targetMasterPlayer = targetMaster->getPlayer()) {
 				tmpPlayer = targetMasterPlayer;
 			}
 		}
 
 		if (isPartner(tmpPlayer)) {
-			party->updatePlayerTicks(this, points);
+			party->updatePlayerTicks(getPlayer(), points);
 		}
 	}
 }
 
-bool Player::onKilledCreature(Creature* target, bool lastHit /* = true*/)
+bool Player::onKilledCreature(const std::shared_ptr<Creature>& target, bool lastHit /* = true*/)
 {
 	bool unjustified = false;
 
@@ -3744,7 +3673,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit /* = true*/)
 
 	Creature::onKilledCreature(target, lastHit);
 
-	Player* targetPlayer = target->getPlayer();
+	const auto& targetPlayer = target->getPlayer();
 	if (!targetPlayer) {
 		return false;
 	}
@@ -3753,8 +3682,8 @@ bool Player::onKilledCreature(Creature* target, bool lastHit /* = true*/)
 		targetPlayer->setDropLoot(false);
 		targetPlayer->setSkillLoss(false);
 	} else if (!hasFlag(PlayerFlag_NotGainInFight) && !isPartner(targetPlayer)) {
-		if (!Combat::isInPvpZone(this, targetPlayer) && hasAttacked(targetPlayer) && !targetPlayer->hasAttacked(this) &&
-		    !isGuildMate(targetPlayer) && targetPlayer != this) {
+		if (!Combat::isInPvpZone(getPlayer(), targetPlayer) && hasAttacked(targetPlayer) &&
+		    !targetPlayer->hasAttacked(getPlayer()) && !isGuildMate(targetPlayer) && targetPlayer.get() != this) {
 			if (targetPlayer->getSkull() == SKULL_NONE && !isInWar(targetPlayer)) {
 				unjustified = true;
 				addUnjustifiedDead(targetPlayer);
@@ -3772,7 +3701,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit /* = true*/)
 	return unjustified;
 }
 
-void Player::gainExperience(uint64_t gainExp, Creature* source)
+void Player::gainExperience(uint64_t gainExp, const std::shared_ptr<Creature>& source)
 {
 	if (hasFlag(PlayerFlag_NotGainExperience) || gainExp == 0 || staminaMinutes == 0) {
 		return;
@@ -3781,7 +3710,7 @@ void Player::gainExperience(uint64_t gainExp, Creature* source)
 	addExperience(source, gainExp, true);
 }
 
-void Player::onGainExperience(uint64_t gainExp, Creature* target)
+void Player::onGainExperience(uint64_t gainExp, const std::shared_ptr<Creature>& target)
 {
 	if (hasFlag(PlayerFlag_NotGainExperience)) {
 		return;
@@ -3798,7 +3727,10 @@ void Player::onGainExperience(uint64_t gainExp, Creature* target)
 	gainExperience(gainExp, target);
 }
 
-void Player::onGainSharedExperience(uint64_t gainExp, Creature* source) { gainExperience(gainExp, source); }
+void Player::onGainSharedExperience(uint64_t gainExp, const std::shared_ptr<Creature>& source)
+{
+	gainExperience(gainExp, source);
+}
 
 bool Player::isImmune(CombatType_t type) const
 {
@@ -3818,7 +3750,7 @@ bool Player::isImmune(ConditionType_t type) const
 
 bool Player::isAttackable() const { return !hasFlag(PlayerFlag_CannotBeAttacked); }
 
-bool Player::lastHitIsPlayer(Creature* lastHitCreature)
+bool Player::lastHitIsPlayer(const std::shared_ptr<Creature>& lastHitCreature)
 {
 	if (!lastHitCreature) {
 		return false;
@@ -3828,7 +3760,7 @@ bool Player::lastHitIsPlayer(Creature* lastHitCreature)
 		return true;
 	}
 
-	Creature* lastHitMaster = lastHitCreature->getMaster();
+	const auto& lastHitMaster = lastHitCreature->getMaster();
 	return lastHitMaster && lastHitMaster->getPlayer();
 }
 
@@ -3881,7 +3813,7 @@ bool Player::canWear(uint32_t lookType, uint8_t addons) const
 		return true;
 	}
 
-	for (auto& [outfitType, addon] : outfits) {
+	for (const auto& [outfitType, addon] : outfits) {
 		if (outfitType == lookType) {
 			if (addon == addons || addon == 3 || addons == 0) {
 				return true;
@@ -3903,7 +3835,7 @@ bool Player::hasOutfit(uint32_t lookType, uint8_t addons)
 		return true;
 	}
 
-	for (auto& [outfitType, addon] : outfits) {
+	for (const auto& [outfitType, addon] : outfits) {
 		if (outfitType == lookType) {
 			if (addon == addons || addon == 3 || addons == 0) {
 				return true;
@@ -3927,7 +3859,7 @@ void Player::addOutfit(uint16_t lookType, uint8_t addons)
 
 bool Player::removeOutfit(uint16_t lookType)
 {
-	for (auto& [outfit, addon] : outfits) {
+	for (const auto& [outfit, addon] : outfits) {
 		if (outfit == lookType) {
 			outfits.erase(outfit);
 			return true;
@@ -3958,7 +3890,7 @@ bool Player::getOutfitAddons(const Outfit& outfit, uint8_t& addons) const
 		return false;
 	}
 
-	for (auto& [lookType, addon] : outfits) {
+	for (const auto& [lookType, addon] : outfits) {
 		if (lookType != outfit.lookType) {
 			continue;
 		}
@@ -3985,18 +3917,18 @@ Skulls_t Player::getSkull() const
 	return skull;
 }
 
-Skulls_t Player::getSkullClient(const Creature* creature) const
+Skulls_t Player::getSkullClient(const std::shared_ptr<const Creature>& creature) const
 {
 	if (!creature || g_game.getWorldType() != WORLD_TYPE_PVP) {
 		return SKULL_NONE;
 	}
 
-	const Player* player = creature->getPlayer();
+	const auto& player = creature->getPlayer();
 	if (!player || player->getSkull() != SKULL_NONE) {
 		return Creature::getSkullClient(creature);
 	}
 
-	if (player->hasAttacked(this)) {
+	if (player->hasAttacked(getPlayer())) {
 		return SKULL_YELLOW;
 	}
 
@@ -4006,7 +3938,7 @@ Skulls_t Player::getSkullClient(const Creature* creature) const
 	return Creature::getSkullClient(creature);
 }
 
-bool Player::hasAttacked(const Player* attacked) const
+bool Player::hasAttacked(const std::shared_ptr<const Player>& attacked) const
 {
 	if (hasFlag(PlayerFlag_NotGainInFight) || !attacked) {
 		return false;
@@ -4015,18 +3947,18 @@ bool Player::hasAttacked(const Player* attacked) const
 	return attackedSet.find(attacked->guid) != attackedSet.end();
 }
 
-void Player::addAttacked(const Player* attacked)
+void Player::addAttacked(const std::shared_ptr<const Player>& attacked)
 {
-	if (hasFlag(PlayerFlag_NotGainInFight) || !attacked || attacked == this) {
+	if (hasFlag(PlayerFlag_NotGainInFight) || !attacked || attacked.get() == this) {
 		return;
 	}
 
 	attackedSet.insert(attacked->guid);
 }
 
-void Player::removeAttacked(const Player* attacked)
+void Player::removeAttacked(const std::shared_ptr<const Player>& attacked)
 {
-	if (!attacked || attacked == this) {
+	if (!attacked || attacked.get() == this) {
 		return;
 	}
 
@@ -4038,9 +3970,10 @@ void Player::removeAttacked(const Player* attacked)
 
 void Player::clearAttacked() { attackedSet.clear(); }
 
-void Player::addUnjustifiedDead(const Player* attacked)
+void Player::addUnjustifiedDead(const std::shared_ptr<const Player>& attacked)
 {
-	if (hasFlag(PlayerFlag_NotGainInFight) || attacked == this || g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
+	if (hasFlag(PlayerFlag_NotGainInFight) || attacked.get() == this ||
+	    g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
 		return;
 	}
 
@@ -4137,8 +4070,9 @@ bool Player::hasLearnedInstantSpell(const std::string& spellName) const
 	return false;
 }
 
-bool Player::isInWar(const Player* player) const
+bool Player::isInWar(const std::shared_ptr<const Player>& player) const
 {
+	const auto& guild = getGuild();
 	if (!player || !guild) {
 		return false;
 	}
@@ -4171,7 +4105,7 @@ void Player::setPremiumTime(time_t premiumEndsAt)
 	sendBasicData();
 }
 
-PartyShields_t Player::getPartyShield(const Player* player) const
+PartyShields_t Player::getPartyShield(const std::shared_ptr<const Player>& player) const
 {
 	if (!player) {
 		return SHIELD_NONE;
@@ -4216,7 +4150,7 @@ PartyShields_t Player::getPartyShield(const Player* player) const
 		}
 	}
 
-	if (player->isInviting(this)) {
+	if (player->isInviting(getPlayer())) {
 		return SHIELD_WHITEYELLOW;
 	}
 
@@ -4227,31 +4161,31 @@ PartyShields_t Player::getPartyShield(const Player* player) const
 	return SHIELD_NONE;
 }
 
-bool Player::isInviting(const Player* player) const
+bool Player::isInviting(const std::shared_ptr<const Player>& player) const
 {
-	if (!player || !party || party->getLeader() != this) {
+	if (!player || !party || party->getLeader().get() != this) {
 		return false;
 	}
 	return party->isPlayerInvited(player);
 }
 
-bool Player::isPartner(const Player* player) const
+bool Player::isPartner(const std::shared_ptr<const Player>& player) const
 {
-	if (!player || !party || player == this) {
+	if (!player || !party || player.get() == this) {
 		return false;
 	}
 	return party == player->party;
 }
 
-bool Player::isGuildMate(const Player* player) const
+bool Player::isGuildMate(const std::shared_ptr<const Player>& player) const
 {
-	if (!player || !guild) {
+	if (!player || guild.expired()) {
 		return false;
 	}
-	return guild == player->guild;
+	return tfs::owner_equal(guild, player->guild);
 }
 
-void Player::sendPlayerPartyIcons(Player* player)
+void Player::sendPlayerPartyIcons(const std::shared_ptr<Player>& player)
 {
 	sendCreatureShield(player);
 	sendCreatureSkull(player);
@@ -4273,12 +4207,12 @@ void Player::removePartyInvitation(Party* party) { invitePartyList.remove(party)
 void Player::clearPartyInvitations()
 {
 	for (Party* invitingParty : invitePartyList) {
-		invitingParty->removeInvite(*this, false);
+		invitingParty->removeInvite(getPlayer(), false);
 	}
 	invitePartyList.clear();
 }
 
-GuildEmblems_t Player::getGuildEmblem(const Player* player) const
+GuildEmblems_t Player::getGuildEmblem(const std::shared_ptr<const Player>& player) const
 {
 	if (!player) {
 		return GUILDEMBLEM_NONE;
@@ -4290,11 +4224,11 @@ GuildEmblems_t Player::getGuildEmblem(const Player* player) const
 	}
 
 	if (player->getGuildWarVector().empty()) {
-		if (guild == playerGuild) {
+		if (tfs::owner_equal(guild, playerGuild)) {
 			return GUILDEMBLEM_MEMBER;
 		}
 		return GUILDEMBLEM_OTHER;
-	} else if (guild == playerGuild) {
+	} else if (tfs::owner_equal(guild, playerGuild)) {
 		return GUILDEMBLEM_ALLY;
 	} else if (isInWar(player)) {
 		return GUILDEMBLEM_ENEMY;
@@ -4321,7 +4255,7 @@ void Player::setCurrentMount(uint16_t mountId) { currentMount = mountId; }
 
 bool Player::toggleMount(bool mount)
 {
-	if ((OTSYS_TIME() - lastToggleMount) < 3000 && !wasMounted) {
+	if ((OTSYS_TIME() - lastToggleMount) < 3000 && !wasMounted_) {
 		sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
 		return false;
 	}
@@ -4331,7 +4265,7 @@ bool Player::toggleMount(bool mount)
 			return false;
 		}
 
-		if (!group->access && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+		if (const auto& tile = getTile(); !group->access && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 			sendCancelMessage(RETURNVALUE_ACTIONNOTPERMITTEDINPROTECTIONZONE);
 			return false;
 		}
@@ -4375,7 +4309,7 @@ bool Player::toggleMount(bool mount)
 		defaultOutfit.lookMount = currentMount->clientId;
 
 		if (currentMount->speed != 0) {
-			g_game.changeSpeed(this, currentMount->speed);
+			g_game.changeSpeed(getPlayer(), currentMount->speed);
 		}
 	} else {
 		if (!isMounted()) {
@@ -4385,7 +4319,7 @@ bool Player::toggleMount(bool mount)
 		dismount();
 	}
 
-	g_game.internalCreatureChangeOutfit(this, defaultOutfit);
+	g_game.internalCreatureChangeOutfit(getPlayer(), defaultOutfit);
 	lastToggleMount = OTSYS_TIME();
 	return true;
 }
@@ -4413,7 +4347,7 @@ bool Player::untameMount(uint16_t mountId)
 	if (getCurrentMount() == mountId) {
 		if (isMounted()) {
 			dismount();
-			g_game.internalCreatureChangeOutfit(this, defaultOutfit);
+			g_game.internalCreatureChangeOutfit(getPlayer(), defaultOutfit);
 		}
 
 		setCurrentMount(0);
@@ -4449,7 +4383,7 @@ void Player::dismount()
 {
 	Mount* mount = g_game.mounts.getMountByID(getCurrentMount());
 	if (mount && mount->speed > 0) {
-		g_game.changeSpeed(this, -mount->speed);
+		g_game.changeSpeed(getPlayer(), -mount->speed);
 	}
 
 	defaultOutfit.lookMount = 0;
@@ -4476,7 +4410,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 		oldSkillValue = magLevel;
 		oldPercentToNextLevel = static_cast<long double>(manaSpent * 100) / nextReqMana;
 
-		tfs::events::player::onGainSkillTries(this, SKILL_MAGLEVEL, tries);
+		tfs::events::player::onGainSkillTries(getPlayer(), SKILL_MAGLEVEL, tries);
 		uint32_t currMagLevel = magLevel;
 
 		while ((manaSpent + tries) >= nextReqMana) {
@@ -4485,7 +4419,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 			magLevel++;
 			manaSpent = 0;
 
-			g_creatureEvents->playerAdvance(this, SKILL_MAGLEVEL, magLevel - 1, magLevel);
+			g_creatureEvents->playerAdvance(getPlayer(), SKILL_MAGLEVEL, magLevel - 1, magLevel);
 
 			sendUpdate = true;
 			currReqMana = nextReqMana;
@@ -4528,7 +4462,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 		oldSkillValue = skills[skill].level;
 		oldPercentToNextLevel = static_cast<long double>(skills[skill].tries * 100) / nextReqTries;
 
-		tfs::events::player::onGainSkillTries(this, skill, tries);
+		tfs::events::player::onGainSkillTries(getPlayer(), skill, tries);
 		uint32_t currSkillLevel = skills[skill].level;
 
 		while ((skills[skill].tries + tries) >= nextReqTries) {
@@ -4538,7 +4472,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 			skills[skill].tries = 0;
 			skills[skill].percent = 0;
 
-			g_creatureEvents->playerAdvance(this, skill, (skills[skill].level - 1), skills[skill].level);
+			g_creatureEvents->playerAdvance(getPlayer(), skill, (skills[skill].level - 1), skills[skill].level);
 
 			sendUpdate = true;
 			currReqTries = nextReqTries;
@@ -4609,7 +4543,7 @@ void Player::clearModalWindows() { modalWindows.clear(); }
 void Player::sendClosePrivate(uint16_t channelId)
 {
 	if (channelId == CHANNEL_GUILD || channelId == CHANNEL_PARTY) {
-		g_chat->removeUserFromChannel(*this, channelId);
+		g_chat->removeUserFromChannel(getPlayer(), channelId);
 	}
 
 	if (client) {
@@ -4619,17 +4553,16 @@ void Player::sendClosePrivate(uint16_t channelId)
 
 uint64_t Player::getMoney() const
 {
-	std::vector<const Container*> containers;
+	std::vector<std::shared_ptr<const Container>> containers;
 	uint64_t moneyCount = 0;
 
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
 
-		const Container* container = item->getContainer();
-		if (container) {
+		if (const auto& container = item->getContainer()) {
 			containers.push_back(container);
 		} else {
 			moneyCount += item->getWorth();
@@ -4638,11 +4571,10 @@ uint64_t Player::getMoney() const
 
 	size_t i = 0;
 	while (i < containers.size()) {
-		const Container* container = containers[i++];
-		for (const Item* item : container->getItemList()) {
-			const Container* tmpContainer = item->getContainer();
-			if (tmpContainer) {
-				containers.push_back(tmpContainer);
+		const auto& container = containers[i++];
+		for (const auto& item : container->getItemList()) {
+			if (const auto& childContainer = item->getContainer()) {
+				containers.push_back(childContainer);
 			} else {
 				moneyCount += item->getWorth();
 			}
@@ -4687,31 +4619,31 @@ std::forward_list<Condition*> Player::getMuteConditions() const
 	return muteConditions;
 }
 
-void Player::setGuild(Guild_ptr guild)
+void Player::setGuild(const std::shared_ptr<Guild>& newGuild)
 {
-	if (guild == this->guild) {
+	if (tfs::owner_equal(newGuild, guild)) {
 		return;
 	}
 
-	auto oldGuild = this->guild;
+	const auto oldGuild = getGuild();
 
-	this->guildNick.clear();
-	this->guild = nullptr;
-	this->guildRank = nullptr;
+	guildNick.clear();
+	guild.reset();
+	guildRank.reset();
 
-	if (guild) {
-		const auto& rank = guild->getRankByLevel(Guild::MEMBER_RANK_LEVEL_DEFAULT);
+	if (newGuild) {
+		const auto& rank = newGuild->getRankByLevel(Guild::MEMBER_RANK_LEVEL_DEFAULT);
 		if (!rank) {
 			return;
 		}
 
-		this->guild = guild;
-		this->guildRank = rank;
-		guild->addMember(this);
+		guild = newGuild;
+		guildRank = rank;
+		newGuild->addMember(getPlayer());
 	}
 
 	if (oldGuild) {
-		oldGuild->removeMember(this);
+		oldGuild->removeMember(getPlayer());
 	}
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -12,6 +12,7 @@
 #include "guild.h"
 #include "inbox.h"
 #include "protocolgame.h"
+#include "storeinbox.h"
 #include "town.h"
 #include "vocation.h"
 
@@ -68,7 +69,7 @@ struct VIPEntry
 
 struct OpenContainer
 {
-	Container* container;
+	std::shared_ptr<Container> container;
 	uint16_t index;
 };
 
@@ -91,20 +92,24 @@ static constexpr int32_t NOTIFY_DEPOT_BOX_RANGE = 1;
 class Player final : public Creature
 {
 public:
-	explicit Player(ProtocolGame_ptr p);
-	~Player();
+	static uint32_t playerAutoID;
+	static uint32_t playerIDLimit;
 
-	using Creature::onWalk;
+	explicit Player(ProtocolGame_ptr p);
+	~Player() = default;
 
 	// non-copyable
 	Player(const Player&) = delete;
 	Player& operator=(const Player&) = delete;
 
-	Player* getPlayer() override { return this; }
-	const Player* getPlayer() const override { return this; }
+	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	Thing* getReceiver() override final { return this; }
-	const Thing* getReceiver() const override final { return this; }
+	std::shared_ptr<Player> getPlayer() override { return std::static_pointer_cast<Player>(shared_from_this()); }
+	std::shared_ptr<const Player> getPlayer() const override
+	{
+		return std::static_pointer_cast<const Player>(shared_from_this());
+	}
 
 	void setID() final;
 
@@ -128,6 +133,12 @@ public:
 	bool hasMounts() const;
 	void dismount();
 
+	bool wasMounted() const { return wasMounted_; }
+	void setWasMounted(bool wasMounted) { wasMounted_ = wasMounted; }
+
+	bool getRandomizeMount() const { return randomizeMount; }
+	void setRandomizeMount(bool mode) { randomizeMount = mode; }
+
 	void sendFYIBox(const std::string& message)
 	{
 		if (client) {
@@ -149,6 +160,7 @@ public:
 	}
 
 	uint16_t getStaminaMinutes() const { return staminaMinutes; }
+	void setStaminaMinutes(uint16_t minutes) { staminaMinutes = std::min<uint16_t>(2520, minutes); }
 
 	bool addOfflineTrainingTries(skills_t skill, uint64_t tries);
 
@@ -168,24 +180,25 @@ public:
 	uint64_t getBankBalance() const { return bankBalance; }
 	void setBankBalance(uint64_t balance) { bankBalance = balance; }
 
-	Guild_ptr getGuild() const { return guild; }
-	void setGuild(Guild_ptr guild);
+	std::shared_ptr<Guild> getGuild() const { return guild.lock(); }
+	void setGuild(const std::shared_ptr<Guild>& guild);
 
-	GuildRank_ptr getGuildRank() const { return guildRank; }
-	void setGuildRank(GuildRank_ptr newGuildRank) { guildRank = newGuildRank; }
+	std::shared_ptr<GuildRank> getGuildRank() const { return guildRank.lock(); }
+	void setGuildRank(const std::shared_ptr<GuildRank>& guildRank) { this->guildRank = guildRank; }
 
-	bool isGuildMate(const Player* player) const;
+	bool isGuildMate(const std::shared_ptr<const Player>& player) const;
 
 	const std::string& getGuildNick() const { return guildNick; }
-	void setGuildNick(std::string nick) { guildNick = nick; }
+	void setGuildNick(std::string nick) { guildNick = std::move(nick); }
 
-	bool isInWar(const Player* player) const;
+	bool isInWar(const std::shared_ptr<const Player>& player) const;
 	bool isInWarList(uint32_t guildId) const;
 
+	void setLoginPosition(Position pos) { loginPosition = pos; }
 	void setLastWalkthroughAttempt(int64_t walkthroughAttempt) { lastWalkthroughAttempt = walkthroughAttempt; }
 	void setLastWalkthroughPosition(Position walkthroughPosition) { lastWalkthroughPosition = walkthroughPosition; }
 
-	Inbox_ptr getInbox()
+	std::shared_ptr<Inbox> getInbox()
 	{
 		if (!inbox) {
 			inbox = std::make_shared<Inbox>(ITEM_INBOX);
@@ -193,7 +206,14 @@ public:
 		return inbox;
 	}
 
-	StoreInbox* getStoreInbox() const { return storeInbox; }
+	std::shared_ptr<StoreInbox> getStoreInbox()
+	{
+		if (!storeInbox) {
+			storeInbox = std::make_shared<StoreInbox>(ITEM_STORE_INBOX);
+			storeInbox->setParent(shared_from_this());
+		}
+		return storeInbox;
+	}
 
 	uint32_t getClientIcons() const;
 
@@ -217,22 +237,22 @@ public:
 
 	void setParty(Party* party) { this->party = party; }
 	Party* getParty() const { return party; }
-	PartyShields_t getPartyShield(const Player* player) const;
-	bool isInviting(const Player* player) const;
-	bool isPartner(const Player* player) const;
-	void sendPlayerPartyIcons(Player* player);
+	PartyShields_t getPartyShield(const std::shared_ptr<const Player>& player) const;
+	bool isInviting(const std::shared_ptr<const Player>& player) const;
+	bool isPartner(const std::shared_ptr<const Player>& player) const;
+	void sendPlayerPartyIcons(const std::shared_ptr<Player>& player);
 	bool addPartyInvitation(Party* party);
 	void removePartyInvitation(Party* party);
 	void clearPartyInvitations();
 
-	GuildEmblems_t getGuildEmblem(const Player* player) const;
+	GuildEmblems_t getGuildEmblem(const std::shared_ptr<const Player>& player) const;
 
 	uint64_t getSpentMana() const { return manaSpent; }
 
 	bool hasFlag(PlayerFlags value) const { return (group->flags & value) != 0; }
 
-	BedItem* getBedItem() { return bedItem; }
-	void setBedItem(BedItem* b) { bedItem = b; }
+	std::shared_ptr<BedItem> getBedItem() const { return bedItem.lock(); }
+	void setBedItem(const std::shared_ptr<BedItem>& bedItem) { this->bedItem = bedItem; }
 
 	void addBlessing(uint8_t blessing) { blessings.set(blessing); }
 	void removeBlessing(uint8_t blessing) { blessings.reset(blessing); }
@@ -247,12 +267,12 @@ public:
 	}
 	Connection::Address getIP() const;
 
-	void addContainer(uint8_t cid, Container* container);
-	void closeContainer(uint8_t cid);
+	void addContainer(uint8_t cid, std::shared_ptr<Container> container);
+	void closeContainer(uint8_t cid) { openContainers.erase(cid); }
 	void setContainerIndex(uint8_t cid, uint16_t index);
 
-	Container* getContainerByID(uint8_t cid);
-	int8_t getContainerID(const Container* container) const;
+	std::shared_ptr<Container> getContainerByID(uint8_t cid);
+	int8_t getContainerID(const std::shared_ptr<const Container>& container) const;
 	uint16_t getContainerIndex(uint8_t cid) const;
 
 	bool canOpenCorpse(uint32_t ownerId) const;
@@ -270,11 +290,12 @@ public:
 	void resetIdleTime() { idleTime = 0; }
 
 	bool isInGhostMode() const override { return ghostMode; }
-	bool canSeeGhostMode(const Creature* creature) const override;
+	bool canSeeGhostMode(const std::shared_ptr<const Creature>& creature) const override;
 	void switchGhostMode() { ghostMode = !ghostMode; }
 
 	uint32_t getAccount() const { return accountNumber; }
 	AccountType_t getAccountType() const { return accountType; }
+	void setAccountType(AccountType_t type) { accountType = type; }
 	uint32_t getLevel() const { return level; }
 	uint8_t getLevelPercent() const { return levelPercent; }
 	uint32_t getMagicLevel() const { return std::max<int32_t>(0, magLevel + varStats[STAT_MAGICPOINTS]); }
@@ -297,8 +318,8 @@ public:
 	uint64_t getExperience() const { return experience; }
 
 	time_t getLastLoginSaved() const { return lastLoginSaved; }
-
 	time_t getLastLogout() const { return lastLogout; }
+	time_t getPremiumEndsAt() const { return premiumEndsAt; }
 
 	const Position& getLoginPosition() const { return loginPosition; }
 	const Position& getTemplePosition() const { return town->templePosition; }
@@ -325,6 +346,7 @@ public:
 		}
 		return capacity;
 	}
+	void setCapacity(uint32_t newCapacity) { capacity = newCapacity; }
 
 	uint32_t getFreeCapacity() const
 	{
@@ -337,14 +359,28 @@ public:
 	}
 
 	int32_t getMaxHealth() const override { return std::max<int32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS]); }
+	void setMaxHealth(int32_t newMaxHealth) override
+	{
+		healthMax = newMaxHealth;
+		health = std::min<int32_t>(health, getMaxHealth());
+	}
+
 	uint32_t getMana() const { return mana; }
+	void setMana(uint32_t newMana) { mana = std::min<int32_t>(newMana, getMaxMana()); }
+
 	uint32_t getMaxMana() const { return std::max<int32_t>(0, manaMax + varStats[STAT_MAXMANAPOINTS]); }
+	void setMaxMana(uint32_t newMaxMana)
+	{
+		manaMax = newMaxMana;
+		mana = std::min<int32_t>(mana, getMaxMana());
+	}
+
 	uint16_t getManaShieldBar() const { return manaShieldBar; }
 	void setManaShieldBar(uint16_t value) { manaShieldBar = value; }
 	uint16_t getMaxManaShieldBar() const { return maxManaShieldBar; }
 	void setMaxManaShieldBar(uint16_t value) { maxManaShieldBar = value; }
 
-	Item* getInventoryItem(slots_t slot) const;
+	std::shared_ptr<Item> getInventoryItem(slots_t slot) const;
 
 	bool isItemAbilityEnabled(slots_t slot) const { return inventoryAbilities[slot]; }
 	void setItemAbility(slots_t slot, bool enabled) { inventoryAbilities[slot] = enabled; }
@@ -362,19 +398,20 @@ public:
 
 	int32_t getDefaultStats(stats_t stat) const;
 
-	void addConditionSuppressions(uint32_t conditions);
-	void removeConditionSuppressions(uint32_t conditions);
+	void addConditionSuppressions(uint32_t conditions) { conditionSuppressions |= conditions; }
+	void removeConditionSuppressions(uint32_t conditions) { conditionSuppressions &= ~conditions; }
 
-	DepotChest_ptr getDepotChest(uint32_t depotId, bool autoCreate);
-	DepotLocker& getDepotLocker();
+	const auto& getDepotChests() const { return depotChests; }
+	std::shared_ptr<DepotChest> getDepotChest(uint32_t depotId, bool autoCreate);
+	std::shared_ptr<DepotLocker> getDepotLocker();
 	void onReceiveMail() const;
 	bool isNearDepotBox() const;
 
 	bool canSee(const Position& pos) const override;
-	bool canSeeCreature(const Creature* creature) const override;
+	bool canSeeCreature(const std::shared_ptr<const Creature>& creature) const override;
 
-	bool canWalkthrough(const Creature* creature) const;
-	bool canWalkthroughEx(const Creature* creature) const;
+	bool canWalkthrough(const std::shared_ptr<const Creature>& creature) const;
+	bool canWalkthroughEx(const std::shared_ptr<const Creature>& creature) const;
 
 	RaceType_t getRace() const override { return RACE_BLOOD; }
 
@@ -383,39 +420,42 @@ public:
 	// safe-trade functions
 	void setTradeState(tradestate_t state) { tradeState = state; }
 	tradestate_t getTradeState() const { return tradeState; }
-	Item* getTradeItem() { return tradeItem; }
+	void setTradePartner(const std::shared_ptr<Player>& tradePartner) { this->tradePartner = tradePartner; }
+	std::shared_ptr<Player> getTradePartner() { return tradePartner.lock(); }
+	void setTradeItem(const std::shared_ptr<Item>& tradeItem) { this->tradeItem = tradeItem; }
+	std::shared_ptr<Item> getTradeItem() { return tradeItem.lock(); }
 
 	// shop functions
-	void setShopOwner(Npc* owner, int32_t onBuy, int32_t onSell)
+	void setShopOwner(std::shared_ptr<Npc> owner, int32_t onBuy, int32_t onSell)
 	{
-		shopOwner = owner;
+		shopOwner = std::move(owner);
 		purchaseCallback = onBuy;
 		saleCallback = onSell;
 	}
 
-	Npc* getShopOwner(int32_t& onBuy, int32_t& onSell)
+	std::shared_ptr<Npc> getShopOwner(int32_t& onBuy, int32_t& onSell)
 	{
 		onBuy = purchaseCallback;
 		onSell = saleCallback;
-		return shopOwner;
+		return shopOwner.lock();
 	}
 
-	const Npc* getShopOwner(int32_t& onBuy, int32_t& onSell) const
+	std::shared_ptr<const Npc> getShopOwner(int32_t& onBuy, int32_t& onSell) const
 	{
 		onBuy = purchaseCallback;
 		onSell = saleCallback;
-		return shopOwner;
+		return shopOwner.lock();
 	}
 
 	// V.I.P. functions
-	void notifyStatusChange(Player* loginPlayer, VipStatus_t status);
+	void notifyStatusChange(const std::shared_ptr<Player>& loginPlayer, VipStatus_t status);
 	bool removeVIP(uint32_t vipGuid);
 	bool addVIP(uint32_t vipGuid, const std::string& vipName, VipStatus_t status);
 	bool addVIPInternal(uint32_t vipGuid);
 	bool editVIP(uint32_t vipGuid, const std::string& description, uint32_t icon, bool notify);
 
 	// follow functions
-	void setFollowCreature(Creature* creature) override;
+	void setFollowCreature(const std::shared_ptr<Creature>& creature) override;
 	void goToFollowCreature() override;
 
 	// follow events
@@ -427,31 +467,35 @@ public:
 	void onWalkComplete() override;
 
 	void stopWalk();
-	void openShopWindow(Npc* npc, const std::list<ShopInfo>& shop);
+	void openShopWindow(const std::shared_ptr<Npc>& npc, const std::list<ShopInfo>& shop);
 	bool closeShopWindow(bool sendCloseShopWindow = true);
-	bool updateSaleShopList(const Item* item);
+	bool updateSaleShopList(const std::shared_ptr<const Item>& item);
 	bool hasShopItemForSale(uint32_t itemId, uint8_t subType) const;
 
+	bool getChaseMode() const { return chaseMode; }
 	void setChaseMode(bool mode);
+	fightMode_t getFightMode() const { return fightMode; }
 	void setFightMode(fightMode_t mode) { fightMode = mode; }
+	bool getSecureMode() const { return secureMode; }
 	void setSecureMode(bool mode) { secureMode = mode; }
 
 	// combat functions
-	void setAttackedCreature(Creature* creature) override;
+	void setAttackedCreature(const std::shared_ptr<Creature>& creature) override;
 	void removeAttackedCreature() override;
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
 	bool isAttackable() const override;
-	static bool lastHitIsPlayer(Creature* lastHitCreature);
+	static bool lastHitIsPlayer(const std::shared_ptr<Creature>& lastHitCreature);
 
 	void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
 	void changeMana(int32_t manaChange);
 	void changeSoul(int32_t soulChange);
 
 	bool isPzLocked() const { return pzLocked; }
-	BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage, bool checkDefense = false,
-	                     bool checkArmor = false, bool field = false, bool ignoreResistances = false) override;
+	BlockType_t blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,
+	                     bool checkDefense = false, bool checkArmor = false, bool field = false,
+	                     bool ignoreResistances = false) override;
 	void doAttacking(uint32_t interval) override;
 	bool hasExtraSwing() override { return lastAttack > 0 && ((OTSYS_TIME() - lastAttack) >= getAttackSpeed()); }
 
@@ -466,18 +510,19 @@ public:
 	}
 	uint16_t getBaseSkill(uint8_t skill) const { return skills[skill].level; }
 	uint16_t getSkillPercent(uint8_t skill) const { return skills[skill].percent; }
+	uint64_t getSkillTries(uint8_t skill) const { return skills[skill].tries; }
 
 	bool getAddAttackSkill() const { return addAttackSkillPoint; }
 	BlockType_t getLastAttackBlockType() const { return lastAttackBlockType; }
 
-	Item* getWeapon(slots_t slot, bool ignoreAmmo) const;
-	Item* getWeapon(bool ignoreAmmo = false) const;
+	std::shared_ptr<Item> getWeapon(slots_t slot, bool ignoreAmmo) const;
+	std::shared_ptr<Item> getWeapon(bool ignoreAmmo = false) const;
 	WeaponType_t getWeaponType() const;
-	int32_t getWeaponSkill(const Item* item) const;
-	void getShieldAndWeapon(const Item*& shield, const Item*& weapon) const;
+	int32_t getWeaponSkill(const std::shared_ptr<const Item>& item) const;
+	std::pair<std::shared_ptr<const Item>, std::shared_ptr<const Item>> getShieldAndWeapon() const;
 
-	void drainHealth(Creature* attacker, int32_t damage) override;
-	void drainMana(Creature* attacker, int32_t manaLoss);
+	void drainHealth(const std::shared_ptr<Creature>& attacker, int32_t damage) override;
+	void drainMana(const std::shared_ptr<Creature>& attacker, int32_t manaLoss);
 	void addManaSpent(uint64_t amount);
 	void removeManaSpent(uint64_t amount, bool notify = false);
 	void addSkillAdvance(skills_t skill, uint64_t count);
@@ -490,20 +535,20 @@ public:
 
 	void addInFightTicks(bool pzlock = false);
 
-	uint64_t getGainedExperience(Creature* attacker) const override;
+	uint64_t getGainedExperience(const std::shared_ptr<Creature>& attacker) const override;
 
 	// combat event functions
 	void onAddCondition(ConditionType_t type) override;
 	void onAddCombatCondition(ConditionType_t type) override;
 	void onEndCondition(ConditionType_t type) override;
 	void onCombatRemoveCondition(Condition* condition) override;
-	void onAttackedCreature(Creature* target, bool addFightTicks = true) override;
+	void onAttackedCreature(const std::shared_ptr<Creature>& target, bool addFightTicks = true) override;
 	void onAttacked() override;
-	void onAttackedCreatureDrainHealth(Creature* target, int32_t points) override;
-	void onTargetCreatureGainHealth(Creature* target, int32_t points) override;
-	bool onKilledCreature(Creature* target, bool lastHit = true) override;
-	void onGainExperience(uint64_t gainExp, Creature* target) override;
-	void onGainSharedExperience(uint64_t gainExp, Creature* source);
+	void onAttackedCreatureDrainHealth(const std::shared_ptr<Creature>& target, int32_t points) override;
+	void onTargetCreatureGainHealth(const std::shared_ptr<Creature>& target, int32_t points) override;
+	bool onKilledCreature(const std::shared_ptr<Creature>& target, bool lastHit = true) override;
+	void onGainExperience(uint64_t gainExp, const std::shared_ptr<Creature>& target) override;
+	void onGainSharedExperience(uint64_t gainExp, const std::shared_ptr<Creature>& source);
 	void onAttackedCreatureBlockHit(BlockType_t blockType) override;
 	void onBlockHit() override;
 	void onChangeZone(ZoneType_t zone) override;
@@ -513,16 +558,16 @@ public:
 	LightInfo getCreatureLight() const override;
 
 	Skulls_t getSkull() const override;
-	Skulls_t getSkullClient(const Creature* creature) const override;
+	Skulls_t getSkullClient(const std::shared_ptr<const Creature>& creature) const override;
 	int64_t getSkullTicks() const { return skullTicks; }
 	void setSkullTicks(int64_t ticks) { skullTicks = ticks; }
 
-	bool hasAttacked(const Player* attacked) const;
-	void addAttacked(const Player* attacked);
-	void removeAttacked(const Player* attacked);
+	bool hasAttacked(const std::shared_ptr<const Player>& attacked) const;
+	void addAttacked(const std::shared_ptr<const Player>& attacked);
+	void removeAttacked(const std::shared_ptr<const Player>& attacked);
 	void clearAttacked();
-	void addUnjustifiedDead(const Player* attacked);
-	void sendCreatureSkull(const Creature* creature) const
+	void addUnjustifiedDead(const std::shared_ptr<const Player>& attacked);
+	void sendCreatureSkull(const std::shared_ptr<const Creature>& creature) const
 	{
 		if (client) {
 			client->sendCreatureSkull(creature);
@@ -542,19 +587,21 @@ public:
 
 	// tile
 	// send methods
-	void sendAddTileItem(const Tile* tile, const Position& pos, const Item* item)
+	void sendAddTileItem(const std::shared_ptr<const Tile>& tile, const Position& pos,
+	                     const std::shared_ptr<const Item>& item)
 	{
 		if (client) {
-			int32_t stackpos = tile->getStackposOfItem(this, item);
+			int32_t stackpos = tile->getStackposOfItem(getPlayer(), item);
 			if (stackpos != -1) {
 				client->sendAddTileItem(pos, stackpos, item);
 			}
 		}
 	}
-	void sendUpdateTileItem(const Tile* tile, const Position& pos, const Item* item)
+	void sendUpdateTileItem(const std::shared_ptr<const Tile>& tile, const Position& pos,
+	                        const std::shared_ptr<const Item>& item)
 	{
 		if (client) {
-			int32_t stackpos = tile->getStackposOfItem(this, item);
+			int32_t stackpos = tile->getStackposOfItem(getPlayer(), item);
 			if (stackpos != -1) {
 				client->sendUpdateTileItem(pos, stackpos, item);
 			}
@@ -566,26 +613,27 @@ public:
 			client->sendRemoveTileThing(pos, stackpos);
 		}
 	}
-	void sendUpdateTileCreature(const Creature* creature)
+	void sendUpdateTileCreature(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client) {
 			client->sendUpdateTileCreature(creature->getPosition(),
-			                               creature->getTile()->getClientIndexOfCreature(this, creature), creature);
+			                               creature->getTile()->getClientIndexOfCreature(getPlayer(), creature),
+			                               creature);
 		}
 	}
-	void sendRemoveTileCreature(const Creature* creature, const Position& pos, int32_t stackpos)
+	void sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos, int32_t stackpos)
 	{
 		if (client) {
 			client->sendRemoveTileCreature(creature, pos, stackpos);
 		}
 	}
-	void sendUpdateTile(const Tile* tile, const Position& pos)
+	void sendUpdateTile(const std::shared_ptr<const Tile>& tile, const Position& pos)
 	{
 		if (client) {
 			client->sendUpdateTile(tile, pos);
 		}
 	}
-	void sendUpdateCreatureIcons(const Creature* creature)
+	void sendUpdateCreatureIcons(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client) {
 			client->sendUpdateCreatureIcons(creature);
@@ -604,55 +652,56 @@ public:
 			client->sendChannelEvent(channelId, playerName, channelEvent);
 		}
 	}
-	void sendAddCreature(const Creature* creature, const Position& pos, MagicEffectClasses magicEffect = CONST_ME_NONE)
+	void sendAddCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
+	                     MagicEffectClasses magicEffect = CONST_ME_NONE)
 	{
 		if (client) {
-			client->sendAddCreature(creature, pos, creature->getTile()->getClientIndexOfCreature(this, creature),
+			client->sendAddCreature(creature, pos, creature->getTile()->getClientIndexOfCreature(getPlayer(), creature),
 			                        magicEffect);
 		}
 	}
-	void sendCreatureMove(const Creature* creature, const Position& newPos, int32_t newStackPos, const Position& oldPos,
-	                      int32_t oldStackPos, bool teleport)
+	void sendCreatureMove(const std::shared_ptr<const Creature>& creature, const Position& newPos, int32_t newStackPos,
+	                      const Position& oldPos, int32_t oldStackPos, bool teleport)
 	{
 		if (client) {
 			client->sendMoveCreature(creature, newPos, newStackPos, oldPos, oldStackPos, teleport);
 		}
 	}
-	void sendCreatureTurn(const Creature* creature)
+	void sendCreatureTurn(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client && canSeeCreature(creature)) {
-			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(this, creature);
+			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(getPlayer(), creature);
 			if (stackpos != -1) {
 				client->sendCreatureTurn(creature, stackpos);
 			}
 		}
 	}
-	void sendCreatureSay(const Creature* creature, SpeakClasses type, const std::string& text,
+	void sendCreatureSay(const std::shared_ptr<const Creature>& creature, SpeakClasses type, const std::string& text,
 	                     const Position* pos = nullptr)
 	{
 		if (client) {
 			client->sendCreatureSay(creature, type, text, pos);
 		}
 	}
-	void sendPrivateMessage(const Player* speaker, SpeakClasses type, const std::string& text)
+	void sendPrivateMessage(const std::shared_ptr<const Player>& speaker, SpeakClasses type, const std::string& text)
 	{
 		if (client) {
 			client->sendPrivateMessage(speaker, type, text);
 		}
 	}
-	void sendCreatureSquare(const Creature* creature, SquareColor_t color)
+	void sendCreatureSquare(const std::shared_ptr<const Creature>& creature, SquareColor_t color)
 	{
 		if (client) {
 			client->sendCreatureSquare(creature, color);
 		}
 	}
-	void sendCreatureChangeOutfit(const Creature* creature, const Outfit_t& outfit)
+	void sendCreatureChangeOutfit(const std::shared_ptr<const Creature>& creature, const Outfit_t& outfit)
 	{
 		if (client) {
 			client->sendCreatureOutfit(creature, outfit);
 		}
 	}
-	void sendCreatureChangeVisible(const Creature* creature, bool visible)
+	void sendCreatureChangeVisible(const std::shared_ptr<const Creature>& creature, bool visible)
 	{
 		if (!client) {
 			return;
@@ -668,7 +717,7 @@ public:
 		} else if (canSeeInvisibility()) {
 			client->sendCreatureOutfit(creature, creature->getCurrentOutfit());
 		} else {
-			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(this, creature);
+			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(getPlayer(), creature);
 			if (stackpos == -1) {
 				return;
 			}
@@ -683,22 +732,22 @@ public:
 	void sendLight()
 	{
 		if (client) {
-			client->sendCreatureLight(this);
+			client->sendCreatureLight(getCreature());
 		}
 	}
-	void sendCreatureLight(const Creature* creature)
+	void sendCreatureLight(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client) {
 			client->sendCreatureLight(creature);
 		}
 	}
-	void sendCreatureWalkthrough(const Creature* creature, bool walkthrough)
+	void sendCreatureWalkthrough(const std::shared_ptr<const Creature>& creature, bool walkthrough)
 	{
 		if (client) {
 			client->sendCreatureWalkthrough(creature, walkthrough);
 		}
 	}
-	void sendCreatureShield(const Creature* creature)
+	void sendCreatureShield(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client) {
 			client->sendCreatureShield(creature);
@@ -731,10 +780,12 @@ public:
 	void sendModalWindow(const ModalWindow& modalWindow);
 
 	// container
-	void sendAddContainerItem(const Container* container, const Item* item);
-	void sendUpdateContainerItem(const Container* container, uint16_t slot, const Item* newItem);
-	void sendRemoveContainerItem(const Container* container, uint16_t slot);
-	void sendContainer(uint8_t cid, const Container* container, uint16_t firstIndex)
+	void sendAddContainerItem(const std::shared_ptr<const Container>& container,
+	                          const std::shared_ptr<const Item>& item);
+	void sendUpdateContainerItem(const std::shared_ptr<const Container>& container, uint16_t slot,
+	                             const std::shared_ptr<const Item>& newItem);
+	void sendRemoveContainerItem(const std::shared_ptr<const Container>& container, uint16_t slot);
+	void sendContainer(uint8_t cid, const std::shared_ptr<const Container>& container, uint16_t firstIndex)
 	{
 		if (client) {
 			client->sendContainer(cid, container, firstIndex);
@@ -742,7 +793,7 @@ public:
 	}
 
 	// inventory
-	void sendInventoryItem(slots_t slot, const Item* item)
+	void sendInventoryItem(slots_t slot, const std::shared_ptr<const Item>& item)
 	{
 		if (client) {
 			client->sendInventoryItem(slot, item);
@@ -759,22 +810,22 @@ public:
 	{
 		if (!sendAll) {
 			// update one slot
-			Thing* slotThing = getThing(CONST_SLOT_RIGHT);
-			if (slotThing) {
-				Item* slotItem = slotThing->getItem();
-				if (slotItem && slotItem->getWeaponType() == WEAPON_QUIVER) {
-					sendInventoryItem(CONST_SLOT_RIGHT, slotItem);
+			if (const auto& slotThing = getThing(CONST_SLOT_RIGHT)) {
+				if (const auto& slotItem = slotThing->getItem()) {
+					if (slotItem->getWeaponType() == WEAPON_QUIVER) {
+						sendInventoryItem(CONST_SLOT_RIGHT, slotItem);
+					}
 				}
 			}
 		} else {
 			// update all slots
-			std::vector<slots_t> slots = {CONST_SLOT_RIGHT, CONST_SLOT_LEFT, CONST_SLOT_AMMO};
-			for (auto const& slot : slots) {
-				Thing* slotThing = getThing(slot);
-				if (slotThing) {
-					Item* slotItem = slotThing->getItem();
-					if (slotItem && slotItem->getWeaponType() == WEAPON_QUIVER) {
-						sendInventoryItem(slot, slotItem);
+			constexpr auto slots = std::array{CONST_SLOT_RIGHT, CONST_SLOT_LEFT, CONST_SLOT_AMMO};
+			for (const auto& slot : slots) {
+				if (const auto& slotThing = getThing(slot)) {
+					if (const auto& slotItem = slotThing->getItem()) {
+						if (slotItem->getWeaponType() == WEAPON_QUIVER) {
+							sendInventoryItem(slot, slotItem);
+						}
 					}
 				}
 			}
@@ -782,30 +833,36 @@ public:
 	}
 
 	// event methods
-	void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem, const ItemType& oldType,
-	                      const Item* newItem, const ItemType& newType) override;
-	void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType, const Item* item) override;
+	void onUpdateTileItem(const std::shared_ptr<const Tile>& tile, const Position& pos,
+	                      const std::shared_ptr<const Item>& oldItem, const ItemType& oldType,
+	                      const std::shared_ptr<const Item>& newItem, const ItemType& newType) override;
+	void onRemoveTileItem(const std::shared_ptr<const Tile>& tile, const Position& pos, const ItemType& iType,
+	                      const std::shared_ptr<const Item>& item) override;
 
-	void onCreatureAppear(Creature* creature, bool isLogin, MagicEffectClasses magicEffect) override;
-	void onRemoveCreature(Creature* creature, bool isLogout) override;
-	void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile,
-	                    const Position& oldPos, bool teleport) override;
+	void onCreatureAppear(const std::shared_ptr<Creature>& creature, bool isLogin,
+	                      MagicEffectClasses magicEffect) override;
+	void onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout) override;
+	void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
+	                    const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
+	                    bool teleport) override;
 
 	void onAttackedCreatureDisappear(bool isLogout) override;
 	void onFollowCreatureDisappear(bool isLogout) override;
 
 	// container
-	void onAddContainerItem(const Item* item);
-	void onUpdateContainerItem(const Container* container, const Item* oldItem, const Item* newItem);
-	void onRemoveContainerItem(const Container* container, const Item* item);
+	void onAddContainerItem(const std::shared_ptr<const Item>& item);
+	void onUpdateContainerItem(const std::shared_ptr<const Container>& container,
+	                           const std::shared_ptr<const Item>& oldItem, const std::shared_ptr<const Item>& newItem);
+	void onRemoveContainerItem(const std::shared_ptr<const Container>& container,
+	                           const std::shared_ptr<const Item>& item);
 
-	void onCloseContainer(const Container* container);
-	void onSendContainer(const Container* container);
-	void autoCloseContainers(const Container* container);
+	void onCloseContainer(const std::shared_ptr<const Container>& container);
+	void onSendContainer(const std::shared_ptr<const Container>& container);
+	void autoCloseContainers(const std::shared_ptr<const Container>& container);
 
 	// inventory
-	void onUpdateInventoryItem(Item* oldItem, Item* newItem);
-	void onRemoveInventoryItem(Item* item);
+	void onUpdateInventoryItem(const std::shared_ptr<Item>& oldItem, const std::shared_ptr<Item>& newItem);
+	void onRemoveInventoryItem(const std::shared_ptr<Item>& item);
 
 	void sendVIPEntries() const
 	{
@@ -856,13 +913,13 @@ public:
 			client->sendCancelWalk();
 		}
 	}
-	void sendChangeSpeed(const Creature* creature, uint32_t newSpeed) const
+	void sendChangeSpeed(const std::shared_ptr<const Creature>& creature, uint32_t newSpeed) const
 	{
 		if (client) {
 			client->sendChangeSpeed(creature, newSpeed);
 		}
 	}
-	void sendCreatureHealth(const Creature* creature) const
+	void sendCreatureHealth(const std::shared_ptr<const Creature>& creature) const
 	{
 		if (client) {
 			client->sendCreatureHealth(creature);
@@ -946,7 +1003,7 @@ public:
 			client->sendReLoginWindow(unfairFightReduction);
 		}
 	}
-	void sendTextWindow(Item* item, uint16_t maxlen, bool canWrite) const
+	void sendTextWindow(const std::shared_ptr<Item>& item, uint16_t maxlen, bool canWrite) const
 	{
 		if (client) {
 			client->sendTextWindow(windowTextId, item, maxlen, canWrite);
@@ -958,13 +1015,14 @@ public:
 			client->sendTextWindow(windowTextId, itemId, text);
 		}
 	}
-	void sendToChannel(const Creature* creature, SpeakClasses type, const std::string& text, uint16_t channelId) const
+	void sendToChannel(const std::shared_ptr<const Creature>& creature, SpeakClasses type, const std::string& text,
+	                   uint16_t channelId) const
 	{
 		if (client) {
 			client->sendToChannel(creature, type, text, channelId);
 		}
 	}
-	void sendShop(Npc* npc) const
+	void sendShop(const std::shared_ptr<Npc>& npc) const
 	{
 		if (client) {
 			client->sendShop(npc, shopItemList);
@@ -1027,7 +1085,7 @@ public:
 			client->sendMarketCancelOffer(offer);
 		}
 	}
-	void sendTradeItemRequest(const std::string& traderName, const Item* item, bool ack) const
+	void sendTradeItemRequest(const std::string& traderName, const std::shared_ptr<const Item>& item, bool ack) const
 	{
 		if (client) {
 			client->sendTradeItemRequest(traderName, item, ack);
@@ -1057,7 +1115,7 @@ public:
 			client->sendOutfitWindow();
 		}
 	}
-	void sendPodiumWindow(const Item* item)
+	void sendPodiumWindow(const std::shared_ptr<const Item>& item)
 	{
 		if (client) {
 			client->sendPodiumWindow(item);
@@ -1125,10 +1183,13 @@ public:
 
 	void onThink(uint32_t interval) override;
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+
+	void setNextWalkActionTask(SchedulerTask* task);
+	void setNextActionTask(SchedulerTask* task, bool resetIdleTime = true);
 
 	void setNextAction(int64_t time)
 	{
@@ -1139,8 +1200,8 @@ public:
 	bool canDoAction() const { return nextAction <= OTSYS_TIME(); }
 	uint32_t getNextActionTime() const;
 
-	Item* getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen);
-	void setWriteItem(Item* item, uint16_t maxWriteLen = 0);
+	std::shared_ptr<Item> getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen);
+	uint32_t setWriteItem(const std::shared_ptr<Item>& item, uint16_t maxWriteLen = 0);
 
 	House* getEditHouse(uint32_t& windowTextId, uint32_t& listId);
 	void setEditHouse(House* house, uint32_t listId = 0);
@@ -1162,56 +1223,58 @@ public:
 	uint16_t getClientLowLevelBonusDisplay() const { return clientLowLevelBonusDisplay; }
 	void setClientLowLevelBonusDisplay(uint16_t value) { clientLowLevelBonusDisplay = value; }
 
-private:
-	std::forward_list<Condition*> getMuteConditions() const;
-
-	void checkTradeState(const Item* item);
-	bool hasCapacity(const Item* item, uint32_t count) const;
-
-	void gainExperience(uint64_t gainExp, Creature* source);
-	void addExperience(Creature* source, uint64_t exp, bool sendText = false);
-	void removeExperience(uint64_t exp, bool sendText = false);
-
-	void updateInventoryWeight();
-
-	void setNextWalkActionTask(SchedulerTask* task);
-	void setNextActionTask(SchedulerTask* task, bool resetIdleTime = true);
-
-	void death(Creature* lastHitCreature) override;
-	bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified,
-	                bool mostDamageUnjustified) override;
-	Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) override;
-
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                     Creature* actor = nullptr) const override;
-	ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-	                          uint32_t flags) const override;
-	ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags,
-	                        Creature* actor = nullptr) const override;
-	Thing* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override;
-
-	void addThing(int32_t index, Thing* thing) override;
-
-	void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
-	void replaceThing(uint32_t index, Thing* thing) override;
-
-	void removeThing(Thing* thing, uint32_t count) override;
-
-	int32_t getThingIndex(const Thing* thing) const override;
+	int32_t getThingIndex(const std::shared_ptr<const Thing>& thing) const override;
 	size_t getFirstIndex() const override { return CONST_SLOT_FIRST; }
 	size_t getLastIndex() const override { return CONST_SLOT_LAST + 1; }
 	uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override;
 	std::map<uint32_t, uint32_t>& getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const override;
-	Thing* getThing(size_t index) const override;
+	std::shared_ptr<Thing> getThing(size_t index) const override;
 
-	void internalAddThing(Thing* thing) override { internalAddThing(0, thing); }
-	void internalAddThing(uint32_t index, Thing* thing) override;
+	void addExperience(const std::shared_ptr<Creature>& source, uint64_t exp, bool sendText = false);
+	void removeExperience(uint64_t exp, bool sendText = false);
+	double getLostPercent() const;
+
+private:
+	std::forward_list<Condition*> getMuteConditions() const;
+
+	void checkTradeState(const std::shared_ptr<const Item>& item);
+	bool hasCapacity(const std::shared_ptr<const Item>& item, uint32_t count) const;
+
+	void gainExperience(uint64_t gainExp, const std::shared_ptr<Creature>& source);
+
+	void updateInventoryWeight();
+
+	void death(const std::shared_ptr<Creature>& lastHitCreature) override;
+	bool dropCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+	                const std::shared_ptr<Creature>& mostDamageCreature, bool lastHitUnjustified,
+	                bool mostDamageUnjustified) override;
+	std::shared_ptr<Item> getCorpse(const std::shared_ptr<Creature>& lastHitCreature,
+	                                const std::shared_ptr<Creature>& mostDamageCreature) override;
+
+	ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                     const std::shared_ptr<Creature>& actor = nullptr) const override;
+	ReturnValue queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+	                          uint32_t& maxQueryCount, uint32_t flags) const override;
+	ReturnValue queryRemove(const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                        const std::shared_ptr<Creature>& actor = nullptr) const override;
+	std::shared_ptr<Thing> queryDestination(int32_t& index, const std::shared_ptr<const Thing>& thing,
+	                                        std::shared_ptr<Item>& destItem, uint32_t& flags) override;
+
+	void addThing(int32_t index, const std::shared_ptr<Thing>& thing) override;
+
+	void updateThing(const std::shared_ptr<Thing>& thing, uint16_t itemId, uint32_t count) override;
+	void replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing) override;
+
+	void removeThing(const std::shared_ptr<Thing>& thing, uint32_t count) override;
+
+	void internalAddThing(const std::shared_ptr<Thing>& thing) override { internalAddThing(0, thing); }
+	void internalAddThing(uint32_t index, const std::shared_ptr<Thing>& thing) override;
 
 	std::unordered_set<uint32_t> attackedSet;
 	std::unordered_set<uint32_t> VIPList;
 
 	std::map<uint8_t, OpenContainer> openContainers;
-	std::map<uint32_t, DepotChest_ptr> depotChests;
+	std::map<uint32_t, std::shared_ptr<DepotChest>> depotChests;
 
 	std::map<uint16_t, uint8_t> outfits;
 	std::unordered_set<uint16_t> mounts;
@@ -1251,23 +1314,23 @@ private:
 
 	ProtocolGame_ptr client;
 	Connection::Address lastIP = {};
-	BedItem* bedItem = nullptr;
-	Guild_ptr guild = nullptr;
-	GuildRank_ptr guildRank = nullptr;
+	std::weak_ptr<BedItem> bedItem;
+	std::weak_ptr<Guild> guild;
+	std::weak_ptr<GuildRank> guildRank;
 	Group* group = nullptr;
-	Inbox_ptr inbox = nullptr;
-	Item* tradeItem = nullptr;
-	Item* inventory[CONST_SLOT_LAST + 1] = {};
-	Item* writeItem = nullptr;
+	std::shared_ptr<Inbox> inbox = nullptr;
+	std::weak_ptr<Item> tradeItem;
+	std::shared_ptr<Item> inventory[CONST_SLOT_LAST + 1] = {};
+	std::weak_ptr<Item> writeItem;
 	House* editHouse = nullptr;
-	Npc* shopOwner = nullptr;
+	std::weak_ptr<Npc> shopOwner;
 	Party* party = nullptr;
-	Player* tradePartner = nullptr;
+	std::weak_ptr<Player> tradePartner;
 	SchedulerTask* walkTask = nullptr;
 	const Town* town = nullptr;
 	Vocation* vocation = nullptr;
-	StoreInbox* storeInbox = nullptr;
-	DepotLocker_ptr depotLocker = nullptr;
+	std::shared_ptr<StoreInbox> storeInbox = nullptr;
+	std::shared_ptr<DepotLocker> depotLocker = nullptr;
 
 	uint32_t inventoryWeight = 0;
 	uint32_t capacity = 40000;
@@ -1323,16 +1386,13 @@ private:
 	bool chaseMode = false;
 	bool secureMode = false;
 	bool inMarket = false;
-	bool wasMounted = false;
+	bool wasMounted_ = false;
 	bool ghostMode = false;
 	bool pzLocked = false;
 	bool isConnecting = false;
 	bool addAttackSkillPoint = false;
 	bool inventoryAbilities[CONST_SLOT_LAST + 1] = {};
 	bool randomizeMount = false;
-
-	static uint32_t playerAutoID;
-	static uint32_t playerIDLimit;
 
 	void updateItemsLight(bool internal = false);
 	int32_t getStepSpeed() const override
@@ -1353,7 +1413,7 @@ private:
 	uint32_t getAttackSpeed() const;
 
 	static uint16_t getBasisPointLevel(uint64_t count, uint64_t nextLevelCount);
-	double getLostPercent() const;
+
 	uint64_t getLostExperience() const override
 	{
 		return skillLoss ? static_cast<uint64_t>(experience * getLostPercent()) : 0;
@@ -1362,13 +1422,8 @@ private:
 	uint32_t getConditionImmunities() const override { return conditionImmunities; }
 	uint32_t getConditionSuppressions() const override { return conditionSuppressions; }
 	uint16_t getLookCorpse() const override;
-	void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
+	void getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const override;
 
-	friend class Game;
-	friend class Npc;
-	friend class LuaScriptInterface;
-	friend class Map;
-	friend class Actions;
 	friend class IOLoginData;
 	friend class ProtocolGame;
 };

--- a/src/podium.cpp
+++ b/src/podium.cpp
@@ -39,7 +39,7 @@ Attr_ReadValue Podium::readAttr(AttrTypes_t attr, PropStream& propStream)
 			propStream.read<uint8_t>(newOutfit.lookMountFeet);
 			setOutfit(newOutfit);
 
-			g_game.updatePodium(this);
+			g_game.updatePodium(getPodium());
 			return ATTR_READ_CONTINUE;
 		}
 

--- a/src/podium.h
+++ b/src/podium.h
@@ -11,8 +11,11 @@ class Podium final : public Item
 public:
 	explicit Podium(uint16_t type) : Item(type) {};
 
-	Podium* getPodium() override { return this; }
-	const Podium* getPodium() const override { return this; }
+	std::shared_ptr<Podium> getPodium() override { return std::static_pointer_cast<Podium>(shared_from_this()); }
+	std::shared_ptr<const Podium> getPodium() const override
+	{
+		return std::static_pointer_cast<const Podium>(shared_from_this());
+	}
 
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 	void serializeAttr(PropWriteStream& propWriteStream) const override;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -9,13 +9,9 @@
 #include "base64.h"
 #include "condition.h"
 #include "configmanager.h"
-#include "depotchest.h"
 #include "game.h"
-#include "inbox.h"
 #include "iologindata.h"
 #include "iomarket.h"
-#include "monster.h"
-#include "npc.h"
 #include "outfit.h"
 #include "outputmessage.h"
 #include "player.h"
@@ -141,7 +137,6 @@ void ProtocolGame::release()
 	// dispatcher thread
 	if (player && player->client == shared_from_this()) {
 		player->client.reset();
-		player->decrementReferenceCounter();
 		player = nullptr;
 	}
 
@@ -153,11 +148,10 @@ void ProtocolGame::release()
 void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSystem_t operatingSystem)
 {
 	// dispatcher thread
-	Player* foundPlayer = g_game.getPlayerByGUID(characterId);
+	const auto& foundPlayer = g_game.getPlayerByGUID(characterId);
 	if (!foundPlayer || getBoolean(ConfigManager::ALLOW_CLONES)) {
-		player = new Player(getThis());
+		player = std::make_shared<Player>(getThis());
 
-		player->incrementReferenceCounter();
 		player->setID();
 		player->setGUID(characterId);
 
@@ -264,7 +258,7 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	// dispatcher thread
 	eventConnect = 0;
 
-	Player* foundPlayer = g_game.getPlayerByID(playerId);
+	const auto& foundPlayer = g_game.getPlayerByID(playerId);
 	if (!foundPlayer || foundPlayer->client) {
 		disconnectClient("You are already logged in.");
 		return;
@@ -277,9 +271,8 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	}
 
 	player = foundPlayer;
-	player->incrementReferenceCounter();
 
-	g_chat->removeUserFromAllChannels(*player);
+	g_chat->removeUserFromAllChannels(player);
 	player->clearModalWindows();
 	player->setOperatingSystem(operatingSystem);
 	player->isConnecting = false;
@@ -805,11 +798,10 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 	}
 }
 
-void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
+void ProtocolGame::GetTileDescription(const std::shared_ptr<const Tile>& tile, NetworkMessage& msg)
 {
 	int32_t count;
-	Item* ground = tile->getGround();
-	if (ground) {
+	if (const auto& ground = tile->getGround()) {
 		msg.addItem(ground);
 		count = 1;
 	} else {
@@ -830,7 +822,7 @@ void ProtocolGame::GetTileDescription(const Tile* tile, NetworkMessage& msg)
 	const CreatureVector* creatures = tile->getCreatures();
 	if (creatures) {
 		for (auto it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
-			const Creature* creature = (*it);
+			const auto& creature = *it;
 			if (!player->canSeeCreature(creature)) {
 				continue;
 			}
@@ -885,8 +877,7 @@ void ProtocolGame::GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y
 {
 	for (int32_t nx = 0; nx < width; nx++) {
 		for (int32_t ny = 0; ny < height; ny++) {
-			Tile* tile = g_game.map.getTile(x + nx + offset, y + ny + offset, z);
-			if (tile) {
+			if (const auto& tile = g_game.map.getTile(x + nx + offset, y + ny + offset, z)) {
 				if (skip >= 0) {
 					msg.addByte(skip);
 					msg.addByte(0xFF);
@@ -918,7 +909,7 @@ void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& remo
 	if (knownCreatureSet.size() > 1300) {
 		// Look for a creature to remove
 		for (auto it = knownCreatureSet.begin(), end = knownCreatureSet.end(); it != end; ++it) {
-			Creature* creature = g_game.getCreatureByID(*it);
+			const auto& creature = g_game.getCreatureByID(*it);
 			if (!canSee(creature)) {
 				removedKnown = *it;
 				knownCreatureSet.erase(it);
@@ -939,7 +930,7 @@ void ProtocolGame::checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& remo
 	}
 }
 
-bool ProtocolGame::canSee(const Creature* c) const
+bool ProtocolGame::canSee(const std::shared_ptr<const Creature>& c) const
 {
 	if (!c || !player || c->isRemoved()) {
 		return false;
@@ -1589,7 +1580,7 @@ void ProtocolGame::sendChannelEvent(uint16_t channelId, const std::string& playe
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit)
+void ProtocolGame::sendCreatureOutfit(const std::shared_ptr<const Creature>& creature, const Outfit_t& outfit)
 {
 	if (!canSee(creature)) {
 		return;
@@ -1602,7 +1593,7 @@ void ProtocolGame::sendCreatureOutfit(const Creature* creature, const Outfit_t& 
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureLight(const Creature* creature)
+void ProtocolGame::sendCreatureLight(const std::shared_ptr<const Creature>& creature)
 {
 	if (!canSee(creature)) {
 		return;
@@ -1618,7 +1609,7 @@ void ProtocolGame::sendCreatureLight(const Creature* creature)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureWalkthrough(const Creature* creature, bool walkthrough)
+void ProtocolGame::sendCreatureWalkthrough(const std::shared_ptr<const Creature>& creature, bool walkthrough)
 {
 	if (!canSee(creature)) {
 		return;
@@ -1631,7 +1622,7 @@ void ProtocolGame::sendCreatureWalkthrough(const Creature* creature, bool walkth
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureShield(const Creature* creature)
+void ProtocolGame::sendCreatureShield(const std::shared_ptr<const Creature>& creature)
 {
 	if (!canSee(creature)) {
 		return;
@@ -1644,7 +1635,7 @@ void ProtocolGame::sendCreatureShield(const Creature* creature)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureSkull(const Creature* creature)
+void ProtocolGame::sendCreatureSkull(const std::shared_ptr<const Creature>& creature)
 {
 	if (g_game.getWorldType() != WORLD_TYPE_PVP) {
 		return;
@@ -1661,7 +1652,7 @@ void ProtocolGame::sendCreatureSkull(const Creature* creature)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureSquare(const Creature* creature, SquareColor_t color)
+void ProtocolGame::sendCreatureSquare(const std::shared_ptr<const Creature>& creature, SquareColor_t color)
 {
 	if (!canSee(creature)) {
 		return;
@@ -1835,7 +1826,7 @@ void ProtocolGame::sendChannelsDialog()
 	NetworkMessage msg;
 	msg.addByte(0xAB);
 
-	const ChannelList& list = g_chat->getChannelList(*player);
+	const ChannelList& list = g_chat->getChannelList(player);
 	msg.addByte(list.size());
 	for (ChatChannel* channel : list) {
 		msg.add<uint16_t>(channel->getId());
@@ -1856,7 +1847,7 @@ void ProtocolGame::sendChannel(uint16_t channelId, const std::string& channelNam
 
 	if (channelUsers) {
 		msg.add<uint16_t>(channelUsers->size());
-		for (auto&& user : *channelUsers | std::views::values | std::views::as_const) {
+		for (auto&& user : *channelUsers | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
 			msg.addString(user->getName());
 		}
 	} else {
@@ -1865,7 +1856,7 @@ void ProtocolGame::sendChannel(uint16_t channelId, const std::string& channelNam
 
 	if (invitedUsers) {
 		msg.add<uint16_t>(invitedUsers->size());
-		for (auto&& user : *invitedUsers | std::views::values | std::views::as_const) {
+		for (auto&& user : *invitedUsers | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
 			msg.addString(user->getName());
 		}
 	} else {
@@ -1896,7 +1887,7 @@ void ProtocolGame::sendIcons(uint32_t icons)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendContainer(uint8_t cid, const Container* container, uint16_t firstIndex)
+void ProtocolGame::sendContainer(uint8_t cid, const std::shared_ptr<const Container>& container, uint16_t firstIndex)
 {
 	NetworkMessage msg;
 	msg.addByte(0x6E);
@@ -1955,7 +1946,7 @@ void ProtocolGame::sendEmptyContainer(uint8_t cid)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendShop(Npc* npc, const ShopInfoList& itemList)
+void ProtocolGame::sendShop(const std::shared_ptr<Npc>& npc, const ShopInfoList& itemList)
 {
 	NetworkMessage msg;
 	msg.addByte(0x7A);
@@ -2101,22 +2092,22 @@ void ProtocolGame::sendMarketEnter()
 	player->setInMarket(true);
 
 	std::map<uint16_t, uint32_t> depotItems;
-	std::forward_list<Container*> containerList{player->getInbox().get()};
+	auto containerList = std::vector{std::static_pointer_cast<Container>(player->getInbox())};
 
-	for (auto&& chest : player->depotChests | std::views::values | std::views::as_const) {
+	for (auto&& chest : player->getDepotChests() | std::views::values) {
 		if (!chest->empty()) {
-			containerList.push_front(chest.get());
+			containerList.push_back(chest);
 		}
 	}
 
 	do {
-		Container* container = containerList.front();
-		containerList.pop_front();
+		const auto container = containerList.back();
+		containerList.pop_back();
 
-		for (Item* item : container->getItemList()) {
-			Container* c = item->getContainer();
+		for (const auto& item : container->getItemList()) {
+			const auto& c = item->getContainer();
 			if (c && !c->empty()) {
-				containerList.push_front(c);
+				containerList.push_back(c);
 				continue;
 			}
 
@@ -2141,7 +2132,7 @@ void ProtocolGame::sendMarketEnter()
 	uint16_t i = 0;
 
 	msg.add<uint16_t>(itemsToSend);
-	for (std::map<uint16_t, uint32_t>::const_iterator it = depotItems.begin(); i < itemsToSend; ++it, ++i) {
+	for (auto it = depotItems.begin(); i < itemsToSend; ++it, ++i) {
 		const ItemType& itemType = Item::items[it->first];
 		msg.add<uint16_t>(itemType.wareId);
 		if (itemType.classification > 0) {
@@ -2341,7 +2332,8 @@ void ProtocolGame::sendMarketBrowseOwnHistory(const HistoryMarketOfferList& buyO
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendTradeItemRequest(const std::string& traderName, const Item* item, bool ack)
+void ProtocolGame::sendTradeItemRequest(const std::string& traderName, const std::shared_ptr<const Item>& item,
+                                        bool ack)
 {
 	NetworkMessage msg;
 
@@ -2353,24 +2345,23 @@ void ProtocolGame::sendTradeItemRequest(const std::string& traderName, const Ite
 
 	msg.addString(traderName);
 
-	if (const Container* tradeContainer = item->getContainer()) {
-		std::list<const Container*> listContainer{tradeContainer};
-		std::list<const Item*> itemList{tradeContainer};
-		while (!listContainer.empty()) {
-			const Container* container = listContainer.front();
-			listContainer.pop_front();
+	if (const auto& tradeContainer = item->getContainer()) {
+		auto containerList = std::deque{tradeContainer};
+		auto itemList = std::deque{std::static_pointer_cast<const Item>(tradeContainer)};
+		while (!containerList.empty()) {
+			const auto container = containerList.front();
+			containerList.pop_front();
 
-			for (Item* containerItem : container->getItemList()) {
-				Container* tmpContainer = containerItem->getContainer();
-				if (tmpContainer) {
-					listContainer.push_back(tmpContainer);
+			for (const auto& containerItem : container->getItemList()) {
+				if (const auto& container = containerItem->getContainer()) {
+					containerList.push_back(container);
 				}
 				itemList.push_back(containerItem);
 			}
 		}
 
 		msg.addByte(itemList.size());
-		for (const Item* listItem : itemList) {
+		for (const auto& listItem : itemList) {
 			msg.addItem(listItem);
 		}
 	} else {
@@ -2395,7 +2386,7 @@ void ProtocolGame::sendCloseContainer(uint8_t cid)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureTurn(const Creature* creature, uint32_t stackpos)
+void ProtocolGame::sendCreatureTurn(const std::shared_ptr<const Creature>& creature, uint32_t stackpos)
 {
 	if (!canSee(creature)) {
 		return;
@@ -2418,8 +2409,8 @@ void ProtocolGame::sendCreatureTurn(const Creature* creature, uint32_t stackpos)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureSay(const Creature* creature, SpeakClasses type, const std::string& text,
-                                   const Position* pos /* = nullptr*/)
+void ProtocolGame::sendCreatureSay(const std::shared_ptr<const Creature>& creature, SpeakClasses type,
+                                   const std::string& text, const Position* pos /* = nullptr*/)
 {
 	NetworkMessage msg;
 	msg.addByte(0xAA);
@@ -2431,7 +2422,7 @@ void ProtocolGame::sendCreatureSay(const Creature* creature, SpeakClasses type, 
 	msg.addByte(0x00); // "(Traded)" suffix after player name
 
 	// Add level only for players
-	if (const Player* speaker = creature->getPlayer()) {
+	if (const auto& speaker = creature->getPlayer()) {
 		msg.add<uint16_t>(speaker->getLevel());
 	} else {
 		msg.add<uint16_t>(0x00);
@@ -2448,8 +2439,8 @@ void ProtocolGame::sendCreatureSay(const Creature* creature, SpeakClasses type, 
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendToChannel(const Creature* creature, SpeakClasses type, const std::string& text,
-                                 uint16_t channelId)
+void ProtocolGame::sendToChannel(const std::shared_ptr<const Creature>& creature, SpeakClasses type,
+                                 const std::string& text, uint16_t channelId)
 {
 	NetworkMessage msg;
 	msg.addByte(0xAA);
@@ -2464,7 +2455,7 @@ void ProtocolGame::sendToChannel(const Creature* creature, SpeakClasses type, co
 		msg.addByte(0x00); // "(Traded)" suffix after player name
 
 		// Add level only for players
-		if (const Player* speaker = creature->getPlayer()) {
+		if (const auto& speaker = creature->getPlayer()) {
 			msg.add<uint16_t>(speaker->getLevel());
 		} else {
 			msg.add<uint16_t>(0x00);
@@ -2477,7 +2468,8 @@ void ProtocolGame::sendToChannel(const Creature* creature, SpeakClasses type, co
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendPrivateMessage(const Player* speaker, SpeakClasses type, const std::string& text)
+void ProtocolGame::sendPrivateMessage(const std::shared_ptr<const Player>& speaker, SpeakClasses type,
+                                      const std::string& text)
 {
 	NetworkMessage msg;
 	msg.addByte(0xAA);
@@ -2504,7 +2496,7 @@ void ProtocolGame::sendCancelTarget()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendChangeSpeed(const Creature* creature, uint32_t speed)
+void ProtocolGame::sendChangeSpeed(const std::shared_ptr<const Creature>& creature, uint32_t speed)
 {
 	NetworkMessage msg;
 	msg.addByte(0x8F);
@@ -2571,7 +2563,7 @@ void ProtocolGame::sendMagicEffect(const Position& pos, uint8_t type)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendCreatureHealth(const Creature* creature)
+void ProtocolGame::sendCreatureHealth(const std::shared_ptr<const Creature>& creature)
 {
 	NetworkMessage msg;
 	msg.addByte(0x8C);
@@ -2605,7 +2597,7 @@ void ProtocolGame::sendMapDescription(const Position& pos)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const Item* item)
+void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const std::shared_ptr<const Item>& item)
 {
 	if (!canSee(pos)) {
 		return;
@@ -2619,7 +2611,7 @@ void ProtocolGame::sendAddTileItem(const Position& pos, uint32_t stackpos, const
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendUpdateTileItem(const Position& pos, uint32_t stackpos, const Item* item)
+void ProtocolGame::sendUpdateTileItem(const Position& pos, uint32_t stackpos, const std::shared_ptr<const Item>& item)
 {
 	if (!canSee(pos)) {
 		return;
@@ -2644,7 +2636,8 @@ void ProtocolGame::sendRemoveTileThing(const Position& pos, uint32_t stackpos)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendUpdateTileCreature(const Position& pos, uint32_t stackpos, const Creature* creature)
+void ProtocolGame::sendUpdateTileCreature(const Position& pos, uint32_t stackpos,
+                                          const std::shared_ptr<const Creature>& creature)
 {
 	if (!canSee(pos)) {
 		return;
@@ -2663,7 +2656,8 @@ void ProtocolGame::sendUpdateTileCreature(const Position& pos, uint32_t stackpos
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendRemoveTileCreature(const Creature* creature, const Position& pos, uint32_t stackpos)
+void ProtocolGame::sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
+                                          uint32_t stackpos)
 {
 	if (stackpos < MAX_STACKPOS) {
 		if (!canSee(pos)) {
@@ -2683,7 +2677,7 @@ void ProtocolGame::sendRemoveTileCreature(const Creature* creature, const Positi
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendUpdateTile(const Tile* tile, const Position& pos)
+void ProtocolGame::sendUpdateTile(const std::shared_ptr<const Tile>& tile, const Position& pos)
 {
 	if (!canSee(pos)) {
 		return;
@@ -2705,7 +2699,7 @@ void ProtocolGame::sendUpdateTile(const Tile* tile, const Position& pos)
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendUpdateCreatureIcons(const Creature* creature)
+void ProtocolGame::sendUpdateCreatureIcons(const std::shared_ptr<const Creature>& creature)
 {
 	if (!canSee(creature->getPosition())) {
 		return;
@@ -2745,8 +2739,8 @@ void ProtocolGame::sendFightModes()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos,
-                                   MagicEffectClasses magicEffect /*= CONST_ME_NONE*/)
+void ProtocolGame::sendAddCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
+                                   int32_t stackpos, MagicEffectClasses magicEffect /*= CONST_ME_NONE*/)
 {
 	assert(creature != player);
 
@@ -2762,7 +2756,7 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	// screen
 	if (stackpos >= MAX_STACKPOS) {
 		// @todo: should we avoid this check?
-		if (const Tile* tile = creature->getTile()) {
+		if (const auto& tile = creature->getTile()) {
 			sendUpdateTile(tile, pos);
 		}
 	} else {
@@ -2784,8 +2778,8 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	}
 }
 
-void ProtocolGame::sendMoveCreature(const Creature* creature, const Position& newPos, int32_t newStackPos,
-                                    const Position& oldPos, int32_t oldStackPos, bool teleport)
+void ProtocolGame::sendMoveCreature(const std::shared_ptr<const Creature>& creature, const Position& newPos,
+                                    int32_t newStackPos, const Position& oldPos, int32_t oldStackPos, bool teleport)
 {
 	if (creature == player) {
 		if (teleport) {
@@ -2858,7 +2852,7 @@ void ProtocolGame::sendMoveCreature(const Creature* creature, const Position& ne
 	}
 }
 
-void ProtocolGame::sendInventoryItem(slots_t slot, const Item* item)
+void ProtocolGame::sendInventoryItem(slots_t slot, const std::shared_ptr<const Item>& item)
 {
 	NetworkMessage msg;
 	if (item) {
@@ -2898,7 +2892,7 @@ void ProtocolGame::sendItems()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendAddContainerItem(uint8_t cid, uint16_t slot, const Item* item)
+void ProtocolGame::sendAddContainerItem(uint8_t cid, uint16_t slot, const std::shared_ptr<const Item>& item)
 {
 	NetworkMessage msg;
 	msg.addByte(0x70);
@@ -2908,7 +2902,7 @@ void ProtocolGame::sendAddContainerItem(uint8_t cid, uint16_t slot, const Item* 
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Item* item)
+void ProtocolGame::sendUpdateContainerItem(uint8_t cid, uint16_t slot, const std::shared_ptr<const Item>& item)
 {
 	NetworkMessage msg;
 	msg.addByte(0x71);
@@ -2918,7 +2912,7 @@ void ProtocolGame::sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Ite
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendRemoveContainerItem(uint8_t cid, uint16_t slot, const Item* lastItem)
+void ProtocolGame::sendRemoveContainerItem(uint8_t cid, uint16_t slot, const std::shared_ptr<const Item>& lastItem)
 {
 	NetworkMessage msg;
 	msg.addByte(0x72);
@@ -2932,7 +2926,8 @@ void ProtocolGame::sendRemoveContainerItem(uint8_t cid, uint16_t slot, const Ite
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendTextWindow(uint32_t windowTextId, Item* item, uint16_t maxlen, bool canWrite)
+void ProtocolGame::sendTextWindow(uint32_t windowTextId, const std::shared_ptr<const Item>& item, uint16_t maxlen,
+                                  bool canWrite)
 {
 	NetworkMessage msg;
 	msg.addByte(0x96);
@@ -3039,7 +3034,7 @@ void ProtocolGame::sendOutfitWindow()
 	}
 
 	bool mounted;
-	if (player->wasMounted) {
+	if (player->wasMounted()) {
 		mounted = currentOutfit.lookMount != 0;
 	} else {
 		mounted = player->isMounted();
@@ -3102,22 +3097,22 @@ void ProtocolGame::sendOutfitWindow()
 
 	msg.addByte(0x00); // Try outfit mode (?)
 	msg.addByte(mounted ? 0x01 : 0x00);
-	msg.addByte(player->randomizeMount ? 0x01 : 0x00);
+	msg.addByte(player->getRandomizeMount() ? 0x01 : 0x00);
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendPodiumWindow(const Item* item)
+void ProtocolGame::sendPodiumWindow(const std::shared_ptr<const Item>& item)
 {
 	if (!item) {
 		return;
 	}
 
-	const Podium* podium = item->getPodium();
+	const auto& podium = item->getPodium();
 	if (!podium) {
 		return;
 	}
 
-	const Tile* tile = item->getTile();
+	const auto& tile = item->getTile();
 	if (!tile) {
 		return;
 	}
@@ -3271,13 +3266,8 @@ void ProtocolGame::sendVIPEntries()
 	const std::forward_list<VIPEntry>& vipEntries = IOLoginData::getVIPEntries(player->getAccount());
 
 	for (const VIPEntry& entry : vipEntries) {
-		VipStatus_t vipStatus = VIPSTATUS_ONLINE;
-
-		Player* vipPlayer = g_game.getPlayerByGUID(entry.guid);
-
-		if (!vipPlayer || !player->canSeeCreature(vipPlayer)) {
-			vipStatus = VIPSTATUS_OFFLINE;
-		}
+		const auto& vipPlayer = g_game.getPlayerByGUID(entry.guid);
+		VipStatus_t vipStatus = vipPlayer && player->canSeeCreature(vipPlayer) ? VIPSTATUS_ONLINE : VIPSTATUS_OFFLINE;
 
 		sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);
 	}
@@ -3384,18 +3374,15 @@ void ProtocolGame::sendSessionEnd(SessionEndTypes_t reason)
 }
 
 ////////////// Add common messages
-void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove)
+void ProtocolGame::AddCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature, bool known,
+                               uint32_t remove)
 {
 	CreatureType_t creatureType = creature->getType();
-	const Player* otherPlayer = creature->getPlayer();
-	const Player* masterPlayer = nullptr;
 	uint32_t masterId = 0;
 
 	if (creatureType == CREATURETYPE_MONSTER) {
-		const Creature* master = creature->getMaster();
-		if (master) {
-			masterPlayer = master->getPlayer();
-			if (masterPlayer) {
+		if (const auto& master = creature->getMaster()) {
+			if (const auto& masterPlayer = master->getPlayer()) {
 				masterId = master->getID();
 				creatureType = CREATURETYPE_SUMMON_OWN;
 			}
@@ -3444,6 +3431,8 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bo
 	AddCreatureIcons(msg, creature);
 
 	msg.addByte(player->getSkullClient(creature));
+
+	const auto& otherPlayer = creature->getPlayer();
 	msg.addByte(player->getPartyShield(otherPlayer));
 
 	if (!known) {
@@ -3473,10 +3462,10 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bo
 	msg.addByte(player->canWalkthroughEx(creature) ? 0x00 : 0x01);
 }
 
-void ProtocolGame::AddCreatureIcons(NetworkMessage& msg, const Creature* creature)
+void ProtocolGame::AddCreatureIcons(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature)
 {
 	const auto& creatureIcons = creature->getIcons();
-	if (const Monster* monster = creature->getMonster()) {
+	if (const auto& monster = creature->getMonster()) {
 		const auto& monsterIcons = monster->getSpecialIcons();
 		msg.addByte(creatureIcons.size() + monsterIcons.size());
 		for (const auto& [iconId, level] : monsterIcons) {
@@ -3611,8 +3600,8 @@ void ProtocolGame::RemoveTileThing(NetworkMessage& msg, const Position& pos, uin
 	msg.addByte(stackpos);
 }
 
-void ProtocolGame::RemoveTileCreature(NetworkMessage& msg, const Creature* creature, const Position& pos,
-                                      uint32_t stackpos)
+void ProtocolGame::RemoveTileCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,
+                                      const Position& pos, uint32_t stackpos)
 {
 	if (stackpos < MAX_STACKPOS) {
 		RemoveTileThing(msg, pos, stackpos);
@@ -3624,8 +3613,8 @@ void ProtocolGame::RemoveTileCreature(NetworkMessage& msg, const Creature* creat
 	msg.add<uint32_t>(creature->getID());
 }
 
-void ProtocolGame::MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos,
-                                  const Position& oldPos)
+void ProtocolGame::MoveUpCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,
+                                  const Position& newPos, const Position& oldPos)
 {
 	if (creature != player) {
 		return;
@@ -3673,8 +3662,8 @@ void ProtocolGame::MoveUpCreature(NetworkMessage& msg, const Creature* creature,
 	                  (Map::maxClientViewportX * 2) + 2, 1, msg);
 }
 
-void ProtocolGame::MoveDownCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos,
-                                    const Position& oldPos)
+void ProtocolGame::MoveDownCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,
+                                    const Position& newPos, const Position& oldPos)
 {
 	if (creature != player) {
 		return;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -79,7 +79,7 @@ private:
 	void checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown);
 
 	bool canSee(int32_t x, int32_t y, int32_t z) const;
-	bool canSee(const Creature*) const;
+	bool canSee(const std::shared_ptr<const Creature>& creature) const;
 	bool canSee(const Position& pos) const;
 
 	// we have all the parse methods
@@ -162,25 +162,26 @@ private:
 	void sendChannel(uint16_t channelId, const std::string& channelName, const UsersMap* channelUsers,
 	                 const InvitedMap* invitedUsers);
 	void sendOpenPrivateChannel(const std::string& receiver);
-	void sendToChannel(const Creature* creature, SpeakClasses type, const std::string& text, uint16_t channelId);
-	void sendPrivateMessage(const Player* speaker, SpeakClasses type, const std::string& text);
+	void sendToChannel(const std::shared_ptr<const Creature>& creature, SpeakClasses type, const std::string& text,
+	                   uint16_t channelId);
+	void sendPrivateMessage(const std::shared_ptr<const Player>& speaker, SpeakClasses type, const std::string& text);
 	void sendIcons(uint32_t icons);
 	void sendFYIBox(const std::string& message);
 
 	void sendDistanceShoot(const Position& from, const Position& to, uint8_t type);
 	void sendMagicEffect(const Position& pos, uint8_t type);
-	void sendCreatureHealth(const Creature* creature);
+	void sendCreatureHealth(const std::shared_ptr<const Creature>& creature);
 	void sendSkills();
 	void sendPing();
 	void sendPingBack();
-	void sendCreatureTurn(const Creature* creature, uint32_t stackpos);
-	void sendCreatureSay(const Creature* creature, SpeakClasses type, const std::string& text,
+	void sendCreatureTurn(const std::shared_ptr<const Creature>& creature, uint32_t stackpos);
+	void sendCreatureSay(const std::shared_ptr<const Creature>& creature, SpeakClasses type, const std::string& text,
 	                     const Position* pos = nullptr);
 
 	void sendCancelWalk();
-	void sendChangeSpeed(const Creature* creature, uint32_t speed);
+	void sendChangeSpeed(const std::shared_ptr<const Creature>& creature, uint32_t speed);
 	void sendCancelTarget();
-	void sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit);
+	void sendCreatureOutfit(const std::shared_ptr<const Creature>& creature, const Outfit_t& outfit);
 	void sendStats();
 	void sendExperienceTracker(int64_t rawExp, int64_t finalExp);
 	void sendClientFeatures();
@@ -191,11 +192,11 @@ private:
 	void sendTutorial(uint8_t tutorialId);
 	void sendAddMarker(const Position& pos, uint8_t markType, const std::string& desc);
 
-	void sendCreatureWalkthrough(const Creature* creature, bool walkthrough);
-	void sendCreatureShield(const Creature* creature);
-	void sendCreatureSkull(const Creature* creature);
+	void sendCreatureWalkthrough(const std::shared_ptr<const Creature>& creature, bool walkthrough);
+	void sendCreatureShield(const std::shared_ptr<const Creature>& creature);
+	void sendCreatureSkull(const std::shared_ptr<const Creature>& creature);
 
-	void sendShop(Npc* npc, const ShopInfoList& itemList);
+	void sendShop(const std::shared_ptr<Npc>& npc, const ShopInfoList& itemList);
 	void sendCloseShop();
 	void sendSaleItemList(const std::list<ShopInfo>& shop);
 	void sendResourceBalance(const ResourceTypes_t resourceType, uint64_t amount);
@@ -207,17 +208,17 @@ private:
 	void sendMarketBrowseOwnOffers(const MarketOfferList& buyOffers, const MarketOfferList& sellOffers);
 	void sendMarketCancelOffer(const MarketOfferEx& offer);
 	void sendMarketBrowseOwnHistory(const HistoryMarketOfferList& buyOffers, const HistoryMarketOfferList& sellOffers);
-	void sendTradeItemRequest(const std::string& traderName, const Item* item, bool ack);
+	void sendTradeItemRequest(const std::string& traderName, const std::shared_ptr<const Item>& item, bool ack);
 	void sendCloseTrade();
 
-	void sendTextWindow(uint32_t windowTextId, Item* item, uint16_t maxlen, bool canWrite);
+	void sendTextWindow(uint32_t windowTextId, const std::shared_ptr<const Item>& item, uint16_t maxlen, bool canWrite);
 	void sendTextWindow(uint32_t windowTextId, uint32_t itemId, const std::string& text);
 	void sendHouseWindow(uint32_t windowTextId, const std::string& text);
 	void sendCombatAnalyzer(CombatType_t type, int32_t amount, DamageAnalyzerImpactType impactType,
 	                        const std::string& target);
 	void sendOutfitWindow();
 
-	void sendPodiumWindow(const Item* item);
+	void sendPodiumWindow(const std::shared_ptr<const Item>& item);
 
 	void sendUpdatedVIPStatus(uint32_t guid, VipStatus_t newStatus);
 	void sendVIP(uint32_t guid, const std::string& name, const std::string& description, uint32_t icon, bool notify,
@@ -231,9 +232,9 @@ private:
 
 	void sendFightModes();
 
-	void sendCreatureLight(const Creature* creature);
+	void sendCreatureLight(const std::shared_ptr<const Creature>& creature);
 
-	void sendCreatureSquare(const Creature* creature, SquareColor_t color);
+	void sendCreatureSquare(const std::shared_ptr<const Creature>& creature, SquareColor_t color);
 
 	void sendSpellCooldown(uint8_t spellId, uint32_t time);
 	void sendSpellGroupCooldown(SpellGroup_t groupId, uint32_t time);
@@ -243,31 +244,33 @@ private:
 	// tiles
 	void sendMapDescription(const Position& pos);
 
-	void sendAddTileItem(const Position& pos, uint32_t stackpos, const Item* item);
-	void sendUpdateTileItem(const Position& pos, uint32_t stackpos, const Item* item);
+	void sendAddTileItem(const Position& pos, uint32_t stackpos, const std::shared_ptr<const Item>& item);
+	void sendUpdateTileItem(const Position& pos, uint32_t stackpos, const std::shared_ptr<const Item>& item);
 	void sendRemoveTileThing(const Position& pos, uint32_t stackpos);
-	void sendUpdateTileCreature(const Position& pos, uint32_t stackpos, const Creature* creature);
-	void sendRemoveTileCreature(const Creature* creature, const Position& pos, uint32_t stackpos);
-	void sendUpdateTile(const Tile* tile, const Position& pos);
+	void sendUpdateTileCreature(const Position& pos, uint32_t stackpos,
+	                            const std::shared_ptr<const Creature>& creature);
+	void sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
+	                            uint32_t stackpos);
+	void sendUpdateTile(const std::shared_ptr<const Tile>& tile, const Position& pos);
 
-	void sendUpdateCreatureIcons(const Creature* creature);
+	void sendUpdateCreatureIcons(const std::shared_ptr<const Creature>& creature);
 
-	void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos,
+	void sendAddCreature(const std::shared_ptr<const Creature>& creature, const Position& pos, int32_t stackpos,
 	                     MagicEffectClasses magicEffect = CONST_ME_NONE);
-	void sendMoveCreature(const Creature* creature, const Position& newPos, int32_t newStackPos, const Position& oldPos,
-	                      int32_t oldStackPos, bool teleport);
+	void sendMoveCreature(const std::shared_ptr<const Creature>& creature, const Position& newPos, int32_t newStackPos,
+	                      const Position& oldPos, int32_t oldStackPos, bool teleport);
 
 	// containers
-	void sendAddContainerItem(uint8_t cid, uint16_t slot, const Item* item);
-	void sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Item* item);
-	void sendRemoveContainerItem(uint8_t cid, uint16_t slot, const Item* lastItem);
+	void sendAddContainerItem(uint8_t cid, uint16_t slot, const std::shared_ptr<const Item>& item);
+	void sendUpdateContainerItem(uint8_t cid, uint16_t slot, const std::shared_ptr<const Item>& item);
+	void sendRemoveContainerItem(uint8_t cid, uint16_t slot, const std::shared_ptr<const Item>& lastItem);
 
-	void sendContainer(uint8_t cid, const Container* container, uint16_t firstIndex);
+	void sendContainer(uint8_t cid, const std::shared_ptr<const Container>& container, uint16_t firstIndex);
 	void sendEmptyContainer(uint8_t cid);
 	void sendCloseContainer(uint8_t cid);
 
 	// inventory
-	void sendInventoryItem(slots_t slot, const Item* item);
+	void sendInventoryItem(slots_t slot, const std::shared_ptr<const Item>& item);
 	void sendItems();
 
 	// messages
@@ -279,7 +282,7 @@ private:
 	// Help functions
 
 	// translate a tile to client-readable format
-	void GetTileDescription(const Tile* tile, NetworkMessage& msg);
+	void GetTileDescription(const std::shared_ptr<const Tile>& tile, NetworkMessage& msg);
 
 	// translate a floor to client-readable format
 	void GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y, int32_t z, int32_t width, int32_t height,
@@ -288,19 +291,20 @@ private:
 	// translate a map area to client-readable format
 	void GetMapDescription(int32_t x, int32_t y, int32_t z, int32_t width, int32_t height, NetworkMessage& msg);
 
-	void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove);
-	void AddCreatureIcons(NetworkMessage& msg, const Creature* creature);
+	void AddCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature, bool known, uint32_t remove);
+	void AddCreatureIcons(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature);
 	void AddPlayerStats(NetworkMessage& msg);
 	void AddOutfit(NetworkMessage& msg, const Outfit_t& outfit);
 	void AddPlayerSkills(NetworkMessage& msg);
 
 	// tiles
 	static void RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos);
-	static void RemoveTileCreature(NetworkMessage& msg, const Creature* creature, const Position& pos,
-	                               uint32_t stackpos);
+	static void RemoveTileCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,
+	                               const Position& pos, uint32_t stackpos);
 
-	void MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
-	void MoveDownCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos,
+	void MoveUpCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature, const Position& newPos,
+	                    const Position& oldPos);
+	void MoveDownCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature, const Position& newPos,
 	                      const Position& oldPos);
 
 	// shop
@@ -312,7 +316,7 @@ private:
 	friend class Player;
 
 	std::unordered_set<uint32_t> knownCreatureSet;
-	Player* player = nullptr;
+	std::shared_ptr<Player> player = nullptr;
 
 	uint32_t eventConnect = 0;
 	uint32_t challengeTimestamp = 0;

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -110,7 +110,7 @@ void ProtocolStatus::sendStatusString()
 	uint32_t maxPlayersPerIp = getNumber(ConfigManager::STATUS_COUNT_MAX_PLAYERS_PER_IP);
 	if (maxPlayersPerIp > 0) {
 		std::map<Connection::Address, uint32_t> playersPerIp;
-		for (auto&& player : g_game.getPlayers() | std::views::values | std::views::as_const) {
+		for (auto&& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
 			if (!player->getIP().is_unspecified()) {
 				++playersPerIp[player->getIP()];
 			}
@@ -206,9 +206,9 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 	if (requestedInfo & REQUEST_EXT_PLAYERS_INFO) {
 		output->addByte(0x21); // players info - online players list
 
-		const auto& players = g_game.getPlayers();
+		const auto& players = g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 		output->add<uint32_t>(players.size());
-		for (auto&& player : players | std::views::values | std::views::as_const) {
+		for (auto&& player : players) {
 			output->addString(player->getName());
 			output->add<uint32_t>(player->getLevel());
 		}

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -14,7 +14,6 @@
 #include "monsters.h"
 #include "mounts.h"
 #include "movement.h"
-#include "npc.h"
 #include "scheduler.h"
 #include "spells.h"
 #include "talkaction.h"

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -8,8 +8,6 @@
 #include "configmanager.h"
 #include "events.h"
 #include "game.h"
-#include "monster.h"
-#include "npc.h"
 #include "pugicast.h"
 #include "scheduler.h"
 
@@ -36,12 +34,9 @@ bool Spawns::loadFromXml(const std::string& filename, bool isCalledByLua)
 		                   pugi::cast<uint16_t>(spawnNode.attribute("centery").value()),
 		                   pugi::cast<uint16_t>(spawnNode.attribute("centerz").value()));
 
-		int32_t radius;
-		pugi::xml_attribute radiusAttribute = spawnNode.attribute("radius");
-		if (radiusAttribute) {
+		int32_t radius = -1;
+		if (const auto radiusAttribute = spawnNode.attribute("radius")) {
 			radius = pugi::cast<int32_t>(radiusAttribute.value());
-		} else {
-			radius = -1;
 		}
 
 		if (radius > 30) {
@@ -55,8 +50,7 @@ bool Spawns::loadFromXml(const std::string& filename, bool isCalledByLua)
 			continue;
 		}
 
-		spawnList.emplace_front(centerPos, radius);
-		Spawn& spawn = spawnList.front();
+		auto& spawn = spawnList.emplace_back(centerPos, radius);
 
 		for (auto childNode : spawnNode.children()) {
 			if (boost::iequals(childNode.name(), "monsters")) {
@@ -169,7 +163,7 @@ bool Spawns::loadFromXml(const std::string& filename, bool isCalledByLua)
 					continue;
 				}
 
-				Npc* npc = Npc::createNpc(nameAttribute.as_string());
+				const auto& npc = Npc::createNpc(nameAttribute.as_string());
 				if (!npc) {
 					continue;
 				}
@@ -183,7 +177,7 @@ bool Spawns::loadFromXml(const std::string& filename, bool isCalledByLua)
 				    Position(centerPos.x + pugi::cast<uint16_t>(childNode.attribute("x").value()),
 				             centerPos.y + pugi::cast<uint16_t>(childNode.attribute("y").value()), centerPos.z),
 				    radius);
-				npcList.push_front(npc);
+				npcList.push_back(npc);
 			}
 		}
 
@@ -200,11 +194,10 @@ void Spawns::startup()
 		return;
 	}
 
-	for (Npc* npc : npcList) {
+	for (const auto& npc : npcList | tfs::views::lock_weak_ptrs) {
 		if (!g_game.placeCreature(npc, npc->getMasterPos(), false, true)) {
 			std::cout << "[Warning - Spawns::startup] Couldn't spawn npc \"" << npc->getName()
 			          << "\" on position: " << npc->getMasterPos() << '.' << std::endl;
-			delete npc;
 		}
 	}
 	npcList.clear();
@@ -247,9 +240,8 @@ void Spawn::startSpawnCheck()
 
 Spawn::~Spawn()
 {
-	for (auto&& monster : spawnedMap | std::views::values | std::views::as_const) {
+	for (auto&& monster : spawnedMap | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
 		monster->setSpawn(nullptr);
-		monster->decrementReferenceCounter();
 	}
 }
 
@@ -257,11 +249,9 @@ bool Spawn::findPlayer(const Position& pos)
 {
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, pos, false, true);
-	for (Creature* spectator : spectators) {
-		assert(dynamic_cast<Player*>(spectator) != nullptr);
-
-		Player* spectatorPlayer = static_cast<Player*>(spectator);
-		if (!spectatorPlayer->hasFlag(PlayerFlag_IgnoredByMonsters)) {
+	for (const auto& spectator : spectators) {
+		assert(spectator->getPlayer() != nullptr);
+		if (!std::static_pointer_cast<Player>(spectator)->hasFlag(PlayerFlag_IgnoredByMonsters)) {
 			return true;
 		}
 	}
@@ -310,29 +300,27 @@ bool Spawn::spawnMonster(uint32_t spawnId, spawnBlock_t sb, bool startup /* = fa
 bool Spawn::spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& pos, Direction dir,
                          bool startup /*= false*/)
 {
-	std::unique_ptr<Monster> monster_ptr(new Monster(mType));
-	if (!tfs::events::monster::onSpawn(monster_ptr.get(), pos, startup, false)) {
+	const auto monster = std::make_shared<Monster>(mType);
+	if (!tfs::events::monster::onSpawn(monster, pos, startup, false)) {
 		return false;
 	}
 
 	if (startup) {
 		// No need to send out events to the surrounding since there is no one out there to listen!
-		if (!g_game.internalPlaceCreature(monster_ptr.get(), pos, true)) {
-			std::cout << "[Warning - Spawns::startup] Couldn't spawn monster \"" << monster_ptr->getName()
+		if (!g_game.internalPlaceCreature(monster, pos, true)) {
+			std::cout << "[Warning - Spawns::startup] Couldn't spawn monster \"" << monster->getName()
 			          << "\" on position: " << pos << '.' << std::endl;
 			return false;
 		}
 	} else {
-		if (!g_game.placeCreature(monster_ptr.get(), pos, false, true)) {
+		if (!g_game.placeCreature(monster, pos, false, true)) {
 			return false;
 		}
 	}
 
-	Monster* monster = monster_ptr.release();
 	monster->setDirection(dir);
 	monster->setSpawn(this);
 	monster->setMasterPos(pos);
-	monster->incrementReferenceCounter();
 
 	spawnedMap.insert({spawnId, monster});
 	spawnMap[spawnId].lastSpawn = OTSYS_TIME();
@@ -380,9 +368,7 @@ void Spawn::cleanup()
 {
 	auto it = spawnedMap.begin();
 	while (it != spawnedMap.end()) {
-		Monster* monster = it->second;
-		if (monster->isRemoved()) {
-			monster->decrementReferenceCounter();
+		if (const auto monster = it->second.lock(); !monster || monster->isRemoved()) {
 			it = spawnedMap.erase(it);
 		} else {
 			++it;
@@ -416,11 +402,10 @@ bool Spawn::addMonster(const std::string& name, const Position& pos, Direction d
 	return addBlock(sb);
 }
 
-void Spawn::removeMonster(Monster* monster)
+void Spawn::removeMonster(const std::shared_ptr<Monster>& monster)
 {
 	for (auto it = spawnedMap.begin(), end = spawnedMap.end(); it != end; ++it) {
-		if (it->second == monster) {
-			monster->decrementReferenceCounter();
+		if (it->second.lock() == monster) {
 			spawnedMap.erase(it);
 			break;
 		}

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -22,16 +22,20 @@ struct spawnBlock_t
 class Spawn
 {
 public:
-	Spawn(Position pos, int32_t radius) : centerPos(std::move(pos)), radius(radius) {}
+	Spawn(const Position& pos, int32_t radius) : centerPos{pos}, radius{radius} {}
 	~Spawn();
 
 	// non-copyable
 	Spawn(const Spawn&) = delete;
 	Spawn& operator=(const Spawn&) = delete;
 
+	// movable
+	Spawn(Spawn&&) = default;
+	Spawn& operator=(Spawn&&) = default;
+
 	bool addBlock(spawnBlock_t sb);
 	bool addMonster(const std::string& name, const Position& pos, Direction dir, uint32_t interval);
-	void removeMonster(Monster* monster);
+	void removeMonster(const std::shared_ptr<Monster>& monster);
 
 	uint32_t getInterval() const { return interval; }
 	void startup();
@@ -39,13 +43,11 @@ public:
 	void startSpawnCheck();
 	void stopEvent();
 
-	bool isInSpawnZone(const Position& pos);
 	void cleanup();
 
 private:
 	// map of the spawned creatures
-	using SpawnedMap = std::multimap<uint32_t, Monster*>;
-	SpawnedMap spawnedMap;
+	std::multimap<uint32_t, std::weak_ptr<Monster>> spawnedMap;
 
 	// map of creatures in the spawn
 	std::map<uint32_t, spawnBlock_t> spawnMap;
@@ -74,8 +76,8 @@ public:
 	bool isStarted() const { return started; }
 
 private:
-	std::forward_list<Npc*> npcList;
-	std::forward_list<Spawn> spawnList;
+	std::vector<std::weak_ptr<Npc>> npcList;
+	std::vector<Spawn> spawnList;
 	std::string filename;
 	bool loaded = false;
 	bool started = false;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -22,7 +22,7 @@ Spells::Spells() { scriptInterface.initState(); }
 
 Spells::~Spells() { clear(false); }
 
-TalkActionResult_t Spells::playerSaySpell(Player* player, std::string& words)
+TalkActionResult_t Spells::playerSaySpell(const std::shared_ptr<Player>& player, std::string& words)
 {
 	std::string str_words = words;
 
@@ -107,9 +107,9 @@ LuaScriptInterface& Spells::getScriptInterface() { return scriptInterface; }
 Event_ptr Spells::getEvent(const std::string& nodeName)
 {
 	if (boost::iequals(nodeName, "rune")) {
-		return Event_ptr(new RuneSpell(&scriptInterface));
+		return std::make_unique<RuneSpell>(&scriptInterface);
 	} else if (boost::iequals(nodeName, "instant")) {
-		return Event_ptr(new InstantSpell(&scriptInterface));
+		return std::make_unique<InstantSpell>(&scriptInterface);
 	}
 	return nullptr;
 }
@@ -249,7 +249,7 @@ InstantSpell* Spells::getInstantSpellByName(const std::string& name)
 	return nullptr;
 }
 
-Position Spells::getCasterPosition(Creature* creature, Direction dir)
+Position Spells::getCasterPosition(const std::shared_ptr<Creature>& creature, Direction dir)
 {
 	return getNextPosition(dir, creature->getPosition());
 }
@@ -264,7 +264,7 @@ bool CombatSpell::loadScriptCombat()
 	return combat != nullptr;
 }
 
-bool CombatSpell::castSpell(Creature* creature)
+bool CombatSpell::castSpell(const std::shared_ptr<Creature>& creature)
 {
 	if (scripted) {
 		LuaVariant var;
@@ -289,7 +289,7 @@ bool CombatSpell::castSpell(Creature* creature)
 	return true;
 }
 
-bool CombatSpell::castSpell(Creature* creature, Creature* target)
+bool CombatSpell::castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target)
 {
 	if (scripted) {
 		LuaVariant var;
@@ -320,7 +320,7 @@ bool CombatSpell::castSpell(Creature* creature, Creature* target)
 	return true;
 }
 
-bool CombatSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
+bool CombatSpell::executeCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var)
 {
 	// onCastSpell(creature, var)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -335,7 +335,7 @@ bool CombatSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 
 	scriptInterface->pushFunction(scriptId);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushVariant(L, var);
@@ -515,7 +515,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 	return true;
 }
 
-bool Spell::playerSpellCheck(Player* player) const
+bool Spell::playerSpellCheck(const std::shared_ptr<Player>& player) const
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
 		return false;
@@ -623,7 +623,7 @@ bool Spell::playerSpellCheck(Player* player) const
 	return true;
 }
 
-bool Spell::playerInstantSpellCheck(Player* player, const Position& toPos)
+bool Spell::playerInstantSpellCheck(const std::shared_ptr<Player>& player, const Position& toPos)
 {
 	if (toPos.x == 0xFFFF) {
 		return true;
@@ -640,9 +640,9 @@ bool Spell::playerInstantSpellCheck(Player* player, const Position& toPos)
 		return false;
 	}
 
-	Tile* tile = g_game.map.getTile(toPos);
+	auto tile = g_game.map.getTile(toPos);
 	if (!tile) {
-		tile = new StaticTile(toPos.x, toPos.y, toPos.z);
+		tile = std::make_shared<StaticTile>(toPos.x, toPos.y, toPos.z);
 		g_game.map.setTile(toPos, tile);
 	}
 
@@ -661,7 +661,7 @@ bool Spell::playerInstantSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
-bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
+bool Spell::playerRuneSpellCheck(const std::shared_ptr<Player>& player, const Position& toPos)
 {
 	if (!playerSpellCheck(player)) {
 		return false;
@@ -682,7 +682,7 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 		return false;
 	}
 
-	Tile* tile = g_game.map.getTile(toPos);
+	const auto& tile = g_game.map.getTile(toPos);
 	if (!tile) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -702,7 +702,7 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 		return false;
 	}
 
-	const Creature* topVisibleCreature = tile->getBottomVisibleCreature(player);
+	const auto& topVisibleCreature = tile->getBottomVisibleCreature(player);
 	if (blockingCreature && topVisibleCreature) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -720,18 +720,20 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	}
 
 	if (aggressive && needTarget && topVisibleCreature && player->hasSecureMode()) {
-		const Player* targetPlayer = topVisibleCreature->getPlayer();
-		if (targetPlayer && targetPlayer != player && player->getSkullClient(targetPlayer) == SKULL_NONE &&
-		    !Combat::isInPvpZone(player, targetPlayer)) {
-			player->sendCancelMessage(RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS);
-			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
-			return false;
+		if (const auto& targetPlayer = topVisibleCreature->getPlayer()) {
+			if (targetPlayer != player && player->getSkullClient(targetPlayer) == SKULL_NONE &&
+			    !Combat::isInPvpZone(player, targetPlayer)) {
+				player->sendCancelMessage(RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS);
+				g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
+				return false;
+			}
 		}
 	}
 	return true;
 }
 
-void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool payCost /*= true*/) const
+void Spell::postCastSpell(const std::shared_ptr<Player>& player, bool finishedCast /*= true*/,
+                          bool payCost /*= true*/) const
 {
 	if (finishedCast) {
 		if (!player->hasFlag(PlayerFlag_HasNoExhaustion)) {
@@ -764,7 +766,7 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 	}
 }
 
-void Spell::postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost)
+void Spell::postCastSpell(const std::shared_ptr<Player>& player, uint32_t manaCost, uint32_t soulCost)
 {
 	if (manaCost > 0) {
 		player->addManaSpent(manaCost);
@@ -778,7 +780,7 @@ void Spell::postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost)
 	}
 }
 
-uint32_t Spell::getManaCost(const Player* player) const
+uint32_t Spell::getManaCost(const std::shared_ptr<const Player>& player) const
 {
 	if (mana != 0) {
 		return mana;
@@ -826,7 +828,7 @@ bool InstantSpell::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-bool InstantSpell::playerCastInstant(Player* player, std::string& param)
+bool InstantSpell::playerCastInstant(const std::shared_ptr<Player>& player, std::string& param)
 {
 	if (!playerSpellCheck(player)) {
 		return false;
@@ -837,11 +839,11 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 	if (selfTarget) {
 		var.setNumber(player->getID());
 	} else if (needTarget || casterTargetOrDirection) {
-		Creature* target = nullptr;
+		std::shared_ptr<Creature> target = nullptr;
 		bool useDirection = false;
 
 		if (hasParam) {
-			Player* playerTarget = nullptr;
+			std::shared_ptr<Player> playerTarget = nullptr;
 			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
 
 			if (playerTarget && playerTarget->isAccessPlayer() && !player->isAccessPlayer()) {
@@ -911,7 +913,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 		}
 	} else if (hasParam) {
 		if (getHasPlayerNameParam()) {
-			Player* playerTarget = nullptr;
+			std::shared_ptr<Player> playerTarget = nullptr;
 			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
 
 			if (ret != RETURNVALUE_NOERROR) {
@@ -964,7 +966,8 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 	return result;
 }
 
-bool InstantSpell::canThrowSpell(const Creature* creature, const Creature* target) const
+bool InstantSpell::canThrowSpell(const std::shared_ptr<const Creature>& creature,
+                                 const std::shared_ptr<const Creature>& target) const
 {
 	const Position& fromPos = creature->getPosition();
 	const Position& toPos = target->getPosition();
@@ -977,23 +980,26 @@ bool InstantSpell::canThrowSpell(const Creature* creature, const Creature* targe
 	return true;
 }
 
-bool InstantSpell::castSpell(Creature* creature)
+bool InstantSpell::castSpell(const std::shared_ptr<Creature>& creature)
 {
 	LuaVariant var;
 
 	if (casterTargetOrDirection) {
-		Creature* target = creature->getAttackedCreature();
-		if (target && !target->isDead()) {
-			if (!canThrowSpell(creature, target)) {
-				return false;
-			}
+		if (const auto& target = creature->getAttackedCreature()) {
+			if (!target->isDead()) {
+				if (!canThrowSpell(creature, target)) {
+					return false;
+				}
 
-			var.setNumber(target->getID());
-			return internalCastSpell(creature, var);
+				var.setNumber(target->getID());
+				return internalCastSpell(creature, var);
+			}
 		}
 
 		return false;
-	} else if (needDirection) {
+	}
+
+	if (needDirection) {
 		var.setPosition(Spells::getCasterPosition(creature, creature->getDirection()));
 	} else {
 		var.setPosition(creature->getPosition());
@@ -1002,7 +1008,7 @@ bool InstantSpell::castSpell(Creature* creature)
 	return internalCastSpell(creature, var);
 }
 
-bool InstantSpell::castSpell(Creature* creature, Creature* target)
+bool InstantSpell::castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target)
 {
 	if (needTarget) {
 		LuaVariant var;
@@ -1012,12 +1018,12 @@ bool InstantSpell::castSpell(Creature* creature, Creature* target)
 	return castSpell(creature);
 }
 
-bool InstantSpell::internalCastSpell(Creature* creature, const LuaVariant& var)
+bool InstantSpell::internalCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var)
 {
 	return executeCastSpell(creature, var);
 }
 
-bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
+bool InstantSpell::executeCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var)
 {
 	// onCastSpell(creature, var)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -1032,7 +1038,7 @@ bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 
 	scriptInterface->pushFunction(scriptId);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushVariant(L, var);
@@ -1040,7 +1046,7 @@ bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 	return scriptInterface->callFunction(2);
 }
 
-bool InstantSpell::canCast(const Player* player) const
+bool InstantSpell::canCast(const std::shared_ptr<const Player>& player) const
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
 		return false;
@@ -1100,7 +1106,7 @@ bool RuneSpell::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-ReturnValue RuneSpell::canExecuteAction(const Player* player, const Position& toPos)
+ReturnValue RuneSpell::canExecuteAction(const std::shared_ptr<const Player>& player, const Position& toPos)
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
 		return RETURNVALUE_CANNOTUSETHISOBJECT;
@@ -1122,8 +1128,8 @@ ReturnValue RuneSpell::canExecuteAction(const Player* player, const Position& to
 	return RETURNVALUE_NOERROR;
 }
 
-bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* target, const Position& toPosition,
-                           bool isHotkey)
+bool RuneSpell::executeUse(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, const Position&,
+                           const std::shared_ptr<Thing>& target, const Position& toPosition, bool isHotkey)
 {
 	if (!playerRuneSpellCheck(player, toPosition)) {
 		return false;
@@ -1137,10 +1143,8 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 
 	if (needTarget) {
 		if (!target) {
-			Tile* toTile = g_game.map.getTile(toPosition);
-			if (toTile) {
-				const Creature* visibleCreature = toTile->getBottomVisibleCreature(player);
-				if (visibleCreature) {
+			if (const auto& toTile = g_game.map.getTile(toPosition)) {
+				if (const auto& visibleCreature = toTile->getBottomVisibleCreature(player)) {
 					var.setNumber(visibleCreature->getID());
 				}
 			}
@@ -1158,9 +1162,10 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	postCastSpell(player);
 
 	if (var.isNumber()) {
-		target = g_game.getCreatureByID(var.getNumber());
-		if (getPzLock() && target) {
-			player->onAttackedCreature(target->getCreature());
+		if (const auto& targetCreature = g_game.getCreatureByID(var.getNumber())) {
+			if (getPzLock()) {
+				player->onAttackedCreature(targetCreature->getCreature());
+			}
 		}
 	}
 
@@ -1172,21 +1177,21 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	return true;
 }
 
-bool RuneSpell::castSpell(Creature* creature)
+bool RuneSpell::castSpell(const std::shared_ptr<Creature>& creature)
 {
 	LuaVariant var;
 	var.setNumber(creature->getID());
 	return internalCastSpell(creature, var, false);
 }
 
-bool RuneSpell::castSpell(Creature* creature, Creature* target)
+bool RuneSpell::castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target)
 {
 	LuaVariant var;
 	var.setNumber(target->getID());
 	return internalCastSpell(creature, var, false);
 }
 
-bool RuneSpell::internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey)
+bool RuneSpell::internalCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var, bool isHotkey)
 {
 	bool result;
 	if (scripted) {
@@ -1197,7 +1202,7 @@ bool RuneSpell::internalCastSpell(Creature* creature, const LuaVariant& var, boo
 	return result;
 }
 
-bool RuneSpell::executeCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey)
+bool RuneSpell::executeCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var, bool isHotkey)
 {
 	// onCastSpell(creature, var, isHotkey)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -1212,7 +1217,7 @@ bool RuneSpell::executeCastSpell(Creature* creature, const LuaVariant& var, bool
 
 	scriptInterface->pushFunction(scriptId);
 
-	tfs::lua::pushUserdata(L, creature);
+	tfs::lua::pushSharedPtr(L, creature);
 	tfs::lua::setCreatureMetatable(L, -1, creature);
 
 	tfs::lua::pushVariant(L, var);

--- a/src/spells.h
+++ b/src/spells.h
@@ -37,9 +37,9 @@ public:
 	InstantSpell* getInstantSpell(const std::string& words);
 	InstantSpell* getInstantSpellByName(const std::string& name);
 
-	TalkActionResult_t playerSaySpell(Player* player, std::string& words);
+	TalkActionResult_t playerSaySpell(const std::shared_ptr<Player>& player, std::string& words);
 
-	static Position getCasterPosition(Creature* creature, Direction dir);
+	static Position getCasterPosition(const std::shared_ptr<Creature>& creature, Direction dir);
 	std::string_view getScriptBaseName() const override { return "spells"; }
 
 	const std::map<uint16_t, RuneSpell>& getRuneSpells() const { return runes; };
@@ -68,8 +68,8 @@ public:
 	constexpr BaseSpell() = default;
 	virtual ~BaseSpell() = default;
 
-	virtual bool castSpell(Creature* creature) = 0;
-	virtual bool castSpell(Creature* creature, Creature* target) = 0;
+	virtual bool castSpell(const std::shared_ptr<Creature>& creature) = 0;
+	virtual bool castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target) = 0;
 };
 
 class CombatSpell final : public Event, public BaseSpell
@@ -81,12 +81,12 @@ public:
 	CombatSpell(const CombatSpell&) = delete;
 	CombatSpell& operator=(const CombatSpell&) = delete;
 
-	bool castSpell(Creature* creature) override;
-	bool castSpell(Creature* creature, Creature* target) override;
+	bool castSpell(const std::shared_ptr<Creature>& creature) override;
+	bool castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target) override;
 	bool configureEvent(const pugi::xml_node&) override { return true; }
 
 	// scripting
-	bool executeCastSpell(Creature* creature, const LuaVariant& var);
+	bool executeCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var);
 
 	bool loadScriptCombat();
 	Combat_ptr getCombat() { return combat; }
@@ -111,10 +111,10 @@ public:
 	uint8_t getId() const { return spellId; }
 	void setId(uint8_t id) { spellId = id; }
 
-	void postCastSpell(Player* player, bool finishedCast = true, bool payCost = true) const;
-	static void postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost);
+	void postCastSpell(const std::shared_ptr<Player>& player, bool finishedCast = true, bool payCost = true) const;
+	static void postCastSpell(const std::shared_ptr<Player>& player, uint32_t manaCost, uint32_t soulCost);
 
-	uint32_t getManaCost(const Player* player) const;
+	uint32_t getManaCost(const std::shared_ptr<const Player>& player) const;
 	uint32_t getSoulCost() const { return soul; }
 	void setSoulCost(uint32_t s) { soul = s; }
 	uint32_t getLevel() const { return level; }
@@ -183,9 +183,9 @@ public:
 	SpellType_t spellType = SPELL_UNDEFINED;
 
 protected:
-	bool playerSpellCheck(Player* player) const;
-	bool playerInstantSpellCheck(Player* player, const Position& toPos);
-	bool playerRuneSpellCheck(Player* player, const Position& toPos);
+	bool playerSpellCheck(const std::shared_ptr<Player>& player) const;
+	bool playerInstantSpellCheck(const std::shared_ptr<Player>& player, const Position& toPos);
+	bool playerRuneSpellCheck(const std::shared_ptr<Player>& player, const Position& toPos);
 
 	std::map<uint16_t, bool> vocationSpellMap;
 
@@ -228,13 +228,13 @@ public:
 
 	bool configureEvent(const pugi::xml_node& node) override;
 
-	virtual bool playerCastInstant(Player* player, std::string& param);
+	bool playerCastInstant(const std::shared_ptr<Player>& player, std::string& param);
 
-	bool castSpell(Creature* creature) override;
-	bool castSpell(Creature* creature, Creature* target) override;
+	bool castSpell(const std::shared_ptr<Creature>& creature) override;
+	bool castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target) override;
 
 	// scripting
-	bool executeCastSpell(Creature* creature, const LuaVariant& var);
+	bool executeCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var);
 
 	bool isInstant() const override { return true; }
 	bool getHasParam() const { return hasParam; }
@@ -247,13 +247,14 @@ public:
 	void setNeedCasterTargetOrDirection(bool d) { casterTargetOrDirection = d; }
 	bool getBlockWalls() const { return checkLineOfSight; }
 	void setBlockWalls(bool w) { checkLineOfSight = w; }
-	bool canCast(const Player* player) const;
-	bool canThrowSpell(const Creature* creature, const Creature* target) const;
+	bool canCast(const std::shared_ptr<const Player>& player) const;
+	bool canThrowSpell(const std::shared_ptr<const Creature>& creature,
+	                   const std::shared_ptr<const Creature>& target) const;
 
 private:
 	std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
-	bool internalCastSpell(Creature* creature, const LuaVariant& var);
+	bool internalCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var);
 
 	bool needDirection = false;
 	bool hasParam = false;
@@ -269,21 +270,23 @@ public:
 
 	bool configureEvent(const pugi::xml_node& node) override;
 
-	ReturnValue canExecuteAction(const Player* player, const Position& toPos) override;
+	ReturnValue canExecuteAction(const std::shared_ptr<const Player>& player, const Position& toPos) override;
 	bool hasOwnErrorHandler() override { return true; }
-	Thing* getTarget(Player*, Creature* targetCreature, const Position&, uint8_t) const override
+	std::shared_ptr<Thing> getTarget(const std::shared_ptr<Player>&, const std::shared_ptr<Creature>& targetCreature,
+	                                 const Position&, uint8_t) const override
 	{
 		return targetCreature;
 	}
 
-	bool executeUse(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition,
+	bool executeUse(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                const Position& fromPosition, const std::shared_ptr<Thing>& target, const Position& toPosition,
 	                bool isHotkey) override;
 
-	bool castSpell(Creature* creature) override;
-	bool castSpell(Creature* creature, Creature* target) override;
+	bool castSpell(const std::shared_ptr<Creature>& creature) override;
+	bool castSpell(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Creature>& target) override;
 
 	// scripting
-	bool executeCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
+	bool executeCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var, bool isHotkey);
 
 	bool isInstant() const override { return false; }
 	uint16_t getRuneItemId() const { return runeId; }
@@ -301,7 +304,7 @@ public:
 private:
 	std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
-	bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
+	bool internalCastSpell(const std::shared_ptr<Creature>& creature, const LuaVariant& var, bool isHotkey);
 
 	uint16_t runeId = 0;
 	uint32_t charges = 0;

--- a/src/storeinbox.cpp
+++ b/src/storeinbox.cpp
@@ -7,16 +7,15 @@
 
 #include "tools.h"
 
-StoreInbox::StoreInbox(uint16_t type) : Container(type, 20, true, true) {}
-
-ReturnValue StoreInbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags, Creature*) const
+ReturnValue StoreInbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, uint32_t, uint32_t flags,
+                                 const std::shared_ptr<Creature>&) const
 {
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	if (item == this) {
+	if (item.get() == this) {
 		return RETURNVALUE_THISISIMPOSSIBLE;
 	}
 
@@ -29,25 +28,28 @@ ReturnValue StoreInbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t
 			return RETURNVALUE_CANNOTMOVEITEMISNOTSTOREITEM;
 		}
 
-		const Container* container = item->getContainer();
-		if (container && !container->empty()) {
-			return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
+		if (const auto& container = item->getContainer()) {
+			if (!container->empty()) {
+				return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
+			}
 		}
 	}
 
 	return RETURNVALUE_NOERROR;
 }
 
-void StoreInbox::postAddNotification(Thing* thing, const Thing* oldParent, int32_t index, ReceiverLink_t)
+void StoreInbox::postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+                                     int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postAddNotification(thing, oldParent, index, LINK_TOPPARENT);
 	}
 }
 
-void StoreInbox::postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index, ReceiverLink_t)
+void StoreInbox::postRemoveNotification(const std::shared_ptr<Thing>& thing,
+                                        const std::shared_ptr<const Thing>& newParent, int32_t index, ReceiverLink_t)
 {
-	if (const auto parent = getParent()) {
+	if (const auto& parent = getParent()) {
 		parent->postRemoveNotification(thing, newParent, index, LINK_TOPPARENT);
 	}
 }

--- a/src/storeinbox.h
+++ b/src/storeinbox.h
@@ -9,18 +9,24 @@
 class StoreInbox final : public Container
 {
 public:
-	explicit StoreInbox(uint16_t type);
+	explicit StoreInbox(uint16_t type) : Container{type, 20, true, true} {}
 
-	StoreInbox* getStoreInbox() override { return this; }
-	const StoreInbox* getStoreInbox() const override { return this; }
+	std::shared_ptr<StoreInbox> getStoreInbox() override
+	{
+		return std::static_pointer_cast<StoreInbox>(shared_from_this());
+	}
+	std::shared_ptr<const StoreInbox> getStoreInbox() const override
+	{
+		return std::static_pointer_cast<const StoreInbox>(shared_from_this());
+	}
 
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags,
-	                     Creature* actor = nullptr) const override;
+	ReturnValue queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
+	                     const std::shared_ptr<Creature>& actor = nullptr) const override;
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 
 	bool canRemove() const override { return false; }
 };

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -66,7 +66,8 @@ bool TalkActions::registerLuaEvent(TalkAction* event)
 	return true;
 }
 
-TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type, const std::string& words) const
+TalkActionResult_t TalkActions::playerSaySpell(const std::shared_ptr<Player>& player, SpeakClasses type,
+                                               const std::string& words) const
 {
 	size_t wordsLength = words.length();
 	for (auto it = talkActions.begin(); it != talkActions.end();) {
@@ -116,7 +117,8 @@ TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type
 	return TALKACTION_CONTINUE;
 }
 
-bool TalkAction::executeSay(Player* player, const std::string& words, const std::string& param, SpeakClasses type) const
+bool TalkAction::executeSay(const std::shared_ptr<Player>& player, const std::string& words, const std::string& param,
+                            SpeakClasses type) const
 {
 	// onSay(player, words, param, type)
 	if (!tfs::lua::reserveScriptEnv()) {
@@ -131,7 +133,7 @@ bool TalkAction::executeSay(Player* player, const std::string& words, const std:
 
 	scriptInterface->pushFunction(scriptId);
 
-	tfs::lua::pushUserdata(L, player);
+	tfs::lua::pushSharedPtr(L, player);
 	tfs::lua::setMetatable(L, -1, "Player");
 
 	tfs::lua::pushString(L, words);

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -36,7 +36,8 @@ public:
 	void setSeparator(std::string sep) { separator = sep; }
 
 	// scripting
-	bool executeSay(Player* player, const std::string& words, const std::string& param, SpeakClasses type) const;
+	bool executeSay(const std::shared_ptr<Player>& player, const std::string& words, const std::string& param,
+	                SpeakClasses type) const;
 
 	AccountType_t getRequiredAccountType() const { return requiredAccountType; }
 
@@ -66,7 +67,8 @@ public:
 	TalkActions(const TalkActions&) = delete;
 	TalkActions& operator=(const TalkActions&) = delete;
 
-	TalkActionResult_t playerSaySpell(Player* player, SpeakClasses type, const std::string& words) const;
+	TalkActionResult_t playerSaySpell(const std::shared_ptr<Player>& player, SpeakClasses type,
+	                                  const std::string& words) const;
 
 	bool registerLuaEvent(TalkAction* event);
 	void clear(bool fromLua) override final;

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -9,13 +9,16 @@
 class Teleport final : public Item
 {
 public:
-	explicit Teleport(uint16_t type) : Item(type) {};
+	explicit Teleport(uint16_t type) : Item{type} {};
 
-	Thing* getReceiver() override final { return this; }
-	const Thing* getReceiver() const override final { return this; }
+	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	Teleport* getTeleport() override { return this; }
-	const Teleport* getTeleport() const override { return this; }
+	std::shared_ptr<Teleport> getTeleport() override { return std::static_pointer_cast<Teleport>(shared_from_this()); }
+	std::shared_ptr<const Teleport> getTeleport() const override
+	{
+		return std::static_pointer_cast<const Teleport>(shared_from_this());
+	}
 
 	Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
 	void serializeAttr(PropWriteStream& propWriteStream) const override;
@@ -23,19 +26,25 @@ public:
 	const Position& getDestPos() const { return destPos; }
 	void setDestPos(const Position& pos) { destPos = pos; }
 
-	ReturnValue queryRemove(const Thing&, uint32_t, uint32_t, Creature* = nullptr) const override
+	ReturnValue queryRemove(const std::shared_ptr<const Thing>&, uint32_t, uint32_t,
+	                        const std::shared_ptr<Creature>& = nullptr) const override
 	{
 		return RETURNVALUE_NOERROR;
 	}
-	Thing* queryDestination(int32_t&, const Thing&, Item**, uint32_t&) override { return this; }
 
-	void addThing(Thing* thing) override { return addThing(0, thing); }
-	void addThing(int32_t index, Thing* thing) override;
+	std::shared_ptr<Thing> queryDestination(int32_t&, const std::shared_ptr<const Thing>&, std::shared_ptr<Item>&,
+	                                        uint32_t&) override
+	{
+		return shared_from_this();
+	}
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void addThing(const std::shared_ptr<Thing>& thing) override { addThing(0, thing); }
+	void addThing(int32_t index, const std::shared_ptr<Thing>& thing) override;
+
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 
 private:
 	Position destPos;

--- a/src/thing.cpp
+++ b/src/thing.cpp
@@ -9,9 +9,6 @@
 
 const Position& Thing::getPosition() const
 {
-	const Tile* tile = getTile();
-	if (!tile) {
-		return Tile::nullptr_tile.getPosition();
-	}
-	return tile->getPosition();
+	const auto& tile = getTile();
+	return tile ? tile->getPosition() : Tile::nullptrTile->getPosition();
 }

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -867,19 +867,6 @@ itemAttrTypes stringToItemAttribute(const std::string& str)
 	return ITEM_ATTRIBUTE_NONE;
 }
 
-std::string getFirstLine(const std::string& str)
-{
-	std::string firstLine;
-	firstLine.reserve(str.length());
-	for (const char c : str) {
-		if (c == '\n') {
-			break;
-		}
-		firstLine.push_back(c);
-	}
-	return firstLine;
-}
-
 const char* getReturnMessage(ReturnValue value)
 {
 	switch (value) {
@@ -1114,9 +1101,9 @@ SpellGroup_t stringToSpellGroup(const std::string& value)
 	return SPELLGROUP_NONE;
 }
 
-const std::vector<Direction>& getShuffleDirections()
+std::array<Direction, 4> getShuffleDirections()
 {
-	static std::vector<Direction> dirList{DIRECTION_NORTH, DIRECTION_WEST, DIRECTION_EAST, DIRECTION_SOUTH};
+	auto dirList = std::array{DIRECTION_NORTH, DIRECTION_WEST, DIRECTION_EAST, DIRECTION_SOUTH};
 	std::shuffle(dirList.begin(), dirList.end(), getRandomGenerator());
 	return dirList;
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -31,8 +31,6 @@ std::string randomBytes(size_t length);
 Position getNextPosition(Direction direction, Position pos);
 Direction getDirectionTo(const Position& from, const Position& to);
 
-std::string getFirstLine(const std::string& str);
-
 std::string formatDateShort(time_t time);
 
 uint16_t getDepotBoxId(uint16_t index);
@@ -66,6 +64,41 @@ int64_t OTSYS_TIME();
 
 SpellGroup_t stringToSpellGroup(const std::string& value);
 
-const std::vector<Direction>& getShuffleDirections();
+std::array<Direction, 4> getShuffleDirections();
+
+namespace tfs::views {
+
+constexpr auto lock_weak_ptrs = std::views::transform([](const auto& wp) { return wp.lock(); }) |
+                                std::views::filter([](const auto& sp) { return sp != nullptr; });
+
+} // namespace tfs::views
+
+namespace tfs {
+
+template <class T, class U>
+bool owner_equal(const std::shared_ptr<T>& x, const std::shared_ptr<U>& y) noexcept
+{
+	return x.owner_before(y) == false && y.owner_before(x) == false;
+}
+
+template <class T, class U>
+bool owner_equal(const std::shared_ptr<T>& x, const std::weak_ptr<U>& y) noexcept
+{
+	return x.owner_before(y) == false && y.owner_before(x) == false;
+}
+
+template <class T, class U>
+bool owner_equal(const std::weak_ptr<T>& x, const std::shared_ptr<U>& y) noexcept
+{
+	return x.owner_before(y) == false && y.owner_before(x) == false;
+}
+
+template <class T, class U>
+bool owner_equal(const std::weak_ptr<T>& x, const std::weak_ptr<U>& y) noexcept
+{
+	return x.owner_before(y) == false && y.owner_before(x) == false;
+}
+
+} // namespace tfs
 
 #endif // FS_TOOLS_H

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -9,30 +9,42 @@
 class TrashHolder final : public Item
 {
 public:
-	explicit TrashHolder(uint16_t itemId) : Item(itemId) {}
+	explicit TrashHolder(uint16_t itemId) : Item{itemId} {}
 
-	Thing* getReceiver() override final { return this; }
-	const Thing* getReceiver() const override final { return this; }
+	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	TrashHolder* getTrashHolder() override { return this; }
-	const TrashHolder* getTrashHolder() const override { return this; }
+	std::shared_ptr<TrashHolder> getTrashHolder() override
+	{
+		return std::static_pointer_cast<TrashHolder>(shared_from_this());
+	}
+	std::shared_ptr<const TrashHolder> getTrashHolder() const override
+	{
+		return std::static_pointer_cast<const TrashHolder>(shared_from_this());
+	}
 
-	ReturnValue queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature* = nullptr) const override
+	ReturnValue queryAdd(int32_t, const std::shared_ptr<const Thing>&, uint32_t, uint32_t,
+	                     const std::shared_ptr<Creature>& = nullptr) const override
 	{
 		return RETURNVALUE_NOERROR;
 	}
-	ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-	                          uint32_t flags) const override;
-	Thing* queryDestination(int32_t&, const Thing&, Item**, uint32_t&) override { return this; }
 
-	void addThing(Thing* thing) override { return addThing(0, thing); }
+	ReturnValue queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
+	                          uint32_t& maxQueryCount, uint32_t flags) const override;
 
-	void addThing(int32_t index, Thing* thing) override;
+	std::shared_ptr<Thing> queryDestination(int32_t&, const std::shared_ptr<const Thing>&, std::shared_ptr<Item>&,
+	                                        uint32_t&) override
+	{
+		return shared_from_this();
+	}
 
-	void postAddNotification(Thing* thing, const Thing* oldParent, int32_t index,
-	                         ReceiverLink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Thing* newParent, int32_t index,
-	                            ReceiverLink_t link = LINK_OWNER) override;
+	void addThing(const std::shared_ptr<Thing>& thing) override { return addThing(0, thing); }
+	void addThing(int32_t index, const std::shared_ptr<Thing>& thing) override;
+
+	void postAddNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& oldParent,
+	                         int32_t index, ReceiverLink_t link = LINK_OWNER) override;
+	void postRemoveNotification(const std::shared_ptr<Thing>& thing, const std::shared_ptr<const Thing>& newParent,
+	                            int32_t index, ReceiverLink_t link = LINK_OWNER) override;
 };
 
 #endif // FS_TRASHHOLDER_H

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -27,7 +27,7 @@ public:
 	Weapons& operator=(const Weapons&) = delete;
 
 	void loadDefaults();
-	const Weapon* getWeapon(const Item* item) const;
+	const Weapon* getWeapon(const std::shared_ptr<const Item>& item) const;
 
 	static int32_t getMaxMeleeDamage(int32_t attackSkill, int32_t attackValue);
 	static int32_t getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t attackValue, float attackFactor);
@@ -56,14 +56,19 @@ public:
 	virtual void configureWeapon(const ItemType& it);
 	virtual bool interruptSwing() const { return false; }
 
-	int32_t playerWeaponCheck(Player* player, Creature* target, uint8_t shootRange) const;
-	bool ammoCheck(const Player* player) const;
-	static bool useFist(Player* player, Creature* target);
-	virtual bool useWeapon(Player* player, Item* item, Creature* target) const;
+	int32_t playerWeaponCheck(const std::shared_ptr<const Player>& player,
+	                          const std::shared_ptr<const Creature>& target, uint8_t shootRange) const;
+	bool ammoCheck(const std::shared_ptr<const Player>& player) const;
+	static bool useFist(const std::shared_ptr<Player>& player, const std::shared_ptr<Creature>& target);
+	virtual bool useWeapon(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                       const std::shared_ptr<Creature>& target) const;
 
-	virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item,
-	                                bool maxDamage = false) const = 0;
-	virtual int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const = 0;
+	virtual int32_t getWeaponDamage(const std::shared_ptr<const Player>& player,
+	                                const std::shared_ptr<const Creature>& target,
+	                                const std::shared_ptr<const Item>& item, bool maxDamage = false) const = 0;
+	virtual int32_t getElementDamage(const std::shared_ptr<const Player>& player,
+	                                 const std::shared_ptr<const Creature>& target,
+	                                 const std::shared_ptr<const Item>& item) const = 0;
 	virtual CombatType_t getElementType() const = 0;
 
 	uint16_t getID() const { return id; }
@@ -128,16 +133,22 @@ public:
 	std::unordered_set<uint16_t> vocationWeaponSet;
 
 protected:
-	void internalUseWeapon(Player* player, Item* item, Creature* target, int32_t damageModifier) const;
-	void internalUseWeapon(Player* player, Item* item, Tile* tile) const;
+	void internalUseWeapon(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                       const std::shared_ptr<Creature>& target, int32_t damageModifier) const;
+	void internalUseWeapon(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                       const std::shared_ptr<Tile>& tile) const;
 
 	uint16_t id = 0;
 
 private:
-	virtual bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const { return false; }
+	virtual bool getSkillType(const std::shared_ptr<const Player>&, const std::shared_ptr<const Item>&, skills_t&,
+	                          uint32_t&) const
+	{
+		return false;
+	}
 
-	uint32_t getManaCost(const Player* player) const;
-	int32_t getHealthCost(const Player* player) const;
+	uint32_t getManaCost(const std::shared_ptr<const Player>& player) const;
+	int32_t getHealthCost(const std::shared_ptr<const Player>& player) const;
 
 	uint32_t level = 0;
 	uint32_t magLevel = 0;
@@ -155,10 +166,11 @@ private:
 
 	std::string_view getScriptEventName() const override final { return "onUseWeapon"; }
 
-	bool executeUseWeapon(Player* player, const LuaVariant& var) const;
-	void onUsedWeapon(Player* player, Item* item, Tile* destTile) const;
+	bool executeUseWeapon(const std::shared_ptr<Player>& player, const LuaVariant& var) const;
+	void onUsedWeapon(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	                  const std::shared_ptr<Tile>& destTile) const;
 
-	static void decrementItemCount(Item* item);
+	static void decrementItemCount(const std::shared_ptr<Item>& item);
 
 	friend class Combat;
 };
@@ -170,15 +182,18 @@ public:
 
 	void configureWeapon(const ItemType& it) override;
 
-	bool useWeapon(Player* player, Item* item, Creature* target) const override;
+	bool useWeapon(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	               const std::shared_ptr<Creature>& target) const override;
 
-	int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item,
-	                        bool maxDamage = false) const override;
-	int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const override;
+	int32_t getWeaponDamage(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Creature>& target,
+	                        const std::shared_ptr<const Item>& item, bool maxDamage = false) const override;
+	int32_t getElementDamage(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Creature>& target,
+	                         const std::shared_ptr<const Item>& item) const override;
 	CombatType_t getElementType() const override { return elementType; }
 
 private:
-	bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const override;
+	bool getSkillType(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Item>& item,
+	                  skills_t& skill, uint32_t& skillpoint) const override;
 
 	CombatType_t elementType = COMBAT_NONE;
 	uint16_t elementDamage = 0;
@@ -192,15 +207,18 @@ public:
 	void configureWeapon(const ItemType& it) override;
 	bool interruptSwing() const override { return true; }
 
-	bool useWeapon(Player* player, Item* item, Creature* target) const override;
+	bool useWeapon(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item,
+	               const std::shared_ptr<Creature>& target) const override;
 
-	int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item,
-	                        bool maxDamage = false) const override;
-	int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const override;
+	int32_t getWeaponDamage(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Creature>& target,
+	                        const std::shared_ptr<const Item>& item, bool maxDamage = false) const override;
+	int32_t getElementDamage(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Creature>& target,
+	                         const std::shared_ptr<const Item>& item) const override;
 	CombatType_t getElementType() const override { return elementType; }
 
 private:
-	bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const override;
+	bool getSkillType(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Item>& item,
+	                  skills_t& skill, uint32_t& skillpoint) const override;
 
 	CombatType_t elementType = COMBAT_NONE;
 	uint16_t elementDamage = 0;
@@ -214,9 +232,13 @@ public:
 	bool configureEvent(const pugi::xml_node& node) override;
 	void configureWeapon(const ItemType& it) override;
 
-	int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item,
-	                        bool maxDamage = false) const override;
-	int32_t getElementDamage(const Player*, const Creature*, const Item*) const override { return 0; }
+	int32_t getWeaponDamage(const std::shared_ptr<const Player>& player, const std::shared_ptr<const Creature>& target,
+	                        const std::shared_ptr<const Item>& item, bool maxDamage = false) const override;
+	int32_t getElementDamage(const std::shared_ptr<const Player>&, const std::shared_ptr<const Creature>&,
+	                         const std::shared_ptr<const Item>&) const override
+	{
+		return 0;
+	}
 	CombatType_t getElementType() const override { return COMBAT_NONE; }
 
 	void setMinChange(int32_t change) { minChange = change; }
@@ -224,7 +246,11 @@ public:
 	void setMaxChange(int32_t change) { maxChange = change; }
 
 private:
-	bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const override { return false; }
+	bool getSkillType(const std::shared_ptr<const Player>&, const std::shared_ptr<const Item>&, skills_t&,
+	                  uint32_t&) const override
+	{
+		return false;
+	}
 
 	int32_t minChange = 0;
 	int32_t maxChange = 0;


### PR DESCRIPTION
- Uses shared_ptr for all entities deriving from Thing
- Get rid of Cylinder in favor of moving behavior to Thing
- Fix userdata handling for shared ptrs, fix unchecked derefs
- Pass all non-owning shared_ptrs as const&

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
