### PR TITLE
refactor(player): move skull ticks to Lua

### DIFF
--- a/data/creaturescripts/scripts/login.lua
+++ b/data/creaturescripts/scripts/login.lua
@@ -39,5 +39,6 @@ function onLogin(player)
 	player:registerEvent("DropLoot")
 	player:registerEvent("BestiaryKills")
 	player:registerEvent("Idle Timeout")
+	player:registerEvent("Skull Decay")
 	return true
 end

--- a/data/scripts/creaturescripts/player/skull_decay.lua
+++ b/data/scripts/creaturescripts/player/skull_decay.lua
@@ -1,0 +1,33 @@
+local event = CreatureEvent("Skull Decay")
+
+function event.onThink(player, interval)
+	if Game.getWorldType() == WORLD_TYPE_PVP_ENFORCED then
+		return true
+	end
+
+	local skullTime = player:getSkullTime()
+	if skullTime <= 0 then
+		return true
+	end
+
+	local elapsed = interval / 1000
+	skullTime = math.max(0, skullTime - elapsed)
+
+	player:setSkullTime(skullTime)
+
+	if skullTime > 0 then
+		return true
+	end
+
+	if player:hasCondition(CONDITION_INFIGHT) then
+		return true
+	end
+
+	local skull = player:getSkull()
+	if skull == SKULL_RED or skull == SKULL_BLACK then
+		player:setSkull(SKULL_NONE)
+	end
+	return true
+end
+
+event:register()

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1501,10 +1501,6 @@ void Player::onThink(uint32_t interval)
 		addMessageBuffer();
 	}
 
-	if (g_game.getWorldType() != WORLD_TYPE_PVP_ENFORCED) {
-		checkSkullTicks(interval / 1000);
-	}
-
 	addOfflineTrainingTime(interval);
 	if (lastStatsTrainingTime != getOfflineTrainingTime() / 60 / 1000) {
 		sendStats();
@@ -3987,22 +3983,6 @@ void Player::addUnjustifiedDead(const std::shared_ptr<const Player>& attacked)
 			setSkull(SKULL_RED);
 		}
 
-		g_game.updateCreatureSkull(getPlayer());
-	}
-}
-
-void Player::checkSkullTicks(int64_t ticks)
-{
-	int64_t newTicks = skullTicks - ticks;
-	if (newTicks < 0) {
-		skullTicks = 0;
-	} else {
-		skullTicks = newTicks;
-	}
-
-	const auto skull = getSkull();
-	if ((skull == SKULL_RED || skull == SKULL_BLACK) && skullTicks < 1 && !hasCondition(CONDITION_INFIGHT)) {
-		setSkull(SKULL_NONE);
 		g_game.updateCreatureSkull(getPlayer());
 	}
 }

--- a/src/player.h
+++ b/src/player.h
@@ -569,8 +569,6 @@ public:
 			client->sendCreatureSkull(creature);
 		}
 	}
-	void checkSkullTicks(int64_t ticks);
-
 	bool canWear(uint32_t lookType, uint8_t addons) const;
 	bool hasOutfit(uint32_t lookType, uint8_t addons);
 	void addOutfit(uint16_t lookType, uint8_t addons);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Moves the player skull decay logic from the C++ core into Lua by introducing a dedicated CreatureEvent that updates skull time on each think cycle. The existing tick-based implementation and world type checks were removed, simplifying the player logic and making skull decay behavior fully scriptable. This change preserves the original rules for PvP-enforced worlds, infight conditions and skull removal.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
