### PR TITLE
fix(protocol): move sendStoreBalance to dispatcher to prevent data race

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1514,19 +1514,22 @@ void ProtocolGame::parseMarketCreateOffer(NetworkMessage& msg)
 	uint16_t amount = msg.get<uint16_t>();
 	uint64_t price = msg.get<uint64_t>();
 	bool anonymous = (msg.getByte() != 0);
-	g_dispatcher.addTask([=, playerID = player->getID()]() {
+
+	g_dispatcher.addTask([=, playerID = player->getID(), thisPtr = getThis()]() {
+		thisPtr->sendStoreBalance();
 		g_game.playerCreateMarketOffer(playerID, type, spriteId, amount, price, anonymous);
 	});
-	sendStoreBalance();
 }
 
 void ProtocolGame::parseMarketCancelOffer(NetworkMessage& msg)
 {
 	uint32_t timestamp = msg.get<uint32_t>();
 	uint16_t counter = msg.get<uint16_t>();
-	g_dispatcher.addTask(
-	    [=, playerID = player->getID()]() { g_game.playerCancelMarketOffer(playerID, timestamp, counter); });
-	sendStoreBalance();
+
+	g_dispatcher.addTask([=, playerID = player->getID(), thisPtr = getThis()]() {
+		thisPtr->sendStoreBalance();
+		g_game.playerCancelMarketOffer(playerID, timestamp, counter);
+	});
 }
 
 void ProtocolGame::parseMarketAcceptOffer(NetworkMessage& msg)


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Move the `sendStoreBalance` call to the dispatcher thread to ensure all output-buffer writes happen on the correct thread, preventing data races and avoiding unsafe access from the network thread

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
