### PR TITLE
fix(general): remove invalid end-iterator caching

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1032,8 +1032,8 @@ bool Creature::addCombatCondition(Condition* condition)
 
 void Creature::removeCondition(ConditionType_t type, bool force /* = false*/)
 {
-	auto it = conditions.begin(), end = conditions.end();
-	while (it != end) {
+	auto it = conditions.begin();
+	while (it != conditions.end()) {
 		Condition* condition = *it;
 		if (condition->getType() != type) {
 			++it;
@@ -1060,8 +1060,8 @@ void Creature::removeCondition(ConditionType_t type, bool force /* = false*/)
 
 void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, bool force /* = false*/)
 {
-	auto it = conditions.begin(), end = conditions.end();
-	while (it != end) {
+	auto it = conditions.begin();
+	while (it != conditions.end()) {
 		Condition* condition = *it;
 		if (condition->getType() != type || condition->getId() != conditionId) {
 			++it;
@@ -1300,8 +1300,8 @@ bool Creature::unregisterCreatureEvent(const std::string& name)
 
 	bool resetTypeBit = true;
 
-	auto it = eventsList.begin(), end = eventsList.end();
-	while (it != end) {
+	auto it = eventsList.begin();
+	while (it != eventsList.end()) {
 		CreatureEvent* curEvent = *it;
 		if (curEvent == event) {
 			it = eventsList.erase(it);

--- a/src/fileloader.cpp
+++ b/src/fileloader.cpp
@@ -110,8 +110,7 @@ void skip(OTB::iterator& first, const OTB::iterator last, const size_t len)
 	auto end = first + len;
 	while (first < end) {
 		if (*first == Node::ESCAPE) [[unlikely]] {
-			++first;
-			++end;
+			++first, ++end;
 		}
 		++first;
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4694,17 +4694,18 @@ void Game::checkDecay()
 	g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() { checkDecay(); }));
 	size_t bucket = (lastBucket + 1) % EVENT_DECAY_BUCKETS;
 
-	auto it = decayItems[bucket].begin();
-	while (it != decayItems[bucket].end()) {
+	auto& decayItemBucket = decayItems[bucket];
+	auto it = decayItemBucket.begin();
+	while (it != decayItemBucket.end()) {
 		const auto item = it->lock();
 		if (!item) {
-			it = decayItems[bucket].erase(it);
+			it = decayItemBucket.erase(it);
 			continue;
 		}
 
 		if (!item->canDecay()) {
 			item->setDecaying(DECAYING_FALSE);
-			it = decayItems[bucket].erase(it);
+			it = decayItemBucket.erase(it);
 			continue;
 		}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3802,8 +3802,8 @@ void Game::checkCreatures(size_t index)
 	                                         [=, this]() { checkCreatures((index + 1) % EVENT_CREATURECOUNT); }));
 
 	auto& checkCreatureList = checkCreatureLists[index];
-	auto it = checkCreatureList.begin(), end = checkCreatureList.end();
-	while (it != end) {
+	auto it = checkCreatureList.begin();
+	while (it != checkCreatureList.end()) {
 		const auto& creature = it->lock();
 		if (!creature) {
 			it = checkCreatureList.erase(it);
@@ -4694,8 +4694,8 @@ void Game::checkDecay()
 	g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() { checkDecay(); }));
 	size_t bucket = (lastBucket + 1) % EVENT_DECAY_BUCKETS;
 
-	auto it = decayItems[bucket].begin(), end = decayItems[bucket].end();
-	while (it != end) {
+	auto it = decayItems[bucket].begin();
+	while (it != decayItems[bucket].end()) {
 		const auto item = it->lock();
 		if (!item) {
 			it = decayItems[bucket].erase(it);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -979,8 +979,8 @@ void ItemAttributes::removeAttribute(itemAttrTypes type)
 	if ((*prev_it).type == type) {
 		attributes.pop_back();
 	} else {
-		auto it = prev_it, end = attributes.rend();
-		while (++it != end) {
+		auto it = prev_it;
+		while (++it != attributes.rend()) {
 			if ((*it).type == type) {
 				(*it) = attributes.back();
 				attributes.pop_back();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2171,8 +2171,8 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 			mana = manaMax;
 		}
 
-		auto it = conditions.begin(), end = conditions.end();
-		while (it != end) {
+		auto it = conditions.begin();
+		while (it != conditions.end()) {
 			Condition* condition = *it;
 			if (condition->isPersistent()) {
 				it = conditions.erase(it);
@@ -2187,8 +2187,8 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 	} else {
 		setSkillLoss(true);
 
-		auto it = conditions.begin(), end = conditions.end();
-		while (it != end) {
+		auto it = conditions.begin();
+		while (it != conditions.end()) {
 			Condition* condition = *it;
 			if (condition->isPersistent()) {
 				it = conditions.erase(it);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Replaced cached end-iterator variables with direct container end evaluations inside loop conditions. This prevents accessing stale iterators when the container is modified during iteration and ensures safer, standards-compliant iteration behavior.

Error: "vector iterators incompatible"

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
