### PR TITLE
fix(player): notify status changes when player appears

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1096,7 +1096,7 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (onlinePlayer != getPlayer()) {
 				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_ONLINE);
 			}
@@ -1243,7 +1243,7 @@ void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (onlinePlayer != getPlayer()) {
 				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_OFFLINE);
 			}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Removed unnecessary `as_const view` from the players range, ensuring players receive the correct VIP online status notification when another player becomes visible.

Introduced in https://github.com/atlas-kit/atlas/pull/19

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
