### PR TITLE
fix(container): correct queryAdd topParent handling and invitation validation

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -267,19 +267,19 @@ ReturnValue Container::queryAdd(int32_t index, const std::shared_ptr<const Thing
 		}
 	}
 
+	const auto& topParent = getTopParent();
 	if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
-		const auto topParent = getTopParent();
-		if (const auto tile = topParent->getTile()) {
-			if (const auto houseTile = tile->getHouseTile()) {
+		if (const auto& tile = topParent->getTile()) {
+			if (const auto& houseTile = tile->getHouseTile()) {
 				if (!topParent->getCreature() && !houseTile->getHouse()->isInvited(actor->getPlayer())) {
 					return RETURNVALUE_PLAYERISNOTINVITED;
 				}
 			}
 		}
+	}
 
-		if (topParent.get() != this) {
-			return topParent->queryAdd(INDEX_WHEREEVER, item, count, flags | FLAG_CHILDISOWNER, actor);
-		}
+	if (topParent.get() != this) {
+		return topParent->queryAdd(INDEX_WHEREEVER, item, count, flags | FLAG_CHILDISOWNER, actor);
 	}
 
 	return RETURNVALUE_NOERROR;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Behavior of Container::queryAdd regarding top-level container delegation and house invitation validation. The previous impl performed these checks inside the parent block, which caused incorrect behavior when the container had no parent or when topParent logic needed to run earlier.

https://github.com/atlas-kit/atlas/commit/afd91657253c7335b3e08ad428140393677faf83

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
