### PR TITLE
refactor(creature): unify creature registry and remove add/remove list methods

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -116,8 +116,6 @@ public:
 	void setRemoved() { isInternalRemoved = true; }
 
 	uint32_t getID() const { return id; }
-	virtual void removeList() = 0;
-	virtual void addList() = 0;
 
 	virtual bool canSee(const Position& pos) const;
 	virtual bool canSeeCreature(const std::shared_ptr<const Creature>& creature) const;

--- a/src/game.h
+++ b/src/game.h
@@ -463,15 +463,6 @@ public:
 	auto getNpcs() const { return npcs | std::views::values; }
 	auto getMonsters() const { return monsters | std::views::values; }
 
-	void addPlayer(const std::shared_ptr<Player>& player);
-	void removePlayer(const std::shared_ptr<Player>& player);
-
-	void addNpc(const std::shared_ptr<Npc>& npc) { npcs[npc->getID()] = npc; }
-	void removeNpc(const std::shared_ptr<Npc>& npc) { npcs.erase(npc->getID()); }
-
-	void addMonster(const std::shared_ptr<Monster>& monster) { monsters[monster->getID()] = monster; }
-	void removeMonster(const std::shared_ptr<Monster>& monster) { monsters.erase(monster->getID()); }
-
 	std::shared_ptr<Guild> getGuild(uint32_t id) const;
 	void addGuild(std::shared_ptr<Guild> guild) { guilds[guild->getId()] = std::move(guild); }
 	void removeGuild(uint32_t guildId) { guilds.erase(guildId); }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -48,10 +48,6 @@ Monster::Monster(MonsterType* mType) : Creature(), nameDescription(mType->nameDe
 	}
 }
 
-void Monster::addList() { g_game.addMonster(getMonster()); }
-
-void Monster::removeList() { g_game.removeMonster(getMonster()); }
-
 const std::string& Monster::getName() const
 {
 	if (name.empty()) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -50,9 +50,6 @@ public:
 		}
 	}
 
-	void addList() override;
-	void removeList() override;
-
 	const std::string& getName() const override;
 	void setName(const std::string& name);
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -38,10 +38,6 @@ Npc::Npc(const std::string& name) : Creature(), filename("data/npc/" + name + ".
 	reset();
 }
 
-void Npc::addList() { g_game.addNpc(getNpc()); }
-
-void Npc::removeList() { g_game.removeNpc(getNpc()); }
-
 bool Npc::load()
 {
 	if (loaded) {

--- a/src/npc.h
+++ b/src/npc.h
@@ -110,9 +110,6 @@ public:
 		}
 	}
 
-	void removeList() override;
-	void addList() override;
-
 	static std::shared_ptr<Npc> createNpc(const std::string& name);
 
 	bool canSee(const Position& pos) const override;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1096,6 +1096,12 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
+		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+			if (onlinePlayer != getPlayer()) {
+				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_ONLINE);
+			}
+		}
+
 		if (!g_creatureEvents->playerLogin(getPlayer())) {
 			kickPlayer(true);
 			return;
@@ -1234,6 +1240,12 @@ void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool is
 			if (const auto item = inventory[slot]) {
 				g_moveEvents->onPlayerDeEquip(getPlayer(), item, static_cast<slots_t>(slot));
 				tfs::events::player::onInventoryUpdate(getPlayer(), item, static_cast<slots_t>(slot), false);
+			}
+		}
+
+		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+			if (onlinePlayer != getPlayer()) {
+				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_OFFLINE);
 			}
 		}
 
@@ -2208,24 +2220,6 @@ void Player::addInFightTicks(bool pzlock /*= false*/)
 	Condition* condition =
 	    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, getNumber(ConfigManager::PZ_LOCKED), 0);
 	addCondition(condition);
-}
-
-void Player::removeList()
-{
-	g_game.removePlayer(getPlayer());
-
-	for (auto&& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
-		player->notifyStatusChange(getPlayer(), VIPSTATUS_OFFLINE);
-	}
-}
-
-void Player::addList()
-{
-	for (auto&& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
-		player->notifyStatusChange(getPlayer(), VIPSTATUS_ONLINE);
-	}
-
-	g_game.addPlayer(getPlayer());
 }
 
 void Player::kickPlayer(bool displayEffect)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1096,7 +1096,7 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
 			if (onlinePlayer != getPlayer()) {
 				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_ONLINE);
 			}
@@ -1243,7 +1243,7 @@ void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
 			if (onlinePlayer != getPlayer()) {
 				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_OFFLINE);
 			}
@@ -2232,7 +2232,7 @@ void Player::kickPlayer(bool displayEffect)
 	}
 }
 
-void Player::notifyStatusChange(const std::shared_ptr<Player>& loginPlayer, VipStatus_t status)
+void Player::notifyStatusChange(const std::shared_ptr<Player>& loginPlayer, VipStatus_t status) const
 {
 	if (!client) {
 		return;

--- a/src/player.h
+++ b/src/player.h
@@ -150,8 +150,6 @@ public:
 	uint32_t getGUID() const { return guid; }
 	bool canSeeInvisibility() const override { return hasFlag(PlayerFlag_CanSenseInvisibility) || group->access; }
 
-	void removeList() override;
-	void addList() override;
 	void kickPlayer(bool displayEffect);
 
 	static uint64_t getExpForLevel(const uint64_t lv)

--- a/src/player.h
+++ b/src/player.h
@@ -446,7 +446,7 @@ public:
 	}
 
 	// V.I.P. functions
-	void notifyStatusChange(const std::shared_ptr<Player>& loginPlayer, VipStatus_t status);
+	void notifyStatusChange(const std::shared_ptr<Player>& loginPlayer, VipStatus_t status) const;
 	bool removeVIP(uint32_t vipGuid);
 	bool addVIP(uint32_t vipGuid, const std::string& vipName, VipStatus_t status);
 	bool addVIPInternal(uint32_t vipGuid);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactors how creatures are registered inside the game by removing the per-type add/remove API and unifying creature tracking inside `Game::internalPlaceCreature` and `Game::removeCreature`.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
