### PR TITLE
fix(protocol/map): handle floor changes correctly and send incremental viewport tiles

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -249,7 +249,9 @@ void Map::moveCreature(const std::shared_ptr<Creature>& creature, const std::sha
 	Position oldPos = oldTile->getPosition();
 	Position newPos = newTile->getPosition();
 
-	bool teleport = forceTeleport || !newTile->getGround() || !oldPos.isInRange(newPos, 1, 1, 0);
+	bool teleport = forceTeleport || !newTile->getGround() ||
+	                !oldPos.isInRange(newPos, maxClientViewportX + (newPos.x > oldPos.x),
+	                                  maxClientViewportY + (newPos.y > oldPos.y), 1);
 
 	SpectatorVec spectators, newPosSpectators;
 	getSpectators(spectators, oldPos, true);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2808,23 +2808,37 @@ void ProtocolGame::sendMoveCreature(const std::shared_ptr<const Creature>& creat
 			}
 
 			if (oldPos.y > newPos.y) { // north, for old x
-				msg.addByte(0x65);
-				GetMapDescription(oldPos.x - Map::maxClientViewportX, newPos.y - Map::maxClientViewportY, newPos.z,
-				                  (Map::maxClientViewportX * 2) + 2, 1, msg);
+				for (auto missingRowOffset = oldPos.y - newPos.y - 1; missingRowOffset >= 0; missingRowOffset--) {
+					msg.addByte(0x65);
+					GetMapDescription(oldPos.x - Map::maxClientViewportX,
+					                  newPos.y - Map::maxClientViewportY + missingRowOffset, newPos.z,
+					                  (Map::maxClientViewportX * 2) + 2, 1, msg);
+				}
 			} else if (oldPos.y < newPos.y) { // south, for old x
-				msg.addByte(0x67);
-				GetMapDescription(oldPos.x - Map::maxClientViewportX, newPos.y + (Map::maxClientViewportY + 1),
-				                  newPos.z, (Map::maxClientViewportX * 2) + 2, 1, msg);
+				for (auto missingRowOffset = newPos.y - oldPos.y - 1; missingRowOffset >= 0; missingRowOffset--) {
+					msg.addByte(0x67);
+					GetMapDescription(oldPos.x - Map::maxClientViewportX,
+					                  newPos.y + (Map::maxClientViewportY + 1 - missingRowOffset), newPos.z,
+					                  (Map::maxClientViewportX * 2) + 2, 1, msg);
+				}
 			}
 
 			if (oldPos.x < newPos.x) { // east, [with new y]
-				msg.addByte(0x66);
-				GetMapDescription(newPos.x + (Map::maxClientViewportX + 1), newPos.y - Map::maxClientViewportY,
-				                  newPos.z, 1, (Map::maxClientViewportY * 2) + 2, msg);
+				for (auto missingColumnOffset = newPos.x - oldPos.x - 1; missingColumnOffset >= 0;
+				     missingColumnOffset--) {
+					msg.addByte(0x66);
+					GetMapDescription(newPos.x + (Map::maxClientViewportX + 1 - missingColumnOffset),
+					                  newPos.y - Map::maxClientViewportY, newPos.z, 1,
+					                  (Map::maxClientViewportY * 2) + 2, msg);
+				}
 			} else if (oldPos.x > newPos.x) { // west, [with new y]
-				msg.addByte(0x68);
-				GetMapDescription(newPos.x - Map::maxClientViewportX, newPos.y - Map::maxClientViewportY, newPos.z, 1,
-				                  (Map::maxClientViewportY * 2) + 2, msg);
+				for (auto missingColumnOffset = oldPos.x - newPos.x - 1; missingColumnOffset >= 0;
+				     missingColumnOffset--) {
+					msg.addByte(0x68);
+					GetMapDescription(newPos.x - Map::maxClientViewportX + missingColumnOffset,
+					                  newPos.y - Map::maxClientViewportY, newPos.z, 1,
+					                  (Map::maxClientViewportY * 2) + 2, msg);
+				}
 			}
 			writeToOutputBuffer(msg);
 		}


### PR DESCRIPTION
It was not working as expected because the statement oldPos.isInRange(newPos, 1, 1, 0);
was never true.

This commit allows the engine to save data because it will only send the tiles that are not on the screen.
The above statement is valid for tiles on the same floor or one floor up and down.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This commit makes the engine emit MoveDownCreature and MoveUpCreature responses. Also saves data when the player moves inside the already sent screen on the same floor (client viewport).

**Issues addressed:** 
The engine is not emitting MoveDownCreature and MoveUpCreature. This causes extra data being sent because everytime the player changes floors it will send all floors. On floors 0-7, this means it will send everything. On floors 8-15 it will send at most 5 floors every time.

Test on a crowded tower:

| Direction | From floor | Before (bytes) | After (bytes) | Δ Bytes | Improvement |
|-----------|------------|----------------|---------------|---------|-------------|
| down | 0  | 3374 | 1126 | 2248 | 66.6% |
| down | 1  | 3302 | 1182 | 2120 | 64.2% |
| down | 2  | 3150 | 1182 | 1968 | 62.5% |
| down | 3  | 3294 | 1230 | 2064 | 62.7% |
| down | 4  | 3270 | 1182 | 2088 | 63.9% |
| down | 5  | 3422 | 1222 | 2200 | 64.3% |
| down | 6  | 3414 | 1190 | 2224 | 65.1% |
| down | 7  | 1598 | 1454 | 144  | 9.0%  |
| down | 8  | 1598 | 862  | 736  | 46.0% |
| down | 9  | 1206 | 930  | 276  | 22.9% |
| down | 10 | 1126 | 830  | 296  | 26.3% |
| down | 11 | 1206 | 990  | 216  | 17.9% |
| down | 12 | 1126 | 830  | 296  | 26.3% |
| down | 13 | 1070 | 510  | 560  | 52.3% |
| down | 14 | 822  | 342  | 480  | 58.4% |
| up   | 15 | 1046 | 766  | 280  | 26.8% |
| up   | 14 | 1126 | 822  | 304  | 27.0% |
| up   | 13 | 1294 | 1014 | 280  | 21.6% |
| up   | 12 | 1134 | 830  | 304  | 26.8% |
| up   | 11 | 1294 | 1014 | 280  | 21.6% |
| up   | 10 | 1134 | 830  | 304  | 26.8% |
| up   | 9  | 1526 | 1022 | 504  | 33.0% |
| up   | 8  | 3158 | 3302 | -144 | -4.6% |
| up   | 7  | 3382 | 1110 | 2272 | 67.2% |
| up   | 6  | 3142 | 1070 | 2072 | 66.0% |
| up   | 5  | 3310 | 1118 | 2192 | 66.3% |
| up   | 4  | 3182 | 1110 | 2072 | 65.1% |
| up   | 3  | 3326 | 1142 | 2184 | 65.7% |
| up   | 2  | 3318 | 1118 | 2200 | 66.3% |
| up   | 1  | 3454 | 1142 | 2312 | 66.9% |

**How to test:** 
Just move up and down while checking wireshark and you will see it that less data will be sent to the client.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
