### PR TITLE
fix(http): respect FREE_PREMIUM config when detecting premium status

### DIFF
--- a/src/http/login.cpp
+++ b/src/http/login.cpp
@@ -79,7 +79,7 @@ std::pair<beast::http::status, json::value> tfs::http::handle_login(const json::
 
 	auto accountId = result->getNumber<uint64_t>("id");
 	auto premiumEndsAt = result->getNumber<int64_t>("premium_ends_at");
-	bool freePremium = getBoolean(ConfigManager::FREE_PREMIUM);
+	auto freePremium = getBoolean(ConfigManager::FREE_PREMIUM);
 
 	std::string sessionKey = randomBytes(16);
 	if (!db.executeQuery(

--- a/src/http/login.cpp
+++ b/src/http/login.cpp
@@ -79,6 +79,7 @@ std::pair<beast::http::status, json::value> tfs::http::handle_login(const json::
 
 	auto accountId = result->getNumber<uint64_t>("id");
 	auto premiumEndsAt = result->getNumber<int64_t>("premium_ends_at");
+	bool freePremium = getBoolean(ConfigManager::FREE_PREMIUM);
 
 	std::string sessionKey = randomBytes(16);
 	if (!db.executeQuery(
@@ -141,7 +142,7 @@ std::pair<beast::http::status, json::value> tfs::http::handle_login(const json::
 	         {
 	             {"sessionkey", tfs::base64::encode(sessionKey)},
 	             {"lastlogintime", lastLogin},
-	             {"ispremium", premiumEndsAt >= now},
+	             {"ispremium", freePremium || premiumEndsAt >= now},
 	             {"premiumuntil", premiumEndsAt},
 	             // not implemented
 	             {"status", "active"},


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed <!-- Describe the changes that this pull request makes. -->
- Fixed premium account detection in login handler to respect the FREE_PREMIUM config setting
- Now properly using ConfigManager to check the FREE_PREMIUM boolean setting

**How to test:** <!-- Write here how to test changes. -->
- Verified that when FREE_PREMIUM is true in config.lua, all accounts are treated as premium
- Confirmed that when FREE_PREMIUM is false, premium status is determined by the premium_ends_at timestamp
- Tested with both premium and free accounts to ensure correct behavior
 
<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
