### PR TITLE
refactor(http): move boost namespace into header

### DIFF
--- a/src/http/cacheinfo.cpp
+++ b/src/http/cacheinfo.cpp
@@ -5,11 +5,7 @@
 #include "../database.h"
 #include "error.h"
 
-namespace beast = boost::beast;
-namespace json = boost::json;
-using boost::beast::http::status;
-
-std::pair<status, json::value> tfs::http::handle_cacheinfo(const json::object&, std::string_view)
+std::pair<beast::http::status, json::value> tfs::http::handle_cacheinfo(const json::object&, std::string_view)
 {
 	thread_local auto& db = Database::getInstance();
 	auto result = db.storeQuery("SELECT COUNT(*) AS `count` FROM `players_online`");
@@ -17,5 +13,5 @@ std::pair<status, json::value> tfs::http::handle_cacheinfo(const json::object&, 
 		return make_error_response();
 	}
 
-	return {status::ok, {{"playersonline", result->getNumber<uint32_t>("count")}}};
+	return {beast::http::status::ok, {{"playersonline", result->getNumber<uint32_t>("count")}}};
 }

--- a/src/http/cacheinfo.h
+++ b/src/http/cacheinfo.h
@@ -3,9 +3,11 @@
 #include <boost/beast/http/status.hpp>
 #include <boost/json/value.hpp>
 
+namespace beast = boost::beast;
+namespace json = boost::json;
+
 namespace tfs::http {
 
-std::pair<boost::beast::http::status, boost::json::value> handle_cacheinfo(const boost::json::object& body,
-                                                                           std::string_view ip);
+std::pair<beast::http::status, boost::json::value> handle_cacheinfo(const json::object& body, std::string_view ip);
 
 }

--- a/src/http/error.cpp
+++ b/src/http/error.cpp
@@ -1,14 +1,10 @@
 #include "error.h"
 
-namespace beast = boost::beast;
-namespace json = boost::json;
-using boost::beast::http::status;
-
-std::pair<status, json::value> tfs::http::make_error_response(detail::ErrorResponseParams params /*= {}*/)
+std::pair<beast::http::status, json::value> tfs::http::make_error_response(detail::ErrorResponseParams params /*= {}*/)
 {
 	json::object body;
 	body["errorCode"] = params.code;
 	body["errorMessage"] = params.message;
 
-	return std::make_pair(status::ok, body);
+	return std::make_pair(beast::http::status::ok, body);
 }

--- a/src/http/error.h
+++ b/src/http/error.h
@@ -3,6 +3,9 @@
 #include <boost/beast/http/status.hpp>
 #include <boost/json/value.hpp>
 
+namespace beast = boost::beast;
+namespace json = boost::json;
+
 namespace tfs::http {
 
 namespace detail {
@@ -12,11 +15,11 @@ struct ErrorResponseParams
 	int code = 2;
 	std::string_view message =
 	    "Internal error. Please try again later or contact customer support if the problem persists.";
-	boost::beast::http::status status = boost::beast::http::status::bad_request;
+	beast::http::status status = beast::http::status::bad_request;
 };
 
 } // namespace detail
 
-std::pair<boost::beast::http::status, boost::json::value> make_error_response(detail::ErrorResponseParams params = {});
+std::pair<beast::http::status, json::value> make_error_response(detail::ErrorResponseParams params = {});
 
 } // namespace tfs::http

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -21,16 +21,14 @@ auto startTimepoint = std::chrono::system_clock::now();
 
 std::chrono::system_clock::duration tfs::http::uptime() { return std::chrono::system_clock::now() - startTimepoint; }
 
-void tfs::http::start(bool bindOnlyOtsIP, std::string_view otsIP, unsigned short port /*= 8080*/, int threads /*= 1*/)
+void tfs::http::start(bool bind_to_specific_ip, std::string_view ip, unsigned short port /*= 8080*/,
+                      int threads /*= 1*/)
 {
 	if (port == 0 || threads < 1) {
 		return;
 	}
 
-	asio::ip::address address = asio::ip::address_v6::any();
-	if (bindOnlyOtsIP) {
-		address = asio::ip::make_address(otsIP);
-	}
+	const auto address = bind_to_specific_ip ? asio::ip::make_address(ip) : asio::ip::address_v6::any();
 	std::println(">> Starting HTTP server on {:s}:{:d} with {:d} threads.", address.to_string(), port, threads);
 
 	auto listener = make_listener(ioc, {address, port});

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -7,7 +7,7 @@ namespace tfs::http {
 
 std::chrono::system_clock::duration uptime();
 
-void start(bool bindOnlyOtsIP, std::string_view otsIP, unsigned short port = 8080, int threads = 1);
+void start(bool bind_to_specific_ip, std::string_view ip, unsigned short port = 8080, int threads = 1);
 void stop();
 
 } // namespace tfs::http

--- a/src/http/listener.cpp
+++ b/src/http/listener.cpp
@@ -5,9 +5,6 @@
 #include <boost/asio/strand.hpp>
 #include <print>
 
-namespace asio = boost::asio;
-namespace beast = boost::beast;
-
 namespace tfs::http {
 
 Listener::Listener(asio::io_context& ioc, asio::ip::tcp::acceptor&& acceptor) : ioc{ioc}, acceptor{std::move(acceptor)}

--- a/src/http/listener.h
+++ b/src/http/listener.h
@@ -4,6 +4,9 @@
 #include <boost/beast/core/error.hpp>
 #include <memory>
 
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+
 namespace boost::asio {
 class io_context;
 }
@@ -13,18 +16,18 @@ namespace tfs::http {
 class Listener final : public std::enable_shared_from_this<Listener>
 {
 public:
-	Listener(boost::asio::io_context& ioc, boost::asio::ip::tcp::acceptor&& acceptor);
+	Listener(asio::io_context& ioc, asio::ip::tcp::acceptor&& acceptor);
 
 	void accept();
 	void run() { accept(); }
 
 private:
-	void on_accept(boost::beast::error_code ec, boost::asio::ip::tcp::socket socket);
+	void on_accept(beast::error_code ec, asio::ip::tcp::socket socket);
 
-	boost::asio::io_context& ioc;
-	boost::asio::ip::tcp::acceptor acceptor;
+	asio::io_context& ioc;
+	asio::ip::tcp::acceptor acceptor;
 };
 
-std::shared_ptr<Listener> make_listener(boost::asio::io_context& ioc, boost::asio::ip::tcp::endpoint endpoint);
+std::shared_ptr<Listener> make_listener(asio::io_context& ioc, asio::ip::tcp::endpoint endpoint);
 
 } // namespace tfs::http

--- a/src/http/login.cpp
+++ b/src/http/login.cpp
@@ -10,10 +10,6 @@
 extern Game g_game;
 extern Vocations g_vocations;
 
-namespace beast = boost::beast;
-namespace json = boost::json;
-using boost::beast::http::status;
-
 namespace {
 
 int getPvpType()
@@ -32,7 +28,7 @@ int getPvpType()
 
 } // namespace
 
-std::pair<status, json::value> tfs::http::handle_login(const json::object& body, std::string_view ip)
+std::pair<beast::http::status, json::value> tfs::http::handle_login(const json::object& body, std::string_view ip)
 {
 	using namespace std::chrono;
 
@@ -140,7 +136,7 @@ std::pair<status, json::value> tfs::http::handle_login(const json::object& body,
 	};
 
 	return {
-	    status::ok,
+	    beast::http::status::ok,
 	    {
 	        {"session",
 	         {

--- a/src/http/login.h
+++ b/src/http/login.h
@@ -3,9 +3,11 @@
 #include <boost/beast/http/status.hpp>
 #include <boost/json/value.hpp>
 
+namespace beast = boost::beast;
+namespace json = boost::json;
+
 namespace tfs::http {
 
-std::pair<boost::beast::http::status, boost::json::value> handle_login(const boost::json::object& body,
-                                                                       std::string_view ip);
+std::pair<beast::http::status, json::value> handle_login(const json::object& body, std::string_view ip);
 
 }

--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -9,9 +9,6 @@
 #include <boost/json/parse.hpp>
 #include <boost/json/serialize.hpp>
 
-namespace beast = boost::beast;
-namespace json = boost::json;
-
 namespace {
 
 auto router(std::string_view type, const json::object& body, std::string_view ip)

--- a/src/http/router.h
+++ b/src/http/router.h
@@ -3,9 +3,12 @@
 #include <boost/beast/http/message_generator.hpp>
 #include <boost/beast/http/string_body.hpp>
 
+namespace beast = boost::beast;
+namespace json = boost::json;
+
 namespace tfs::http {
 
-boost::beast::http::message_generator handle_request(
-    const boost::beast::http::request<boost::beast::http::string_body>& req, std::string_view ip);
+beast::http::message_generator handle_request(const beast::http::request<beast::http::string_body>& req,
+                                              std::string_view ip);
 
 } // namespace tfs::http

--- a/src/http/serverinfo.cpp
+++ b/src/http/serverinfo.cpp
@@ -6,17 +6,13 @@
 #include "../game.h"
 #include "http.h"
 
-namespace beast = boost::beast;
-namespace json = boost::json;
-using boost::beast::http::status;
-
-std::pair<status, json::value> tfs::http::handle_serverinfo(const json::object&, std::string_view)
+std::pair<beast::http::status, json::value> tfs::http::handle_serverinfo(const json::object&, std::string_view)
 {
 	uint32_t mapWidth, mapHeight;
 	g_game.getMapDimensions(mapWidth, mapHeight);
 
 	return {
-	    status::ok,
+	    beast::http::status::ok,
 	    {{
 	         "serverinfo",
 	         {{"uptime", duration_cast<std::chrono::seconds>(uptime()).count()},

--- a/src/http/serverinfo.h
+++ b/src/http/serverinfo.h
@@ -3,9 +3,11 @@
 #include <boost/beast/http/status.hpp>
 #include <boost/json/value.hpp>
 
+namespace beast = boost::beast;
+namespace json = boost::json;
+
 namespace tfs::http {
 
-std::pair<boost::beast::http::status, boost::json::value> handle_serverinfo(const boost::json::object& body,
-                                                                            std::string_view ip);
+std::pair<beast::http::status, json::value> handle_serverinfo(const json::object& body, std::string_view ip);
 
 }

--- a/src/http/session.cpp
+++ b/src/http/session.cpp
@@ -7,9 +7,6 @@
 #include <boost/beast/http/write.hpp>
 #include <print>
 
-namespace asio = boost::asio;
-namespace beast = boost::beast;
-
 namespace tfs::http {
 
 Session::Session(asio::ip::tcp::socket&& socket) : stream{std::move(socket)} {}
@@ -70,7 +67,7 @@ void Session::on_read(beast::error_code ec, size_t /*bytes_transferred*/)
 	if (ec) {
 		std::println(stderr, "{}: {}", __FUNCTION__, ec.message());
 		return;
-	};
+	}
 
 	auto ip = stream.socket().remote_endpoint().address().to_string();
 	write(handle_request(std::move(req), ip));
@@ -81,7 +78,7 @@ void Session::on_write(beast::error_code ec, size_t /*bytes_transferred*/, bool 
 	if (ec) {
 		std::println(stderr, "{}: {}", __FUNCTION__, ec.message());
 		return;
-	};
+	}
 
 	if (!keep_alive) {
 		// This means we should close the connection, usually because

--- a/src/http/session.h
+++ b/src/http/session.h
@@ -6,6 +6,9 @@
 #include <boost/beast/http/string_body.hpp>
 #include <memory>
 
+namespace asio = boost::asio;
+namespace beast = boost::beast;
+
 namespace boost::beast::http {
 class message_generator;
 }
@@ -15,22 +18,22 @@ namespace tfs::http {
 class Session final : public std::enable_shared_from_this<Session>
 {
 public:
-	Session(boost::asio::ip::tcp::socket&& socket);
+	Session(asio::ip::tcp::socket&& socket);
 
 	void read();
-	void write(boost::beast::http::message_generator&& msg);
+	void write(beast::http::message_generator&& msg);
 	void close();
 	void run();
 
 private:
-	void on_read(boost::beast::error_code ec, size_t bytes_transferred);
-	void on_write(boost::beast::error_code ec, size_t bytes_transferred, bool keep_alive);
+	void on_read(beast::error_code ec, size_t bytes_transferred);
+	void on_write(beast::error_code ec, size_t bytes_transferred, bool keep_alive);
 
-	boost::beast::tcp_stream stream;
-	boost::beast::flat_buffer buffer;
-	boost::beast::http::request<boost::beast::http::string_body> req;
+	beast::tcp_stream stream;
+	beast::flat_buffer buffer;
+	beast::http::request<beast::http::string_body> req;
 };
 
-std::shared_ptr<Session> make_session(boost::asio::ip::tcp::socket&& socket);
+std::shared_ptr<Session> make_session(asio::ip::tcp::socket&& socket);
 
 } // namespace tfs::http


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Move boost namespace into header and rename bind/ip params

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
