### PR TITLE
feat(general): drop x32 support in favor of x64

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -30,7 +30,7 @@ static constexpr auto AUTHENTICATOR_PERIOD = 30U;
 #define _USE_MATH_DEFINES
 #endif
 
-#ifdef _WIN32
+#ifdef _WIN64
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -56,7 +56,7 @@ void mainLoader(ServiceManager* services)
 	g_game.setGameState(GAME_STATE_STARTUP);
 
 	srand(static_cast<unsigned int>(OTSYS_TIME()));
-#ifdef _WIN32
+#ifdef _WIN64
 	SetConsoleTitle(STATUS_SERVER_NAME);
 
 	// fixes a problem with escape characters not being processed in Windows consoles
@@ -92,7 +92,7 @@ void mainLoader(ServiceManager* services)
 		return;
 	}
 
-#ifdef _WIN32
+#ifdef _WIN64
 	const std::string& defaultPriority = getString(ConfigManager::DEFAULT_PRIORITY);
 	if (boost::iequals(defaultPriority, "high")) {
 		SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
@@ -251,7 +251,7 @@ void mainLoader(ServiceManager* services)
 
 	std::cout << ">> Loaded all modules, server starting up..." << std::endl;
 
-#ifndef _WIN32
+#ifndef _WIN64
 	if (getuid() == 0 || geteuid() == 0) {
 		std::cout << "> Warning: " << STATUS_SERVER_NAME
 		          << " has been executed as root user, please consider running it as a normal user." << std::endl;

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -40,7 +40,7 @@ extern LuaEnvironment g_luaEnvironment;
 
 namespace {
 
-#ifndef _WIN32
+#ifndef _WIN64
 void sigusr1Handler()
 {
 	// Dispatcher thread
@@ -136,7 +136,7 @@ void dispatchSignalHandler(int signal)
 		case SIGTERM: // Shuts the server down
 			g_dispatcher.addTask(sigtermHandler);
 			break;
-#ifndef _WIN32
+#ifndef _WIN64
 		case SIGHUP: // Reload config/data
 			g_dispatcher.addTask(sighupHandler);
 			break;
@@ -163,7 +163,7 @@ Signals::Signals(boost::asio::io_context& ioc) : set(ioc)
 {
 	set.add(SIGINT);
 	set.add(SIGTERM);
-#ifndef _WIN32
+#ifndef _WIN64
 	set.add(SIGUSR1);
 	set.add(SIGHUP);
 #else


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Removed support for 32-bit builds throughout the codebase on 64-bit targets.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
