### PR TITLE
refactor(player): remove unused isConnecting var

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -1373,7 +1373,6 @@ private:
 	bool wasMounted_ = false;
 	bool ghostMode = false;
 	bool pzLocked = false;
-	bool isConnecting = false;
 	bool addAttackSkillPoint = false;
 	bool inventoryAbilities[CONST_SLOT_LAST + 1] = {};
 	bool randomizeMount = false;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -239,7 +239,6 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 
 		if (foundPlayer->client) {
 			foundPlayer->disconnect();
-			foundPlayer->isConnecting = true;
 
 			eventConnect = g_scheduler.addEvent(
 			    createSchedulerTask(1000, [=, thisPtr = getThis(), playerID = foundPlayer->getID()]() {
@@ -275,7 +274,6 @@ void ProtocolGame::connect(uint32_t playerId, OperatingSystem_t operatingSystem)
 	g_chat->removeUserFromAllChannels(player);
 	player->clearModalWindows();
 	player->setOperatingSystem(operatingSystem);
-	player->isConnecting = false;
 
 	player->client = getThis();
 	player->onCreatureAppear(player, false, CONST_ME_NONE);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Remove unused player isConnecting variable (removed by https://github.com/atlas-kit/atlas/pull/70)

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
