### PR TITLE
fix(creature): update followers paths and remove invalid followers during path update

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -784,13 +784,12 @@ void Creature::updateFollowersPaths()
 	}
 
 	followers = followers | tfs::views::lock_weak_ptrs | std::views::filter([this](const auto& creature) {
-		            const auto& followerPosition = creature->getPosition();
-		            if (position.z != followerPosition.z) {
+		            if (position.z != creature->position.z) {
 			            return false;
 		            }
 
-		            return position.getDistanceX(followerPosition) < Map::maxViewportX &&
-		                   position.getDistanceY(followerPosition) < Map::maxViewportY;
+		            return position.getDistanceX(creature->position) < Map::maxViewportX &&
+		                   position.getDistanceY(creature->position) < Map::maxViewportY;
 	            }) |
 	            std::ranges::to<decltype(followers)>();
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -169,7 +169,6 @@ void Creature::onWalk()
 		}
 	}
 
-	removeFollowers();
 	updateFollowersPaths();
 
 	if (cancelNextWalk) {
@@ -778,35 +777,25 @@ void Creature::onFollowCreature(const std::shared_ptr<const Creature>&)
 void Creature::onUnfollowCreature() { hasFollowPath = false; }
 
 // Pathfinding Events
-void Creature::removeFollowers()
-{
-	const Position& position = getPosition();
-
-	followers = followers | tfs::views::lock_weak_ptrs | std::views::filter([&position](const auto& creature) {
-		            const Position& followerPosition = creature->getPosition();
-		            uint16_t distance =
-		                position.getDistanceX(followerPosition) + position.getDistanceY(followerPosition);
-		            return distance >= Map::maxViewportX + Map::maxViewportY || position.z != followerPosition.z;
-	            }) |
-	            std::ranges::to<decltype(followers)>();
-}
-
 void Creature::updateFollowersPaths()
 {
 	if (followers.empty()) {
 		return;
 	}
 
-	const Position& thisPosition = getPosition();
+	followers = followers | tfs::views::lock_weak_ptrs | std::views::filter([=](const auto& creature) {
+		            const auto& followerPosition = creature->getPosition();
+		            if (position.z != followerPosition.z) {
+			            return false;
+		            }
+
+		            return position.getDistanceX(followerPosition) < Map::maxViewportX &&
+		                   position.getDistanceY(followerPosition) < Map::maxViewportY;
+	            }) |
+	            std::ranges::to<decltype(followers)>();
+
 	for (const auto& follower : followers | tfs::views::lock_weak_ptrs) {
-		const Position& followerPosition = follower->getPosition();
-
 		if (follower->lastPathUpdate < OTSYS_TIME()) {
-			continue;
-		}
-
-		if (thisPosition.getDistanceX(followerPosition) >= Map::maxViewportX ||
-		    thisPosition.getDistanceY(followerPosition) >= Map::maxViewportY) {
 			continue;
 		}
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -783,7 +783,7 @@ void Creature::updateFollowersPaths()
 		return;
 	}
 
-	followers = followers | tfs::views::lock_weak_ptrs | std::views::filter([=](const auto& creature) {
+	followers = followers | tfs::views::lock_weak_ptrs | std::views::filter([this](const auto& creature) {
 		            const auto& followerPosition = creature->getPosition();
 		            if (position.z != followerPosition.z) {
 			            return false;

--- a/src/creature.h
+++ b/src/creature.h
@@ -223,7 +223,6 @@ public:
 	// Pathfinding functions
 	void addFollower(const std::shared_ptr<Creature>& creature) { followers.insert(creature); }
 	void removeFollower(const std::shared_ptr<Creature>& creature) { followers.erase(creature); }
-	void removeFollowers();
 
 	// Pathfinding events
 	void updateFollowersPaths();


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Removed the separate removeFollowers logic and merged follower validation into updateFollowersPaths. Only valid followers have their path updated, reducing duplicated checks and keeping follower state consistent during pathfinding updates.

Followers are now filtered by: Same floor (z level) and Viewport distance limits (X and Y). 

#1

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
