### PR TITLE
refactor(creature): move health/maxHealth behavor to private context

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -163,11 +163,13 @@ public:
 	void setBaseSpeed(uint32_t newBaseSpeed) { baseSpeed = newBaseSpeed; }
 	uint32_t getBaseSpeed() const { return baseSpeed; }
 
-	int32_t getHealth() const { return health; }
-	void setHealth(int32_t newHealth) { health = std::clamp(newHealth, 0, healthMax); }
-	virtual int32_t getMaxHealth() const { return healthMax; }
-	virtual void setMaxHealth(int32_t newMaxHealth) { healthMax = newMaxHealth; }
 	bool isDead() const { return health <= 0; }
+
+	auto getHealth() const { return health; }
+	void setHealth(int32_t health) { this->health = std::clamp(health, 0, maxHealth); }
+
+	virtual int32_t getMaxHealth() const { return maxHealth; }
+	virtual void setMaxHealth(int32_t maxHealth) { this->maxHealth = maxHealth; }
 
 	void setDrunkenness(uint8_t newDrunkenness) { drunkenness = newDrunkenness; }
 	uint8_t getDrunkenness() const { return drunkenness; }
@@ -413,8 +415,6 @@ protected:
 	uint32_t lastStepCost = 1;
 	uint32_t baseSpeed = 220;
 	int32_t varSpeed = 0;
-	int32_t health = 1000;
-	int32_t healthMax = 1000;
 	uint8_t drunkenness = 0;
 
 	Outfit_t currentOutfit;
@@ -469,6 +469,9 @@ private:
 
 	std::map<uint32_t, CountBlock_t> damageMap;
 	std::map<uint32_t, int32_t> storageMap;
+
+	int32_t health = 1000;
+	int32_t maxHealth = 1000;
 
 	Position position;
 	Position lastPosition;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -220,8 +220,8 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, DBResult_ptr
 	player->manaSpent = manaSpent;
 	player->magLevelPercent = Player::getBasisPointLevel(player->manaSpent, nextManaCount);
 
-	player->health = result->getNumber<int32_t>("health");
-	player->healthMax = result->getNumber<int32_t>("healthmax");
+	player->setHealth(result->getNumber<int32_t>("health"));
+	player->setMaxHealth(result->getNumber<int32_t>("healthmax"));
 
 	player->defaultOutfit.lookType = result->getNumber<uint16_t>("looktype");
 	player->defaultOutfit.lookHead = result->getNumber<uint16_t>("lookhead");
@@ -614,8 +614,8 @@ bool IOLoginData::savePlayer(const std::shared_ptr<Player>& player)
 	query << "`level` = " << player->level << ',';
 	query << "`group_id` = " << player->group->id << ',';
 	query << "`vocation` = " << player->getVocationId() << ',';
-	query << "`health` = " << player->health << ',';
-	query << "`healthmax` = " << player->healthMax << ',';
+	query << "`health` = " << player->getHealth() << ',';
+	query << "`healthmax` = " << player->getMaxHealth() << ',';
 	query << "`experience` = " << player->experience << ',';
 	query << "`lookbody` = " << static_cast<uint32_t>(player->defaultOutfit.lookBody) << ',';
 	query << "`lookfeet` = " << static_cast<uint32_t>(player->defaultOutfit.lookFeet) << ',';

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -34,8 +34,8 @@ Monster::Monster(MonsterType* mType) : Creature(), nameDescription(mType->nameDe
 	defaultOutfit = mType->info.outfit;
 	currentOutfit = mType->info.outfit;
 	setSkull(mType->info.skull);
-	health = mType->info.health;
-	healthMax = mType->info.healthMax;
+	setHealth(mType->info.health);
+	setMaxHealth(mType->info.healthMax);
 	baseSpeed = mType->info.baseSpeed;
 	internalLight = mType->info.light;
 	hiddenHealth = mType->info.hiddenHealth;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -148,19 +148,19 @@ bool Npc::loadFromXml()
 	pugi::xml_node healthNode = npcNode.child("health");
 	if (healthNode) {
 		if ((attr = healthNode.attribute("now"))) {
-			health = pugi::cast<int32_t>(attr.value());
+			setHealth(pugi::cast<int32_t>(attr.value()));
 		} else {
-			health = 100;
+			setHealth(100);
 		}
 
 		if ((attr = healthNode.attribute("max"))) {
-			healthMax = pugi::cast<int32_t>(attr.value());
+			setMaxHealth(pugi::cast<int32_t>(attr.value()));
 		} else {
-			healthMax = 100;
+			setMaxHealth(100);
 		}
 
-		if (health > healthMax) {
-			health = healthMax;
+		if (getHealth() > getMaxHealth()) {
+			setHealth(getMaxHealth());
 			std::cout << "[Warning - Npc::loadFromXml] Health now is greater than health max in " << filename
 			          << std::endl;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -556,7 +556,7 @@ int32_t Player::getDefaultStats(stats_t stat) const
 {
 	switch (stat) {
 		case STAT_MAXHITPOINTS:
-			return healthMax;
+			return getMaxHealth();
 		case STAT_MAXMANAPOINTS:
 			return manaMax;
 		case STAT_MAGICPOINTS:
@@ -1771,8 +1771,8 @@ void Player::addExperience(const std::shared_ptr<Creature>& source, uint64_t exp
 	uint32_t prevLevel = level;
 	while (experience >= nextLevelExp) {
 		++level;
-		healthMax += vocation->getHPGain();
-		health += vocation->getHPGain();
+		setMaxHealth(getMaxHealth() + vocation->getHPGain());
+		setHealth(getHealth() + vocation->getHPGain());
 		manaMax += vocation->getManaGain();
 		mana += vocation->getManaGain();
 		capacity += vocation->getCapGain();
@@ -1786,7 +1786,7 @@ void Player::addExperience(const std::shared_ptr<Creature>& source, uint64_t exp
 	}
 
 	if (prevLevel != level) {
-		health = getMaxHealth();
+		setHealth(getMaxHealth());
 		mana = getMaxMana();
 
 		updateBaseSpeed();
@@ -1864,14 +1864,15 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 
 	while (level > 1 && experience < currLevelExp) {
 		--level;
-		healthMax = std::max<int32_t>(0, healthMax - vocation->getHPGain());
+
+		setMaxHealth(std::max<int32_t>(0, getMaxHealth() - vocation->getHPGain()));
 		manaMax = std::max<int32_t>(0, manaMax - vocation->getManaGain());
 		capacity = std::max<int32_t>(0, capacity - vocation->getCapGain());
 		currLevelExp = Player::getExpForLevel(level);
 	}
 
 	if (oldLevel != level) {
-		health = getMaxHealth();
+		setHealth(getMaxHealth());
 		mana = getMaxMana();
 
 		updateBaseSpeed();
@@ -2129,7 +2130,7 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 
 			while (level > 1 && experience < Player::getExpForLevel(level)) {
 				--level;
-				healthMax = std::max<int32_t>(0, healthMax - vocation->getHPGain());
+				setMaxHealth(std::max<int32_t>(0, getMaxHealth() - vocation->getHPGain()));
 				manaMax = std::max<int32_t>(0, manaMax - vocation->getManaGain());
 				capacity = std::max<int32_t>(0, capacity - vocation->getCapGain());
 			}
@@ -2164,10 +2165,10 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 		sendReLoginWindow(unfairFightReduction);
 
 		if (getSkull() == SKULL_BLACK) {
-			health = 40;
+			setHealth(40);
 			mana = 0;
 		} else {
-			health = healthMax;
+			setHealth(getMaxHealth());
 			mana = manaMax;
 		}
 
@@ -2201,7 +2202,7 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 			}
 		}
 
-		health = healthMax;
+		setHealth(getMaxHealth());
 		g_game.internalTeleport(getCreature(), getTemplePosition(), true);
 		g_game.addCreatureHealth(getPlayer());
 		onThink(EVENT_CREATURE_THINK_INTERVAL);

--- a/src/player.h
+++ b/src/player.h
@@ -356,11 +356,14 @@ public:
 		return std::max<int32_t>(0, capacity - inventoryWeight);
 	}
 
-	int32_t getMaxHealth() const override { return std::max<int32_t>(1, healthMax + varStats[STAT_MAXHITPOINTS]); }
-	void setMaxHealth(int32_t newMaxHealth) override
+	int32_t getMaxHealth() const override
 	{
-		healthMax = newMaxHealth;
-		health = std::min<int32_t>(health, getMaxHealth());
+		return std::max<int32_t>(1, Creature::getMaxHealth() + varStats[STAT_MAXHITPOINTS]);
+	}
+	void setMaxHealth(int32_t maxHealth) override
+	{
+		Creature::setMaxHealth(maxHealth);
+		Creature::setHealth(std::min<int32_t>(getHealth(), getMaxHealth()));
 	}
 
 	uint32_t getMana() const { return mana; }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactor moves the health/maxHealth logic into a more appropriate private context

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
