### PR TITLE
fix(monster): monster follows master even when not attacking another creature

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -740,7 +740,7 @@ void Monster::onThink(uint32_t interval)
 					if (master->getAttackedCreature()) {
 						// This happens if the monster is summoned during combat
 						selectTarget(master->getAttackedCreature());
-					} else if (tfs::owner_equal(master, getFollowCreature())) {
+					} else if (!tfs::owner_equal(master, getFollowCreature())) {
 						// Our master has not ordered us to attack anything, lets follow him around instead.
 						setFollowCreature(master);
 					}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
 Fixed an issue where the monster continued to follow its master even when it was not actively attacking another creature.

#1

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
