### PR TITLE
refactor(thing): remove unused throw range fallback from base class

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -131,7 +131,7 @@ public:
 	bool isHealthHidden() const { return hiddenHealth; }
 	void setHiddenHealth(bool b) { hiddenHealth = b; }
 
-	int32_t getThrowRange() const override final { return 1; }
+	int32_t getThrowRange() const { return 1; }
 	bool isPushable() const override { return getWalkDelay() <= 0; }
 	bool isRemoved() const override final { return isInternalRemoved; }
 	virtual bool canSeeInvisibility() const { return false; }

--- a/src/item.h
+++ b/src/item.h
@@ -691,7 +691,7 @@ public:
 	virtual void serializeAttr(PropWriteStream& propWriteStream) const;
 
 	bool isPushable() const override final { return isMoveable(); }
-	int32_t getThrowRange() const override final { return (isPickupable() ? 15 : 2); }
+	int32_t getThrowRange() const { return (isPickupable() ? 15 : 2); }
 
 	uint16_t getID() const { return id; }
 	uint16_t getClientID() const { return items[id].clientId; }

--- a/src/thing.h
+++ b/src/thing.h
@@ -49,7 +49,6 @@ public:
 	virtual void setParent(const std::shared_ptr<Thing>& thing) { parent = thing; }
 
 	virtual const Position& getPosition() const;
-	virtual int32_t getThrowRange() const { return 0; };
 	virtual bool isPushable() const { return false; };
 
 	virtual std::shared_ptr<Tile> getTile() { return nullptr; }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Base Thing class exposed a virtual `getThrowRange` method returning 0, but no code path referenced throw range through Thing itself. All actual usage occurs through Item and Creature instances, which already provide their own concrete impls.

To simplify the class hierarchy and avoid misleading default behavior, the method was removed from Thing. Item and Creature now declare their throw range methods directly without override/final.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
