### PR TITLE
refactor(creature): move skull behavor to private context and rename getSkullClient method

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -108,7 +108,7 @@ static bool isProtected(const std::shared_ptr<const Player>& attacker, const std
 		return true;
 	}
 
-	if (attacker->getSkull() == SKULL_BLACK && attacker->getSkullClient(target) == SKULL_NONE) {
+	if (attacker->getSkull() == SKULL_BLACK && attacker->getCombatSkull(target) == SKULL_NONE) {
 		return true;
 	}
 
@@ -169,7 +169,7 @@ ReturnValue Combat::canTargetCreature(const std::shared_ptr<Player>& attacker, c
 		}
 
 		if (attacker->hasSecureMode() && !Combat::isInPvpZone(attacker, target) &&
-		    attacker->getSkullClient(target->getPlayer()) == SKULL_NONE) {
+		    attacker->getCombatSkull(target->getPlayer()) == SKULL_NONE) {
 			return RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS;
 		}
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -73,9 +73,9 @@ bool Creature::canSeeCreature(const std::shared_ptr<const Creature>& creature) c
 	return true;
 }
 
-void Creature::setSkull(Skulls_t newSkull)
+void Creature::setSkull(Skulls_t skull)
 {
-	skull = newSkull;
+	this->skull = skull;
 	g_game.updateCreatureSkull(getCreature());
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -123,12 +123,10 @@ public:
 	virtual bool canSeeCreature(const std::shared_ptr<const Creature>& creature) const;
 
 	virtual RaceType_t getRace() const { return RACE_NONE; }
+
 	virtual Skulls_t getSkull() const { return skull; }
-	virtual Skulls_t getSkullClient(const std::shared_ptr<const Creature>& creature) const
-	{
-		return creature->getSkull();
-	}
-	void setSkull(Skulls_t newSkull);
+	void setSkull(Skulls_t skull);
+
 	Direction getDirection() const { return direction; }
 	void setDirection(Direction dir) { direction = dir; }
 
@@ -431,7 +429,6 @@ protected:
 	LightInfo internalLight;
 
 	Direction direction = DIRECTION_SOUTH;
-	Skulls_t skull = SKULL_NONE;
 
 	bool isInternalRemoved = false;
 	bool creatureCheck = false;
@@ -479,6 +476,8 @@ private:
 
 	std::map<uint32_t, CountBlock_t> damageMap;
 	std::map<uint32_t, int32_t> storageMap;
+
+	Skulls_t skull = SKULL_NONE;
 };
 
 #endif // FS_CREATURE_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4076,7 +4076,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature>& attacker, const s
 		const auto& attackerPlayer = attacker ? attacker->getPlayer() : nullptr;
 		const auto& targetPlayer = target->getPlayer();
 		if (attackerPlayer && targetPlayer && attackerPlayer->getSkull() == SKULL_BLACK &&
-		    attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
+		    attackerPlayer->getCombatSkull(targetPlayer) == SKULL_NONE) {
 			return false;
 		}
 
@@ -4176,7 +4176,7 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature>& attacker, const s
 		const auto& attackerPlayer = attacker ? attacker->getPlayer() : nullptr;
 		const auto& targetPlayer = target->getPlayer();
 		if (attackerPlayer && targetPlayer && attackerPlayer->getSkull() == SKULL_BLACK &&
-		    attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
+		    attackerPlayer->getCombatSkull(targetPlayer) == SKULL_NONE) {
 			return false;
 		}
 
@@ -4458,7 +4458,7 @@ bool Game::combatChangeMana(const std::shared_ptr<Creature>& attacker, const std
 		if (attacker) {
 			const auto& attackerPlayer = attacker->getPlayer();
 			if (attackerPlayer && attackerPlayer->getSkull() == SKULL_BLACK &&
-			    attackerPlayer->getSkullClient(target) == SKULL_NONE) {
+			    attackerPlayer->getCombatSkull(target) == SKULL_NONE) {
 				return false;
 			}
 		}
@@ -4496,7 +4496,7 @@ bool Game::combatChangeMana(const std::shared_ptr<Creature>& attacker, const std
 
 		const auto& attackerPlayer = attacker ? attacker->getPlayer() : nullptr;
 		if (attackerPlayer && attackerPlayer->getSkull() == SKULL_BLACK &&
-		    attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
+		    attackerPlayer->getCombatSkull(targetPlayer) == SKULL_NONE) {
 			return false;
 		}
 

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -247,9 +247,9 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, DBResult_ptr
 
 			uint16_t skull = result->getNumber<uint16_t>("skull");
 			if (skull == SKULL_RED) {
-				player->skull = SKULL_RED;
+				player->setSkull(SKULL_RED);
 			} else if (skull == SKULL_BLACK) {
-				player->skull = SKULL_BLACK;
+				player->setSkull(SKULL_BLACK);
 			}
 		}
 	}
@@ -664,9 +664,9 @@ bool IOLoginData::savePlayer(const std::shared_ptr<Player>& player)
 		query << "`skulltime` = " << skullTime << ',';
 
 		Skulls_t skull = SKULL_NONE;
-		if (player->skull == SKULL_RED) {
+		if (player->getSkull() == SKULL_RED) {
 			skull = SKULL_RED;
-		} else if (player->skull == SKULL_BLACK) {
+		} else if (player->getSkull() == SKULL_BLACK) {
 			skull = SKULL_BLACK;
 		}
 		query << "`skull` = " << static_cast<int64_t>(skull) << ',';

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -33,7 +33,7 @@ Monster::Monster(MonsterType* mType) : Creature(), nameDescription(mType->nameDe
 {
 	defaultOutfit = mType->info.outfit;
 	currentOutfit = mType->info.outfit;
-	skull = mType->info.skull;
+	setSkull(mType->info.skull);
 	health = mType->info.health;
 	healthMax = mType->info.healthMax;
 	baseSpeed = mType->info.baseSpeed;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3603,7 +3603,7 @@ void Player::onAttackedCreature(const std::shared_ptr<Creature>& target, bool ad
 
 		targetPlayer->addInFightTicks();
 
-		if (getSkull() == SKULL_NONE && getSkullClient(targetPlayer) == SKULL_YELLOW) {
+		if (getSkull() == SKULL_NONE && getCombatSkull(targetPlayer) == SKULL_YELLOW) {
 			addAttacked(targetPlayer);
 			targetPlayer->sendCreatureSkull(getPlayer());
 		} else if (!targetPlayer->hasAttacked(getPlayer())) {
@@ -3924,18 +3924,23 @@ Skulls_t Player::getSkull() const
 	if (hasFlag(PlayerFlag_NotGainInFight)) {
 		return SKULL_NONE;
 	}
-	return skull;
+	return Creature::getSkull();
 }
 
-Skulls_t Player::getSkullClient(const std::shared_ptr<const Creature>& creature) const
+Skulls_t Player::getCombatSkull(const std::shared_ptr<const Creature>& creature) const
 {
-	if (!creature || g_game.getWorldType() != WORLD_TYPE_PVP) {
+	// No skulls in non-pvp worlds
+	if (g_game.getWorldType() != WORLD_TYPE_PVP) {
+		return SKULL_NONE;
+	}
+
+	if (!creature) {
 		return SKULL_NONE;
 	}
 
 	const auto& player = creature->getPlayer();
 	if (!player || player->getSkull() != SKULL_NONE) {
-		return Creature::getSkullClient(creature);
+		return creature->getSkull();
 	}
 
 	if (player->hasAttacked(getPlayer())) {
@@ -3945,7 +3950,7 @@ Skulls_t Player::getSkullClient(const std::shared_ptr<const Creature>& creature)
 	if (party && party == player->party) {
 		return SKULL_GREEN;
 	}
-	return Creature::getSkullClient(creature);
+	return creature->getSkull();
 }
 
 bool Player::hasAttacked(const std::shared_ptr<const Player>& attacked) const
@@ -4013,6 +4018,7 @@ void Player::checkSkullTicks(int64_t ticks)
 		skullTicks = newTicks;
 	}
 
+	const auto skull = getSkull();
 	if ((skull == SKULL_RED || skull == SKULL_BLACK) && skullTicks < 1 && !hasCondition(CONDITION_INFIGHT)) {
 		setSkull(SKULL_NONE);
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -555,8 +555,8 @@ public:
 
 	LightInfo getCreatureLight() const override;
 
+	Skulls_t getCombatSkull(const std::shared_ptr<const Creature>& creature) const;
 	Skulls_t getSkull() const override;
-	Skulls_t getSkullClient(const std::shared_ptr<const Creature>& creature) const override;
 	int64_t getSkullTicks() const { return skullTicks; }
 	void setSkullTicks(int64_t ticks) { skullTicks = ticks; }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1648,7 +1648,7 @@ void ProtocolGame::sendCreatureSkull(const std::shared_ptr<const Creature>& crea
 	NetworkMessage msg;
 	msg.addByte(0x90);
 	msg.add<uint32_t>(creature->getID());
-	msg.addByte(player->getSkullClient(creature));
+	msg.addByte(player->getCombatSkull(creature));
 	writeToOutputBuffer(msg);
 }
 
@@ -3430,7 +3430,7 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const std::shared_ptr<const 
 
 	AddCreatureIcons(msg, creature);
 
-	msg.addByte(player->getSkullClient(creature));
+	msg.addByte(player->getCombatSkull(creature));
 
 	const auto& otherPlayer = creature->getPlayer();
 	msg.addByte(player->getPartyShield(otherPlayer));

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -721,7 +721,7 @@ bool Spell::playerRuneSpellCheck(const std::shared_ptr<Player>& player, const Po
 
 	if (aggressive && needTarget && topVisibleCreature && player->hasSecureMode()) {
 		if (const auto& targetPlayer = topVisibleCreature->getPlayer()) {
-			if (targetPlayer != player && player->getSkullClient(targetPlayer) == SKULL_NONE &&
+			if (targetPlayer != player && player->getCombatSkull(targetPlayer) == SKULL_NONE &&
 			    !Combat::isInPvpZone(player, targetPlayer)) {
 				player->sendCancelMessage(RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS);
 				g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactor moves the skull logic into a more appropriate private context inside Creature and Player. The method formerly known as getSkullClient was renamed to getCombatSkull to better reflect its purpose and remove ambiguity with the regular getSkull() accessor.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
