### PR TITLE
fix(monster): reorder Monster::onCreatureAppear to run scripts before AI logic

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -106,16 +106,6 @@ void Monster::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, 
 {
 	if (creature.get() == this) {
 		setLastPosition(getPosition());
-
-		// We just spawned lets look around to see who is there.
-		if (isSummon()) {
-			isMasterInRange = canSee(getMaster()->getPosition());
-		}
-
-		updateTargetList();
-		updateIdleStatus();
-	} else {
-		onCreatureEnter(creature);
 	}
 
 	if (mType->info.creatureAppearEvent != -1) {
@@ -141,6 +131,18 @@ void Monster::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, 
 		if (scriptInterface->callFunction(2)) {
 			return;
 		}
+	}
+
+	if (creature.get() == this) {
+		// We just spawned lets look around to see who is there.
+		if (isSummon()) {
+			isMasterInRange = canSee(getMaster()->getPosition());
+		}
+
+		updateTargetList();
+		updateIdleStatus();
+	} else {
+		onCreatureEnter(creature);
 	}
 }
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Reordered the flow of Monster::onCreatureAppear so that the Lua creatureAppearEvent is executed before the internal AI logic. This aligns the function with other event handlers that evaluate Lua callbacks first and only execute internal behavior afterwards.

Introduced in https://github.com/atlas-kit/atlas/commit/133f91ea16b5a72c4dfe2710b5a17eedaf359bc0

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
