### PR TITLE
feat(docker): migrate base image to debian forky

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,33 @@
-FROM alpine:3.22 AS build
-RUN apk add --no-cache \
-  build-base \
-  boost-dev \
+FROM debian:forky-slim AS build
+RUN apt-get update -q && apt-get install -yq \
+  build-essential \
+  libboost-iostreams1.88-dev \
+  libboost-json1.88-dev \
+  libboost-system1.88-dev \
   cmake \
-  luajit-dev \
-  mariadb-connector-c-dev \
-  openssl-dev \
-  pugixml-dev \
-  samurai \
-  simdutf-dev
+  liblua5.4-dev \
+  libmariadb-dev \
+  libpugixml-dev \
+  libsimdutf-dev \
+  libssl-dev \
+  ninja-build
 
 COPY cmake /usr/src/forgottenserver/cmake/
 COPY src /usr/src/forgottenserver/src/
 COPY CMakeLists.txt CMakePresets.json /usr/src/forgottenserver/
 WORKDIR /usr/src/forgottenserver
-RUN cmake --preset default -DUSE_LUAJIT=ON && cmake --build --config RelWithDebInfo --preset default
+RUN cmake --preset default && cmake --build --config RelWithDebInfo --preset default
 
-FROM alpine:3.22
-RUN apk add --no-cache \
-  boost-iostreams \
-  boost-system \
-  boost-json \
-  luajit \
-  mariadb-connector-c \
-  openssl \
-  pugixml \
-  simdutf
+FROM debian:forky-slim
+RUN apt-get update -q && apt-get install -yq \
+  libboost-iostreams1.88.0 \
+  libboost-json1.88.0 \
+  libboost-system1.88.0 \
+  liblua5.4-0 \
+  libmariadb3 \
+  libpugixml1v5 \
+  libsimdutf27 \
+  libssl3t64
 
 COPY --from=build /usr/src/forgottenserver/build/RelWithDebInfo/tfs /bin/tfs
 COPY data /srv/data/

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -10,12 +10,6 @@
 #include "monster.h"
 #include "pugicast.h"
 
-#if __has_include("luajit/lua.hpp")
-#include <luajit/lua.hpp>
-#else
-#include <lua.hpp>
-#endif
-
 #if LUA_VERSION_NUM >= 502
 #undef lua_strlen
 #define lua_strlen lua_rawlen

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -7,7 +7,11 @@
 
 #include "configmanager.h"
 
+#if __has_include(<mariadb/errmsg.h>)
+#include <mariadb/errmsg.h>
+#else
 #include <mysql/errmsg.h>
+#endif
 
 static tfs::detail::Mysql_ptr connectToDatabase(const bool retryIfError)
 {

--- a/src/otpch.h
+++ b/src/otpch.h
@@ -33,7 +33,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <mysql/mysql.h>
 #include <optional>
 #include <print>
 #include <pugixml.hpp>
@@ -56,6 +55,12 @@
 #include <luajit/lua.hpp>
 #else
 #include <lua.hpp>
+#endif
+
+#if __has_include("mariadb/mysql.h")
+#include <mariadb/mysql.h>
+#else
+#include <mysql/mysql.h>
 #endif
 
 #endif // FS_OTPCH_H


### PR DESCRIPTION
This pull request changes the Docker base image to Debian forky due to errors when building with Lua 5.4 caused by Alpine messing with CMake modules. `simdutf` is not present in the current stable release of Debian (trixie).

**Build environment migration and dependency updates:**

* Migrated the `Dockerfile` from Alpine Linux to Debian (`debian:forky-slim`), updating package installation commands and switching to Debian-compatible package names for all dependencies. This also removes the use of LuaJIT in favor of standard Lua by default, and replaces `samurai` with `ninja-build` for CMake.

**MariaDB compatibility improvements:**

* Updated header inclusion in `src/database.cpp` to prefer MariaDB headers (`mariadb/errmsg.h`) if available, falling back to MySQL headers otherwise, improving support for both database variants.
* Changed the inclusion of the MySQL client header in `src/otpch.h` to prefer MariaDB (`mariadb/mysql.h`) if present, otherwise using the MySQL header, ensuring compatibility with MariaDB installations.
* Removed the unconditional inclusion of `<mysql/mysql.h>` in `src/otpch.h` to avoid conflicts and rely on the new conditional logic.

**Lua compatibility clean-up:**

* Removed the conditional inclusion of LuaJIT headers in `src/configmanager.cpp`, as they are already covered by `src/otpch.h`