### PR TITLE
refactor(thing): rename item accessor to asItem

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -207,7 +207,7 @@ ReturnValue Container::queryAdd(int32_t index, const std::shared_ptr<const Thing
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -288,7 +288,7 @@ ReturnValue Container::queryAdd(int32_t index, const std::shared_ptr<const Thing
 ReturnValue Container::queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
                                      uint32_t& maxQueryCount, uint32_t flags) const
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		maxQueryCount = 0;
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -345,7 +345,7 @@ ReturnValue Container::queryRemove(const std::shared_ptr<const Thing>& thing, ui
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -405,7 +405,7 @@ std::shared_ptr<Thing> Container::queryDestination(int32_t& index, const std::sh
 		destItem = nullptr;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return shared_from_this();
 	}
@@ -448,7 +448,7 @@ void Container::addThing(int32_t index, const std::shared_ptr<Thing>& thing)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -483,7 +483,7 @@ void Container::updateThing(const std::shared_ptr<Thing>& thing, uint16_t itemId
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -508,7 +508,7 @@ void Container::replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -540,7 +540,7 @@ void Container::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -675,7 +675,7 @@ void Container::internalRemoveThing(const std::shared_ptr<Thing>& thing)
 
 void Container::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return;
 	}

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -10,7 +10,7 @@
 ReturnValue DepotChest::queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
                                  uint32_t flags, const std::shared_ptr<Creature>& actor /* = nullptr*/) const
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -700,7 +700,7 @@ void onLook(const std::shared_ptr<Player>& player, const Position& position, con
 	if (const auto& creature = thing->getCreature()) {
 		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		tfs::lua::pushSharedPtr(L, item);
 		tfs::lua::setItemMetatable(L, -1, item);
 	} else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -208,7 +208,7 @@ std::shared_ptr<Thing> Game::internalGetThing(const std::shared_ptr<Player>& pla
 
 				if (player && tile->hasFlag(TILESTATE_SUPPORTS_HANGABLE)) {
 					// do extra checks here if the thing is accessible
-					if (thing && thing->getItem()) {
+					if (thing && thing->asItem()) {
 						if (tile->hasProperty(CONST_PROP_ISVERTICAL)) {
 							if (player->getPosition().x + 1 == tile->getPosition().x) {
 								return nullptr;
@@ -652,7 +652,7 @@ void Game::playerMoveThing(uint32_t playerId, const Position& fromPos, uint16_t 
 		} else {
 			playerMoveCreature(player, movingCreature, movingCreature->getPosition(), tile);
 		}
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		const auto& toThing = internalGetThing(player, toPos);
 		if (!toThing) {
 			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
@@ -928,12 +928,12 @@ void Game::playerMoveItem(const std::shared_ptr<Player>& player, const Position&
 		}
 
 		const auto& thing = internalGetThing(player, fromPos, fromIndex, 0, STACKPOS_MOVE);
-		if (!thing || !thing->getItem()) {
+		if (!thing || !thing->asItem()) {
 			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 			return;
 		}
 
-		item = thing->getItem();
+		item = thing->asItem();
 	}
 
 	if (item->getClientID() != spriteId) {
@@ -1197,13 +1197,13 @@ ReturnValue Game::internalMoveItem(std::shared_ptr<Thing> fromThing, std::shared
 	}
 
 	if (tradeItem) {
-		if (toThing->getItem() == tradeItem) {
+		if (toThing->asItem() == tradeItem) {
 			return RETURNVALUE_NOTENOUGHROOM;
 		}
 
 		auto parent = toThing->getParent();
 		while (parent) {
-			if (parent->getItem() == tradeItem) {
+			if (parent->asItem() == tradeItem) {
 				return RETURNVALUE_NOTENOUGHROOM;
 			}
 
@@ -1470,7 +1470,7 @@ std::shared_ptr<Item> Game::findItemOfType(const std::shared_ptr<Thing>& fromThi
 			continue;
 		}
 
-		const auto& item = thing->getItem();
+		const auto& item = thing->asItem();
 		if (!item) {
 			continue;
 		}
@@ -1523,7 +1523,7 @@ bool Game::removeMoney(const std::shared_ptr<Thing>& fromThing, uint64_t money, 
 			continue;
 		}
 
-		const auto& item = thing->getItem();
+		const auto& item = thing->asItem();
 		if (!item) {
 			continue;
 		}
@@ -1764,7 +1764,7 @@ ReturnValue Game::internalTeleport(const std::shared_ptr<Thing>& thing, const Po
 
 		map.moveCreature(creature, toTile, !pushMove);
 		return RETURNVALUE_NOERROR;
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		std::shared_ptr<Item> moveItem = nullptr;
 		return internalMoveItem(item->getParent(), toTile, INDEX_WHEREEVER, item, item->getItemCount(), moveItem,
 		                        flags);
@@ -2069,7 +2069,7 @@ void Game::playerUseItemEx(uint32_t playerId, const Position& fromPos, uint8_t f
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item || !item->isUseable() || item->getClientID() != fromSpriteId) {
 		player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
 		return;
@@ -2156,7 +2156,7 @@ void Game::playerUseItem(uint32_t playerId, const Position& pos, uint8_t stackPo
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item || item->isUseable() || item->getClientID() != spriteId) {
 		player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
 		return;
@@ -2229,7 +2229,7 @@ void Game::playerUseWithCreature(uint32_t playerId, const Position& fromPos, uin
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item || !item->isUseable() || item->getClientID() != spriteId) {
 		player->sendCancelMessage(RETURNVALUE_CANNOTUSETHISOBJECT);
 		return;
@@ -2384,7 +2384,7 @@ void Game::playerRotateItem(uint32_t playerId, const Position& pos, uint8_t stac
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item || item->getClientID() != spriteId || (!item->isRotatable() && !item->isPodium()) ||
 	    item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
@@ -2581,7 +2581,7 @@ void Game::playerWrapItem(uint32_t playerId, const Position& position, uint8_t s
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item || item->getClientID() != spriteId || !item->hasAttribute(ITEM_ATTRIBUTE_WRAPID) ||
 	    item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
@@ -2636,7 +2636,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 		return;
 	}
 
-	const auto& tradeItem = tradeThing->getItem();
+	const auto& tradeItem = tradeThing->asItem();
 	if (tradeItem->getClientID() != spriteId || !tradeItem->isPickupable() ||
 	    tradeItem->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
@@ -3334,7 +3334,7 @@ void Game::playerRequestEditPodium(uint32_t playerId, const Position& position, 
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item || item->getClientID() != spriteId || it.type != ITEM_TYPE_PODIUM) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
@@ -3375,7 +3375,7 @@ void Game::playerEditPodium(uint32_t playerId, Outfit_t outfit, const Position& 
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return;
 	}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -345,10 +345,10 @@ void HouseTransferItem::onTradeEvent(TradeEvents_t event, const std::shared_ptr<
 {
 	if (event == ON_TRADE_TRANSFER) {
 		if (house) {
-			house->executeTransfer(std::static_pointer_cast<HouseTransferItem>(getItem()), owner);
+			house->executeTransfer(std::static_pointer_cast<HouseTransferItem>(asItem()), owner);
 		}
 
-		g_game.internalRemoveItem(getItem(), 1);
+		g_game.internalRemoveItem(asItem(), 1);
 	} else if (event == ON_TRADE_CANCEL) {
 		if (house) {
 			house->resetTransferItem();

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -19,7 +19,7 @@ void HouseTile::addThing(int32_t index, const std::shared_ptr<Thing>& thing)
 		return;
 	}
 
-	if (const auto& item = thing->getItem()) {
+	if (const auto& item = thing->asItem()) {
 		updateHouse(item);
 	}
 }
@@ -32,7 +32,7 @@ void HouseTile::internalAddThing(uint32_t index, const std::shared_ptr<Thing>& t
 		return;
 	}
 
-	if (const auto& item = thing->getItem()) {
+	if (const auto& item = thing->asItem()) {
 		updateHouse(item);
 	}
 }
@@ -65,7 +65,7 @@ ReturnValue HouseTile::queryAdd(int32_t index, const std::shared_ptr<const Thing
 		} else {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		if (item->isStoreItem() && !item->hasAttribute(ITEM_ATTRIBUTE_WRAPID)) {
 			return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
 		}
@@ -111,7 +111,7 @@ std::shared_ptr<Thing> HouseTile::queryDestination(int32_t& index, const std::sh
 ReturnValue HouseTile::queryRemove(const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
                                    const std::shared_ptr<Creature>& actor /*= nullptr*/) const
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}

--- a/src/inbox.cpp
+++ b/src/inbox.cpp
@@ -14,7 +14,7 @@ ReturnValue Inbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, 
 		return RETURNVALUE_CONTAINERNOTENOUGHROOM;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -814,7 +814,7 @@ std::string Item::getNameDescription(const ItemType& it, const std::shared_ptr<c
 std::string Item::getNameDescription() const
 {
 	const ItemType& it = items[id];
-	return getNameDescription(it, getItem());
+	return getNameDescription(it, asItem());
 }
 
 std::string Item::getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count /*= 1*/)
@@ -861,7 +861,7 @@ void Item::setUniqueId(uint16_t n)
 		return;
 	}
 
-	if (g_game.addUniqueItem(n, getItem())) {
+	if (g_game.addUniqueItem(n, asItem())) {
 		getAttributes()->setUniqueId(n);
 	}
 }
@@ -1046,7 +1046,7 @@ ItemAttributes::Attribute& ItemAttributes::getAttr(itemAttrTypes type)
 	return attributes.back();
 }
 
-void Item::startDecaying() { g_game.startDecay(getItem()); }
+void Item::startDecaying() { g_game.startDecay(asItem()); }
 
 bool Item::hasMarketAttributes() const
 {

--- a/src/item.h
+++ b/src/item.h
@@ -459,8 +459,8 @@ public:
 	Item& operator=(const Item&) = delete;
 	bool operator==(const Item& otherItem) const;
 
-	std::shared_ptr<Item> getItem() override final { return std::static_pointer_cast<Item>(shared_from_this()); }
-	std::shared_ptr<const Item> getItem() const override final
+	std::shared_ptr<Item> asItem() override final { return std::static_pointer_cast<Item>(shared_from_this()); }
+	std::shared_ptr<const Item> asItem() const override final
 	{
 		return std::static_pointer_cast<const Item>(shared_from_this());
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -289,7 +289,7 @@ uint32_t ScriptEnvironment::addThing(const std::shared_ptr<Thing>& thing)
 		return creature->getID();
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (item && item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		return item->getUniqueId();
 	}
@@ -343,7 +343,7 @@ std::shared_ptr<Item> ScriptEnvironment::getItemByUID(uint32_t uid)
 	if (!thing) {
 		return nullptr;
 	}
-	return thing->getItem();
+	return thing->asItem();
 }
 
 std::shared_ptr<Container> ScriptEnvironment::getContainerByUID(uint32_t uid)
@@ -735,7 +735,7 @@ void tfs::lua::pushThing(lua_State* L, const std::shared_ptr<Thing>& thing)
 		return;
 	}
 
-	if (const auto& item = thing->getItem()) {
+	if (const auto& item = thing->asItem()) {
 		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else if (const auto& creature = thing->getCreature()) {
@@ -5324,7 +5324,7 @@ int LuaScriptInterface::luaTileGetThing(lua_State* L)
 	if (const auto& creature = thing->getCreature()) {
 		tfs::lua::pushSharedPtr(L, creature);
 		tfs::lua::setCreatureMetatable(L, -1, creature);
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		tfs::lua::pushSharedPtr(L, item);
 		tfs::lua::setItemMetatable(L, -1, item);
 	} else {
@@ -5363,7 +5363,7 @@ int LuaScriptInterface::luaTileGetTopVisibleThing(lua_State* L)
 	if (const auto& visibleCreature = thing->getCreature()) {
 		tfs::lua::pushSharedPtr(L, visibleCreature);
 		tfs::lua::setCreatureMetatable(L, -1, visibleCreature);
-	} else if (const auto& visibleItem = thing->getItem()) {
+	} else if (const auto& visibleItem = thing->asItem()) {
 		tfs::lua::pushSharedPtr(L, visibleItem);
 		tfs::lua::setItemMetatable(L, -1, visibleItem);
 	} else {
@@ -6503,7 +6503,7 @@ int LuaScriptInterface::luaItemIsItem(lua_State* L)
 {
 	// item:isItem()
 	if (const auto& thing = tfs::lua::getThing(L, 1)) {
-		tfs::lua::pushBoolean(L, thing->getItem() != nullptr);
+		tfs::lua::pushBoolean(L, thing->asItem() != nullptr);
 	} else {
 		lua_pushnil(L);
 	}
@@ -10190,7 +10190,7 @@ int LuaScriptInterface::luaPlayerGetSlotItem(lua_State* L)
 		return 1;
 	}
 
-	if (const auto& item = thing->getItem()) {
+	if (const auto& item = thing->asItem()) {
 		tfs::lua::pushSharedPtr(L, item);
 		tfs::lua::setItemMetatable(L, -1, item);
 	} else {

--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -77,7 +77,7 @@ bool sendItem(const std::shared_ptr<Item>& item)
 ReturnValue Mailbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, uint32_t, uint32_t,
                               const std::shared_ptr<Creature>&) const
 {
-	if (const auto& item = thing->getItem(); item && canSend(item)) {
+	if (const auto& item = thing->asItem(); item && canSend(item)) {
 		return RETURNVALUE_NOERROR;
 	}
 	return RETURNVALUE_NOTPOSSIBLE;
@@ -92,7 +92,7 @@ ReturnValue Mailbox::queryMaxCount(int32_t, const std::shared_ptr<const Thing>&,
 
 void Mailbox::addThing(int32_t, const std::shared_ptr<Thing>& thing)
 {
-	if (const auto& item = thing->getItem(); item && canSend(item)) {
+	if (const auto& item = thing->asItem(); item && canSend(item)) {
 		sendItem(item);
 	}
 }

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -411,7 +411,7 @@ uint32_t MoveEvents::onCreatureMove(const std::shared_ptr<Creature>& creature, c
 			continue;
 		}
 
-		const auto& tileItem = thing->getItem();
+		const auto& tileItem = thing->asItem();
 		if (!tileItem) {
 			continue;
 		}
@@ -475,7 +475,7 @@ uint32_t MoveEvents::onItemMove(const std::shared_ptr<Item>& item, const std::sh
 			continue;
 		}
 
-		const auto& tileItem = thing->getItem();
+		const auto& tileItem = thing->asItem();
 		if (!tileItem || tileItem == item) {
 			continue;
 		}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1125,7 +1125,7 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 		auto slot = static_cast<slots_t>(i);
 		sendInventoryItem(slot, getInventoryItem(slot));
 	}
-	sendInventoryItem(CONST_SLOT_STORE_INBOX, getStoreInbox()->getItem());
+	sendInventoryItem(CONST_SLOT_STORE_INBOX, getStoreInbox()->asItem());
 
 	openSavedContainers();
 
@@ -2408,7 +2408,7 @@ bool Player::hasCapacity(const std::shared_ptr<const Item>& item, uint32_t count
 ReturnValue Player::queryAdd(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count, uint32_t flags,
                              const std::shared_ptr<Creature>&) const
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -2662,7 +2662,7 @@ ReturnValue Player::queryAdd(int32_t index, const std::shared_ptr<const Thing>& 
 ReturnValue Player::queryMaxCount(int32_t index, const std::shared_ptr<const Thing>& thing, uint32_t count,
                                   uint32_t& maxQueryCount, uint32_t flags) const
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		maxQueryCount = 0;
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -2707,7 +2707,7 @@ ReturnValue Player::queryMaxCount(int32_t index, const std::shared_ptr<const Thi
 		std::shared_ptr<Item> destItem = nullptr;
 
 		if (const auto& destThing = getThing(index)) {
-			destItem = destThing->getItem();
+			destItem = destThing->asItem();
 		}
 
 		if (destItem) {
@@ -2741,7 +2741,7 @@ ReturnValue Player::queryRemove(const std::shared_ptr<const Thing>& thing, uint3
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -2763,7 +2763,7 @@ std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::share
 	destItem = nullptr;
 
 	if (index == 0 /*drop to capacity window*/ || index == INDEX_WHEREEVER) {
-		const auto& item = thing->getItem();
+		const auto& item = thing->asItem();
 		if (!item) {
 			return getPlayer();
 		}
@@ -2874,7 +2874,7 @@ std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::share
 		return getPlayer();
 	}
 
-	const auto& item = destThing->getItem();
+	const auto& item = destThing->asItem();
 	if (!item) {
 		return getPlayer();
 	}
@@ -2895,7 +2895,7 @@ void Player::addThing(int32_t index, const std::shared_ptr<Thing>& thing)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -2914,7 +2914,7 @@ void Player::updateThing(const std::shared_ptr<Thing>& thing, uint16_t itemId, u
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -2940,7 +2940,7 @@ void Player::replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -2958,7 +2958,7 @@ void Player::replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing)
 
 void Player::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -3116,14 +3116,14 @@ void Player::postAddNotification(const std::shared_ptr<Thing>& thing, const std:
 {
 	if (link == LINK_OWNER) {
 		// calling movement scripts
-		g_moveEvents->onPlayerEquip(getPlayer(), thing->getItem(), static_cast<slots_t>(index), false);
-		tfs::events::player::onInventoryUpdate(getPlayer(), thing->getItem(), static_cast<slots_t>(index), true);
+		g_moveEvents->onPlayerEquip(getPlayer(), thing->asItem(), static_cast<slots_t>(index), false);
+		tfs::events::player::onInventoryUpdate(getPlayer(), thing->asItem(), static_cast<slots_t>(index), true);
 	}
 
 	bool requireListUpdate = false;
 
 	if (link == LINK_OWNER || link == LINK_TOPPARENT) {
-		const auto& i = (oldParent ? oldParent->getItem() : nullptr);
+		const auto& i = (oldParent ? oldParent->asItem() : nullptr);
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
@@ -3141,7 +3141,7 @@ void Player::postAddNotification(const std::shared_ptr<Thing>& thing, const std:
 		sendItems();
 	}
 
-	if (const auto& item = thing->getItem()) {
+	if (const auto& item = thing->asItem()) {
 		if (const auto& container = item->getContainer()) {
 			onSendContainer(container);
 		}
@@ -3172,14 +3172,14 @@ void Player::postRemoveNotification(const std::shared_ptr<Thing>& thing, const s
 {
 	if (link == LINK_OWNER) {
 		// calling movement scripts
-		g_moveEvents->onPlayerDeEquip(getPlayer(), thing->getItem(), static_cast<slots_t>(index));
-		tfs::events::player::onInventoryUpdate(getPlayer(), thing->getItem(), static_cast<slots_t>(index), false);
+		g_moveEvents->onPlayerDeEquip(getPlayer(), thing->asItem(), static_cast<slots_t>(index));
+		tfs::events::player::onInventoryUpdate(getPlayer(), thing->asItem(), static_cast<slots_t>(index), false);
 	}
 
 	bool requireListUpdate = false;
 
 	if (link == LINK_OWNER || link == LINK_TOPPARENT) {
-		const auto& i = (newParent ? newParent->getItem() : nullptr);
+		const auto& i = (newParent ? newParent->asItem() : nullptr);
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
@@ -3197,7 +3197,7 @@ void Player::postRemoveNotification(const std::shared_ptr<Thing>& thing, const s
 		sendItems();
 	}
 
-	if (const auto& item = thing->getItem()) {
+	if (const auto& item = thing->asItem()) {
 		if (item->isSupply()) {
 			if (const auto& player = item->getHoldingPlayer()) {
 				player->sendSupplyUsed(item->getClientID());
@@ -3287,7 +3287,7 @@ bool Player::hasShopItemForSale(uint32_t itemId, uint8_t subType) const
 
 void Player::internalAddThing(uint32_t index, const std::shared_ptr<Thing>& thing)
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return;
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -807,7 +807,7 @@ public:
 		if (!sendAll) {
 			// update one slot
 			if (const auto& slotThing = getThing(CONST_SLOT_RIGHT)) {
-				if (const auto& slotItem = slotThing->getItem()) {
+				if (const auto& slotItem = slotThing->asItem()) {
 					if (slotItem->getWeaponType() == WEAPON_QUIVER) {
 						sendInventoryItem(CONST_SLOT_RIGHT, slotItem);
 					}
@@ -818,7 +818,7 @@ public:
 			constexpr auto slots = std::array{CONST_SLOT_RIGHT, CONST_SLOT_LEFT, CONST_SLOT_AMMO};
 			for (const auto& slot : slots) {
 				if (const auto& slotThing = getThing(slot)) {
-					if (const auto& slotItem = slotThing->getItem()) {
+					if (const auto& slotItem = slotThing->asItem()) {
 						if (slotItem->getWeaponType() == WEAPON_QUIVER) {
 							sendInventoryItem(slot, slotItem);
 						}

--- a/src/storeinbox.cpp
+++ b/src/storeinbox.cpp
@@ -10,7 +10,7 @@
 ReturnValue StoreInbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, uint32_t, uint32_t flags,
                                  const std::shared_ptr<Creature>&) const
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -73,7 +73,7 @@ void Teleport::addThing(int32_t, const std::shared_ptr<Thing>& thing)
 			g_game.addMagicEffect(origPos, effect);
 			g_game.addMagicEffect(destTile->getPosition(), effect);
 		}
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		if (effect != CONST_ME_NONE) {
 			g_game.addMagicEffect(destTile->getPosition(), effect);
 			g_game.addMagicEffect(item->getPosition(), effect);

--- a/src/thing.h
+++ b/src/thing.h
@@ -54,8 +54,8 @@ public:
 
 	virtual std::shared_ptr<Tile> getTile() { return nullptr; }
 	virtual std::shared_ptr<const Tile> getTile() const { return nullptr; }
-	virtual std::shared_ptr<Item> getItem() { return nullptr; }
-	virtual std::shared_ptr<const Item> getItem() const { return nullptr; }
+	virtual std::shared_ptr<Item> asItem() { return nullptr; }
+	virtual std::shared_ptr<const Item> asItem() const { return nullptr; }
 	virtual std::shared_ptr<Creature> getCreature() { return nullptr; }
 	virtual std::shared_ptr<const Creature> getCreature() const { return nullptr; }
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -613,7 +613,7 @@ ReturnValue Tile::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, u
 				}
 			}
 		}
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		const TileItemVector* items = getItemList();
 		if (items && items->size() >= 0xFFFF) {
 			return RETURNVALUE_NOTPOSSIBLE;
@@ -705,7 +705,7 @@ ReturnValue Tile::queryRemove(const std::shared_ptr<const Thing>& thing, uint32_
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -808,7 +808,7 @@ std::shared_ptr<Thing> Tile::queryDestination(int32_t&, const std::shared_ptr<co
 
 	if (destTile) {
 		if (const auto& destThing = destTile->getTopDownItem()) {
-			destItem = destThing->getItem();
+			destItem = destThing->asItem();
 		}
 	}
 	return destTile;
@@ -825,7 +825,7 @@ void Tile::addThing(int32_t, const std::shared_ptr<Thing>& thing)
 		creature->setParent(getTile());
 		CreatureVector* creatures = makeCreatures();
 		creatures->insert(creatures->begin(), creature);
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		TileItemVector* items = getItemList();
 		if (items && items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
@@ -920,7 +920,7 @@ void Tile::updateThing(const std::shared_ptr<Thing>& thing, uint16_t itemId, uin
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -938,7 +938,7 @@ void Tile::replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing)
 {
 	int32_t pos = index;
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -1023,7 +1023,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 		return;
 	}
 
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return;
 	}
@@ -1120,7 +1120,7 @@ int32_t Tile::getThingIndex(const std::shared_ptr<const Thing>& thing) const
 
 	const TileItemVector* items = getItemList();
 	if (items) {
-		const auto& item = thing->getItem();
+		const auto& item = thing->asItem();
 		if (item && item->isAlwaysOnTop()) {
 			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 				++n;
@@ -1147,7 +1147,7 @@ int32_t Tile::getThingIndex(const std::shared_ptr<const Thing>& thing) const
 	}
 
 	if (items) {
-		const auto& item = thing->getItem();
+		const auto& item = thing->asItem();
 		if (item && !item->isAlwaysOnTop()) {
 			for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
 				++n;
@@ -1310,7 +1310,7 @@ void Tile::postAddNotification(const std::shared_ptr<Thing>& thing, const std::s
 		// calling movement scripts
 		if (const auto& creature = thing->getCreature()) {
 			g_moveEvents->onCreatureMove(creature, getTile(), MOVE_EVENT_STEP_IN);
-		} else if (const auto& item = thing->getItem()) {
+		} else if (const auto& item = thing->asItem()) {
 			g_moveEvents->onItemMove(item, getTile(), true);
 		}
 	}
@@ -1340,7 +1340,7 @@ void Tile::postRemoveNotification(const std::shared_ptr<Thing>& thing, const std
 
 	if (const auto& creature = thing->getCreature()) {
 		g_moveEvents->onCreatureMove(creature, getTile(), MOVE_EVENT_STEP_OUT);
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		g_moveEvents->onItemMove(item, getTile(), false);
 	}
 }
@@ -1357,7 +1357,7 @@ void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 
 		CreatureVector* creatures = makeCreatures();
 		creatures->insert(creatures->begin(), creature);
-	} else if (const auto& item = thing->getItem()) {
+	} else if (const auto& item = thing->asItem()) {
 		const ItemType& itemType = Item::items[item->getID()];
 		if (itemType.isGroundTile()) {
 			if (!ground) {
@@ -1530,7 +1530,7 @@ std::shared_ptr<Item> Tile::getUseItem(int32_t index) const
 
 	// try getting thing by index
 	if (const auto& thing = getThing(index)) {
-		if (const auto& item = thing->getItem()) {
+		if (const auto& item = thing->asItem()) {
 			return item;
 		}
 	}

--- a/src/trashholder.cpp
+++ b/src/trashholder.cpp
@@ -18,7 +18,7 @@ ReturnValue TrashHolder::queryMaxCount(int32_t, const std::shared_ptr<const Thin
 
 void TrashHolder::addThing(int32_t, const std::shared_ptr<Thing>& thing)
 {
-	const auto& item = thing->getItem();
+	const auto& item = thing->asItem();
 	if (!item) {
 		return;
 	}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Replaces the `getItem` accessor with a more explicit `asItem` method in the `Thing` hierarchy.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
