### PR TITLE
refactor(protocolgame): move ping & ping back packets to Lua

### DIFF
--- a/data/creaturescripts/scripts/login.lua
+++ b/data/creaturescripts/scripts/login.lua
@@ -34,6 +34,11 @@ function onLogin(player)
 		player:setStorageValue(PlayerStorageKeys.achievementsTotal, player:getAchievementPoints())
 	end
 
+	-- initialize ping-pong timestamps
+	local timeNow = os.mtime()
+	player:setLastPing(timeNow)
+	player:setLastPong(timeNow)
+
 	-- Events
 	player:registerEvent("PlayerDeath")
 	player:registerEvent("DropLoot")

--- a/data/creaturescripts/scripts/login.lua
+++ b/data/creaturescripts/scripts/login.lua
@@ -40,5 +40,6 @@ function onLogin(player)
 	player:registerEvent("BestiaryKills")
 	player:registerEvent("Idle Timeout")
 	player:registerEvent("Skull Decay")
+	player:registerEvent("PingPong")
 	return true
 end

--- a/data/creaturescripts/scripts/logout.lua
+++ b/data/creaturescripts/scripts/logout.lua
@@ -3,5 +3,9 @@ function onLogout(player)
 	if nextUseStaminaTime[playerId] then
 		nextUseStaminaTime[playerId] = nil
 	end
+
+	player:setLastPing(nil)
+	player:setLastPong(nil)
+
 	return true
 end

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -13,6 +13,10 @@ GlobalStorageKeys = {
 }
 
 PlayerStorageKeys = {
+	-- connection stability subsystem
+	lastPing = 7464,
+	lastPong = 7465,
+
 	-- Misc:
 	annihilatorReward = 30015,
 	goldenOutfit = 30016,

--- a/data/scripts/creaturescripts/player/ping_pong.lua
+++ b/data/scripts/creaturescripts/player/ping_pong.lua
@@ -38,7 +38,7 @@ function event.onThink(player, interval)
             return true
         end
 
-        player:kick()
+        player:remove()
     end
     return true
 end

--- a/data/scripts/creaturescripts/player/ping_pong.lua
+++ b/data/scripts/creaturescripts/player/ping_pong.lua
@@ -1,0 +1,46 @@
+local event = CreatureEvent("PingPong")
+
+local LOST_CONNECTION_MILLIS = 5000
+local REMOVE_TARGET_PLAYER_MILLIS = 7000
+local PZ_LOCKED_NO_PONG_KICK_MILLIS = 60000
+
+function event.onThink(player, interval)
+    local timeNow = os.mtime()
+
+    local hasLostConnection = false
+    if timeNow - player:getLastPing() >= LOST_CONNECTION_MILLIS then
+        player:setLastPing(timeNow)
+        if player:getClient() then
+            local msg = NetworkMessage()
+            msg:addByte(0x1D)
+            msg:sendToPlayer(player)
+            msg:delete()
+        else
+            hasLostConnection = true
+        end
+    end
+
+    local noPongTime = timeNow - player:getLastPong()
+    if hasLostConnection or noPongTime >= REMOVE_TARGET_PLAYER_MILLIS then
+        local target = player:getTarget()
+        if target and target:isPlayer() then
+            player:setTarget(nil)
+        end
+    end
+
+    local noPongKickTime = player:getVocation():getNoPongKickTime()
+    if player:isPzLocked() and noPongKickTime < PZ_LOCKED_NO_PONG_KICK_MILLIS then
+        noPongKickTime = PZ_LOCKED_NO_PONG_KICK_MILLIS
+    end
+
+    if noPongTime >= noPongKickTime then
+        if player:getTile():hasFlag(TILESTATE_NOLOGOUT) then
+            return true
+        end
+
+        player:kick()
+    end
+    return true
+end
+
+event:register()

--- a/data/scripts/lib/ping_pong.lua
+++ b/data/scripts/lib/ping_pong.lua
@@ -1,0 +1,18 @@
+local LAST_PING_STORAGE = 7464
+local LAST_PONG_STORAGE = 7664
+
+function Player.getLastPing(self)
+  return self:getStorageValue(LAST_PING_STORAGE) or 0
+end
+
+function Player.setLastPing(self, time)
+  self:setStorageValue(LAST_PING_STORAGE, time)
+end
+
+function Player.getLastPong(self)
+  return self:getStorageValue(LAST_PONG_STORAGE) or 0
+end
+
+function Player.setLastPong(self, time)
+  self:setStorageValue(LAST_PONG_STORAGE, time)
+end

--- a/data/scripts/lib/ping_pong.lua
+++ b/data/scripts/lib/ping_pong.lua
@@ -1,5 +1,5 @@
 function Player.getLastPing(self)
-  return self:getStorageValue(PlayerStorageKeys.lastPing) or 0
+  return self:getStorageValue(PlayerStorageKeys.lastPing)
 end
 
 function Player.setLastPing(self, time)
@@ -7,7 +7,7 @@ function Player.setLastPing(self, time)
 end
 
 function Player.getLastPong(self)
-  return self:getStorageValue(PlayerStorageKeys.lastPong) or 0
+  return self:getStorageValue(PlayerStorageKeys.lastPong)
 end
 
 function Player.setLastPong(self, time)

--- a/data/scripts/lib/ping_pong.lua
+++ b/data/scripts/lib/ping_pong.lua
@@ -1,18 +1,15 @@
-local LAST_PING_STORAGE = 7464
-local LAST_PONG_STORAGE = 7664
-
 function Player.getLastPing(self)
-  return self:getStorageValue(LAST_PING_STORAGE) or 0
+  return self:getStorageValue(PlayerStorageKeys.lastPing) or 0
 end
 
 function Player.setLastPing(self, time)
-  self:setStorageValue(LAST_PING_STORAGE, time)
+  self:setStorageValue(PlayerStorageKeys.lastPing, time)
 end
 
 function Player.getLastPong(self)
-  return self:getStorageValue(LAST_PONG_STORAGE) or 0
+  return self:getStorageValue(PlayerStorageKeys.lastPong) or 0
 end
 
 function Player.setLastPong(self, time)
-  self:setStorageValue(LAST_PONG_STORAGE, time)
+  self:setStorageValue(PlayerStorageKeys.lastPong, time)
 end

--- a/data/scripts/network/receive_ping.lua
+++ b/data/scripts/network/receive_ping.lua
@@ -1,0 +1,7 @@
+local handler = PacketHandler(0x1E)
+
+function handler.onReceive(player)
+    player:setLastPong(os.mtime())
+end
+
+handler:register()

--- a/data/scripts/network/receive_pong.lua
+++ b/data/scripts/network/receive_pong.lua
@@ -1,0 +1,10 @@
+local handler = PacketHandler(0x1D)
+
+function handler.onReceive(player)
+    local msg = NetworkMessage()
+    msg:addByte(0x1E)
+    msg:sendToPlayer(player)
+    msg:delete()
+end
+
+handler:register()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2021,20 +2021,6 @@ void Game::playerCloseNpcChannel(uint32_t playerId)
 	}
 }
 
-void Game::playerReceivePing(uint32_t playerId)
-{
-	if (const auto& player = getPlayerByID(playerId)) {
-		player->receivePing();
-	}
-}
-
-void Game::playerReceivePingBack(uint32_t playerId)
-{
-	if (const auto& player = getPlayerByID(playerId)) {
-		player->sendPingBack();
-	}
-}
-
 void Game::playerAutoWalk(uint32_t playerId, const std::vector<Direction>& listDir)
 {
 	if (const auto& player = getPlayerByID(playerId)) {

--- a/src/game.h
+++ b/src/game.h
@@ -337,8 +337,6 @@ public:
 	void playerCloseChannel(uint32_t playerId, uint16_t channelId);
 	void playerOpenPrivateChannel(uint32_t playerId, std::string receiver);
 	void playerCloseNpcChannel(uint32_t playerId);
-	void playerReceivePing(uint32_t playerId);
-	void playerReceivePingBack(uint32_t playerId);
 	void playerAutoWalk(uint32_t playerId, const std::vector<Direction>& listDir);
 	void playerStopAutoWalk(uint32_t playerId);
 	void playerUseItemEx(uint32_t playerId, const Position& fromPos, uint8_t fromStackPos, uint16_t fromSpriteId,

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8891,21 +8891,6 @@ int LuaScriptInterface::luaPlayerGetLastLogout(lua_State* L)
 	return 1;
 }
 
-int LuaScriptInterface::luaPlayerKick(lua_State* L)
-{
-	// player:kick([displayEffect = false])
-	const auto& player = tfs::lua::getSharedPtr<Player>(L, 1);
-	if (!player) {
-		lua_pushnil(L);
-		return 1;
-	}
-
-	const auto displayEffect = tfs::lua::getBoolean(L, 2, false);
-	player->kickPlayer(displayEffect);
-	tfs::lua::pushBoolean(L, true);
-	return 1;
-}
-
 int LuaScriptInterface::luaPlayerGetAccountType(lua_State* L)
 {
 	// player:getAccountType()

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2679,7 +2679,6 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "Player", "getAccountId", LuaScriptInterface::luaPlayerGetAccountId);
 	registerMethod(L, "Player", "getLastLoginSaved", LuaScriptInterface::luaPlayerGetLastLoginSaved);
 	registerMethod(L, "Player", "getLastLogout", LuaScriptInterface::luaPlayerGetLastLogout);
-	registerMethod(L, "Player", "kick", LuaScriptInterface::luaPlayerKick);
 
 	registerMethod(L, "Player", "getAccountType", LuaScriptInterface::luaPlayerGetAccountType);
 	registerMethod(L, "Player", "setAccountType", LuaScriptInterface::luaPlayerSetAccountType);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -988,6 +988,8 @@ std::shared_ptr<Creature> tfs::lua::getCreature(lua_State* L, int32_t arg)
 {
 	if (lua_isuserdata(L, arg)) {
 		return getSharedPtr<Creature>(L, arg);
+	} else if (lua_isnil(L, arg)) {
+		return nullptr;
 	}
 	return g_game.getCreatureByID(getNumber<uint32_t>(L, arg));
 }
@@ -2677,6 +2679,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "Player", "getAccountId", LuaScriptInterface::luaPlayerGetAccountId);
 	registerMethod(L, "Player", "getLastLoginSaved", LuaScriptInterface::luaPlayerGetLastLoginSaved);
 	registerMethod(L, "Player", "getLastLogout", LuaScriptInterface::luaPlayerGetLastLogout);
+	registerMethod(L, "Player", "kick", LuaScriptInterface::luaPlayerKick);
 
 	registerMethod(L, "Player", "getAccountType", LuaScriptInterface::luaPlayerGetAccountType);
 	registerMethod(L, "Player", "setAccountType", LuaScriptInterface::luaPlayerSetAccountType);
@@ -2984,6 +2987,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod(L, "Vocation", "getPromotion", LuaScriptInterface::luaVocationGetPromotion);
 
 	registerMethod(L, "Vocation", "allowsPvp", LuaScriptInterface::luaVocationAllowsPvp);
+	registerMethod(L, "Vocation", "getNoPongKickTime", LuaScriptInterface::luaVocationGetNoPongKickTime);
 
 	// House
 	registerClass(L, "House", "", LuaScriptInterface::luaHouseCreate);
@@ -8887,6 +8891,21 @@ int LuaScriptInterface::luaPlayerGetLastLogout(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaPlayerKick(lua_State* L)
+{
+	// player:kick([displayEffect = false])
+	const auto& player = tfs::lua::getSharedPtr<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	const auto displayEffect = tfs::lua::getBoolean(L, 2, false);
+	player->kickPlayer(displayEffect);
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
 int LuaScriptInterface::luaPlayerGetAccountType(lua_State* L)
 {
 	// player:getAccountType()
@@ -12216,6 +12235,18 @@ int LuaScriptInterface::luaVocationAllowsPvp(lua_State* L)
 	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
 	if (vocation) {
 		tfs::lua::pushBoolean(L, vocation->allowsPvp());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaVocationGetNoPongKickTime(lua_State* L)
+{
+	// vocation:getNoPongKickTime()
+	Vocation* vocation = tfs::lua::getUserdata<Vocation>(L, 1);
+	if (vocation) {
+		tfs::lua::pushNumber(L, vocation->getNoPongKickTime());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -611,7 +611,6 @@ private:
 	static int luaPlayerGetAccountId(lua_State* L);
 	static int luaPlayerGetLastLoginSaved(lua_State* L);
 	static int luaPlayerGetLastLogout(lua_State* L);
-	static int luaPlayerKick(lua_State* L);
 
 	static int luaPlayerGetAccountType(lua_State* L);
 	static int luaPlayerSetAccountType(lua_State* L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -611,6 +611,7 @@ private:
 	static int luaPlayerGetAccountId(lua_State* L);
 	static int luaPlayerGetLastLoginSaved(lua_State* L);
 	static int luaPlayerGetLastLogout(lua_State* L);
+	static int luaPlayerKick(lua_State* L);
 
 	static int luaPlayerGetAccountType(lua_State* L);
 	static int luaPlayerSetAccountType(lua_State* L);
@@ -909,6 +910,7 @@ private:
 	static int luaVocationGetPromotion(lua_State* L);
 
 	static int luaVocationAllowsPvp(lua_State* L);
+	static int luaVocationGetNoPongKickTime(lua_State* L);
 
 	// House
 	static int luaHouseCreate(lua_State* L);

--- a/src/player.h
+++ b/src/player.h
@@ -951,13 +951,6 @@ public:
 			client->sendMagicEffect(pos, type);
 		}
 	}
-	void sendPing();
-	void sendPingBack() const
-	{
-		if (client) {
-			client->sendPingBack();
-		}
-	}
 	void sendStats();
 
 	void sendExperienceTracker(int64_t rawExp, int64_t finalExp) const
@@ -1173,8 +1166,6 @@ public:
 		}
 	}
 
-	void receivePing() { lastPong = OTSYS_TIME(); }
-
 	void onThink(uint32_t interval) override;
 	void onAttacking(uint32_t) override;
 
@@ -1303,8 +1294,6 @@ private:
 	int64_t skullTicks = 0;
 	int64_t lastWalkthroughAttempt = 0;
 	int64_t lastToggleMount = 0;
-	int64_t lastPing;
-	int64_t lastPong;
 	int64_t nextAction = 0;
 
 	ProtocolGame_ptr client;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -524,12 +524,6 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 		case 0x14:
 			g_dispatcher.addTask([thisPtr = getThis()]() { thisPtr->logout(true, false); });
 			break;
-		case 0x1D:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerReceivePingBack(playerID); });
-			break;
-		case 0x1E:
-			g_dispatcher.addTask([playerID = player->getID()]() { g_game.playerReceivePing(playerID); });
-			break;
 		// case 0x2A: break; // bestiary tracker
 		// case 0x2C: break; // team finder (leader)
 		// case 0x2D: break; // team finder (member)
@@ -2518,20 +2512,6 @@ void ProtocolGame::sendSkills()
 {
 	NetworkMessage msg;
 	AddPlayerSkills(msg);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendPing()
-{
-	NetworkMessage msg;
-	msg.addByte(0x1D);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::sendPingBack()
-{
-	NetworkMessage msg;
-	msg.addByte(0x1E);
 	writeToOutputBuffer(msg);
 }
 

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -172,8 +172,6 @@ private:
 	void sendMagicEffect(const Position& pos, uint8_t type);
 	void sendCreatureHealth(const std::shared_ptr<const Creature>& creature);
 	void sendSkills();
-	void sendPing();
-	void sendPingBack();
 	void sendCreatureTurn(const std::shared_ptr<const Creature>& creature, uint32_t stackpos);
 	void sendCreatureSay(const std::shared_ptr<const Creature>& creature, SpeakClasses type, const std::string& text,
 	                     const Position* pos = nullptr);


### PR DESCRIPTION
This pull request migrates the ping/pong system to handle player connectivity and kicking to Lua, moving the logic out of the C++ core and into scripts for improved flexibility.

It removes the old C++ ping/pong implementation, adds new Lua APIs for tracking ping/pong times and kicking players, and implements network handlers for the ping/pong protocol. The new system allows for more configurable and vocation-aware kick times.

**Key changes:**

### Migration of Ping/Pong Logic from C++ to Lua

* Removed the old C++-based ping/pong logic, including member variables, methods, and protocol handlers in `Player`, `Game`, and `ProtocolGame`. All ping/pong handling is now managed in Lua scripts. [[1]](diffhunk://#diff-10c39dd978ada90e0d090a045c4ae5f51dad010f3b754679e15894c9b93d254bL791-L833) [[2]](diffhunk://#diff-10c39dd978ada90e0d090a045c4ae5f51dad010f3b754679e15894c9b93d254bL1496-L1497) [[3]](diffhunk://#diff-71ab3d0cd534a1608f1c652185c8a8e1247c81813161673bedf7f5433dad2483L954-L960) [[4]](diffhunk://#diff-71ab3d0cd534a1608f1c652185c8a8e1247c81813161673bedf7f5433dad2483L1176-L1177) [[5]](diffhunk://#diff-71ab3d0cd534a1608f1c652185c8a8e1247c81813161673bedf7f5433dad2483L1306-L1307) [[6]](diffhunk://#diff-0bb6c7b942a6c15255f935db679c066dfce4d4114fdb99698c1e1a09b7f5a98aL2024-L2037) [[7]](diffhunk://#diff-ca54668860ba1b6ad285983b8a53a637120a3c906f4f124f0a974f864d1bd4caL340-L341) [[8]](diffhunk://#diff-eb01d79b279ebf659ed73216c0b3c490685221c9358e058ce55a1c8ab4e99c35L527-L532) [[9]](diffhunk://#diff-eb01d79b279ebf659ed73216c0b3c490685221c9358e058ce55a1c8ab4e99c35L2524-L2537) [[10]](diffhunk://#diff-6ed2a49bb4f08e3cbe0be799d582b4d314a15df6b10b9b8836271056402f7851L175-L176) [[11]](diffhunk://#diff-10c39dd978ada90e0d090a045c4ae5f51dad010f3b754679e15894c9b93d254bL37-R37)

### Lua Ping/Pong System Implementation

* Added new Lua scripts to manage ping/pong events, including periodic checks, sending/receiving ping and pong packets, and disconnecting players who do not respond in time. [[1]](diffhunk://#diff-428d60dd573060448ecc1b9e9930ea5bf4706f2c25e9482ac2233405a5532d45R1-R46) [[2]](diffhunk://#diff-3519ae820a0fdb6487fe5124232fa47bbb59784c399df5f7f15b19147eb2f776R1-R7) [[3]](diffhunk://#diff-8039e1aa0e24750d8cdaba1e4a8fa97a69a680e4ffb6398a8371a5c127467a55R1-R10)
* Registered the new `PingPong` event for players on login.

### Lua API Extensions

* Introduced new Lua methods for `Player` to get/set last ping/pong times and to kick players, and for `Vocation` to get the allowed no-pong kick time. [[1]](diffhunk://#diff-bf021c17080d126ac8f3a72354f763b820e5def59a3c39dd331ea5a1282200e1R1-R18) [[2]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2682) [[3]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2990) [[4]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR8894-R8908) [[5]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR12244-R12255) [[6]](diffhunk://#diff-598839b71fc10f5de97308acde2eb45c1f014514679c625191046eb611288538R614) [[7]](diffhunk://#diff-598839b71fc10f5de97308acde2eb45c1f014514679c625191046eb611288538R913)

### Network Protocol Handling in Lua

* Implemented Lua packet handlers for ping (0x1D) and pong (0x1E) messages, ensuring correct communication between client and server using the new system. [[1]](diffhunk://#diff-8039e1aa0e24750d8cdaba1e4a8fa97a69a680e4ffb6398a8371a5c127467a55R1-R10) [[2]](diffhunk://#diff-3519ae820a0fdb6487fe5124232fa47bbb59784c399df5f7f15b19147eb2f776R1-R7)

### Minor Improvements

* Allowed `getCreature` to return `nullptr` for `nil` arguments in Lua, improving script robustness.

These changes modernize and modularize the player connectivity check system, making it easier to configure and maintain.