### PR TITLE
fix(creature): update skull only after creature is fully spawned

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -73,12 +73,6 @@ bool Creature::canSeeCreature(const std::shared_ptr<const Creature>& creature) c
 	return true;
 }
 
-void Creature::setSkull(Skulls_t skull)
-{
-	this->skull = skull;
-	g_game.updateCreatureSkull(getCreature());
-}
-
 int64_t Creature::getTimeSinceLastMove() const
 {
 	if (lastStep) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -123,7 +123,7 @@ public:
 	virtual RaceType_t getRace() const { return RACE_NONE; }
 
 	virtual Skulls_t getSkull() const { return skull; }
-	void setSkull(Skulls_t skull);
+	void setSkull(Skulls_t skull) { this->skull = skull; }
 
 	Direction getDirection() const { return direction; }
 	void setDirection(Direction dir) { direction = dir; }

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8281,6 +8281,7 @@ int LuaScriptInterface::luaCreatureSetSkull(lua_State* L)
 	// creature:setSkull(skull)
 	if (const auto& creature = tfs::lua::getSharedPtr<Creature>(L, 1)) {
 		creature->setSkull(tfs::lua::getNumber<Skulls_t>(L, 2));
+		g_game.updateCreatureSkull(creature);
 		tfs::lua::pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -142,7 +142,7 @@ bool Npc::loadFromXml()
 
 	if ((attr = npcNode.attribute("skull"))) {
 		setSkull(getSkullType(boost::algorithm::to_lower_copy<std::string>(attr.as_string())));
-		g_game.updateCreatureSkull(getCreature());
+		g_game.updateCreatureSkull(getNpc());
 	}
 
 	pugi::xml_node healthNode = npcNode.child("health");

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -142,6 +142,7 @@ bool Npc::loadFromXml()
 
 	if ((attr = npcNode.attribute("skull"))) {
 		setSkull(getSkullType(boost::algorithm::to_lower_copy<std::string>(attr.as_string())));
+		g_game.updateCreatureSkull(getCreature());
 	}
 
 	pugi::xml_node healthNode = npcNode.child("health");

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3534,6 +3534,7 @@ void Player::onEndCondition(ConditionType_t type)
 
 		if (getSkull() != SKULL_RED && getSkull() != SKULL_BLACK) {
 			setSkull(SKULL_NONE);
+			g_game.updateCreatureSkull(getPlayer());
 		}
 	}
 
@@ -3611,6 +3612,7 @@ void Player::onAttackedCreature(const std::shared_ptr<Creature>& target, bool ad
 
 				if (targetPlayer->getSkull() == SKULL_NONE && getSkull() == SKULL_NONE) {
 					setSkull(SKULL_WHITE);
+					g_game.updateCreatureSkull(getPlayer());
 				}
 
 				if (getSkull() == SKULL_NONE) {
@@ -4000,6 +4002,8 @@ void Player::addUnjustifiedDead(const std::shared_ptr<const Player>& attacked)
 		                            static_cast<int64_t>(getNumber(ConfigManager::FRAG_TIME))) {
 			setSkull(SKULL_RED);
 		}
+
+		g_game.updateCreatureSkull(getPlayer());
 	}
 }
 
@@ -4015,6 +4019,7 @@ void Player::checkSkullTicks(int64_t ticks)
 	const auto skull = getSkull();
 	if ((skull == SKULL_RED || skull == SKULL_BLACK) && skullTicks < 1 && !hasCondition(CONDITION_INFIGHT)) {
 		setSkull(SKULL_NONE);
+		g_game.updateCreatureSkull(getPlayer());
 	}
 }
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Moved the skull update logic out of the Creature constructor and into the spawn flow to avoid calling g_game.updateCreatureSkull() before the Creature instance is fully initialized.

Introduced in https://github.com/atlas-kit/atlas/pull/24

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
