### PR TITLE
fix(player): store ping-pong time in seconds

### DIFF
--- a/data/creaturescripts/scripts/login.lua
+++ b/data/creaturescripts/scripts/login.lua
@@ -35,7 +35,7 @@ function onLogin(player)
 	end
 
 	-- initialize ping-pong timestamps
-	local timeNow = os.mtime()
+	local timeNow = os.time()
 	player:setLastPing(timeNow)
 	player:setLastPong(timeNow)
 

--- a/data/scripts/creaturescripts/player/ping_pong.lua
+++ b/data/scripts/creaturescripts/player/ping_pong.lua
@@ -1,14 +1,14 @@
 local event = CreatureEvent("PingPong")
 
-local LOST_CONNECTION_MILLIS = 5000
-local REMOVE_TARGET_PLAYER_MILLIS = 7000
-local PZ_LOCKED_NO_PONG_KICK_MILLIS = 60000
+local LOST_CONNECTION_SECS = 5
+local REMOVE_TARGET_PLAYER_SECS = 7
+local PZ_LOCKED_NO_PONG_KICK_SECS = 60
 
 function event.onThink(player, interval)
-    local timeNow = os.mtime()
+    local timeNow = os.time()
 
     local hasLostConnection = false
-    if timeNow - player:getLastPing() >= LOST_CONNECTION_MILLIS then
+    if timeNow - player:getLastPing() >= LOST_CONNECTION_SECS then
         player:setLastPing(timeNow)
         if player:getClient() then
             local msg = NetworkMessage()
@@ -21,16 +21,16 @@ function event.onThink(player, interval)
     end
 
     local noPongTime = timeNow - player:getLastPong()
-    if hasLostConnection or noPongTime >= REMOVE_TARGET_PLAYER_MILLIS then
+    if hasLostConnection or noPongTime >= REMOVE_TARGET_PLAYER_SECS then
         local target = player:getTarget()
         if target and target:isPlayer() then
             player:setTarget(nil)
         end
     end
 
-    local noPongKickTime = player:getVocation():getNoPongKickTime()
-    if player:isPzLocked() and noPongKickTime < PZ_LOCKED_NO_PONG_KICK_MILLIS then
-        noPongKickTime = PZ_LOCKED_NO_PONG_KICK_MILLIS
+    local noPongKickTime = player:getVocation():getNoPongKickTime() / 1000
+    if player:isPzLocked() and noPongKickTime < PZ_LOCKED_NO_PONG_KICK_SECS then
+        noPongKickTime = PZ_LOCKED_NO_PONG_KICK_SECS
     end
 
     if noPongTime >= noPongKickTime then

--- a/data/scripts/network/receive_ping.lua
+++ b/data/scripts/network/receive_ping.lua
@@ -1,7 +1,7 @@
 local handler = PacketHandler(0x1E)
 
 function handler.onReceive(player)
-    player:setLastPong(os.mtime())
+    player:setLastPong(os.time())
 end
 
 handler:register()


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes the ping-pong time storage to consistently use seconds instead of mixed or incorrect time units.

Alternative to #76

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
