### PR TITLE
refactor(luascript): remove built-in bit and table functions

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -7,14 +7,6 @@
 ---@field __index fun(self: table, key: any): any
 rawgetmetatable = {}
 
----@class bit
----@field band fun(a: number, b: number): number
----@field bor fun(a: number, b: number): number
----@field bxor fun(a: number, b: number): number
----@field lshift fun(a: number, b: number): number
----@field rshift fun(a: number, b: number): number
-bit = {}
-
 ---@alias Outfit_t table<string, integer>
 ---@alias MagicEffect_t table<string, integer>
 

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -624,7 +624,7 @@ function getPlayersByIPAddress(ip, mask)
 	local players = {}
 	for _, player in ipairs(Game.getPlayers()) do
 		local a, b, c, d = player:getIp():match("(%d*)%.(%d*)%.(%d*)%.(%d*)")
-		if a and b and c and d and ((a << 24) + (b << 16) + (c << 8) + d) & mask == masked then
+		if a and b and c and d and (((a << 24) + (b << 16) + (c << 8) + d) & mask) == masked then
 			players[#players + 1] = player:getId()
 		end
 	end

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -620,12 +620,11 @@ function getPlayersByIPAddress(ip, mask)
 	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking getPlayersByIPAddress with a numeric IP is deprecated and will be removed in the future. Please use the string representation of the IP.")
 
 	if not mask then mask = 0xFFFFFFFF end
-	local masked = bit.band(ip, mask)
-	local lshift = bit.lshift
+	local masked = ip & mask
 	local players = {}
 	for _, player in ipairs(Game.getPlayers()) do
 		local a, b, c, d = player:getIp():match("(%d*)%.(%d*)%.(%d*)%.(%d*)")
-		if a and b and c and d and bit.band(lshift(a, 24) + lshift(b, 16) + lshift(c, 8) + d, mask) == masked then
+		if a and b and c and d and ((a << 24) + (b << 16) + (c << 8) + d) & mask == masked then
 			players[#players + 1] = player:getId()
 		end
 	end
@@ -1027,11 +1026,11 @@ function getItemRWInfo(uid)
 	local rwFlags = 0
 	local itemType = ItemType(item:getId())
 	if itemType:isReadable() then
-		rwFlags = bit.bor(rwFlags, 1)
+		rwFlags = rwFlags | 1
 	end
 
 	if itemType:isWritable() then
-		rwFlags = bit.bor(rwFlags, 2)
+		rwFlags = rwFlags | 2
 	end
 	return rwFlags
 end
@@ -1353,13 +1352,11 @@ function Game.convertIpToString(ip)
 		return ip
 	end
 
-	local band = bit.band
-	local rshift = bit.rshift
 	return string.format("%d.%d.%d.%d",
-		band(ip, 0xFF),
-		band(rshift(ip, 8), 0xFF),
-		band(rshift(ip, 16), 0xFF),
-		rshift(ip, 24)
+		ip & 0xFF,
+		(ip >> 8) & 0xFF,
+		(ip >> 16) & 0xFF,
+		ip >> 24
 	)
 end
 
@@ -1608,7 +1605,7 @@ do
 end
 
 function indexToCombatType(idx)
-	return bit.lshift(1, idx)
+	return 1 << idx
 end
 
 function showpos(v)
@@ -1619,6 +1616,13 @@ end
 if not unpack then unpack = table.unpack end
 
 if not loadstring then loadstring = load end
+
+function bit.bnot(a) return ~a end
+function bit.band(a, b) return a & b end
+function bit.bor(a, b) return a | b end
+function bit.bxor(a, b) return a ~ b end
+function bit.lshift(a, b) return a << b end
+function bit.rshift(a, b) return a >> b end
 
 function table.maxn(t)
 	local max = 0

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -1617,6 +1617,7 @@ if not unpack then unpack = table.unpack end
 
 if not loadstring then loadstring = load end
 
+bit = bit or {}
 function bit.bnot(a) return ~a end
 function bit.band(a, b) return a & b end
 function bit.bor(a, b) return a | b end

--- a/data/lib/core/item.lua
+++ b/data/lib/core/item.lua
@@ -430,7 +430,7 @@ do
 		do
 			local suppressions = abilities.conditionSuppressions
 			for conditionId, conditionName in pairs(suppressedConditionNames) do
-				if bit.band(abilities.conditionSuppressions, conditionId) ~= 0 then
+				if (abilities.conditionSuppressions & conditionId) ~= 0 then
 					descriptions[#descriptions + 1] = conditionName
 				end
 			end
@@ -587,7 +587,7 @@ do
 		-- imbuements (to do)
 		-- \nImbuements: (Basic Strike 2:30h, Basic Void 2:30h, Empty Slot).
 
-		
+
 		-- item class (placeholder)
 		-- Classification: x.
 		-- Disabled until classification system is implemented.
@@ -659,7 +659,7 @@ do
 				local wieldInfo = itemType:getWieldInfo()
 				if wieldInfo ~= 0 then
 					local wieldAttrs = {}
-					if bit.band(wieldInfo, WIELDINFO_PREMIUM) ~= 0 then
+					if (wieldInfo & WIELDINFO_PREMIUM) ~= 0 then
 						wieldAttrs[#wieldAttrs + 1] = "premium"
 					end
 
@@ -671,11 +671,11 @@ do
 					end
 
 					local levelInfo = {}
-					if bit.band(wieldInfo, WIELDINFO_LEVEL) ~= 0 then
+					if (wieldInfo & WIELDINFO_LEVEL) ~= 0 then
 						levelInfo[#levelInfo + 1] = string.format("level %d", itemType:getMinReqLevel())
 					end
 
-					if bit.band(wieldInfo, WIELDINFO_MAGLV) ~= 0 then
+					if (wieldInfo & WIELDINFO_MAGLV) ~= 0 then
 						levelInfo[#levelInfo + 1] = string.format("magic level %d", itemType:getMinReqMagicLevel())
 					end
 

--- a/data/lib/core/itemtype.lua
+++ b/data/lib/core/itemtype.lua
@@ -17,7 +17,7 @@ do
 	}
 
 	function ItemType:usesSlot(slot)
-		return bit.band(self:getSlotPosition(), slotBits[slot] or 0) ~= 0
+		return (self:getSlotPosition() & (slotBits[slot] or 0)) ~= 0
 	end
 end
 
@@ -43,7 +43,7 @@ function ItemType:isWeapon()
 end
 
 function ItemType:isTwoHanded()
-	return bit.band(self:getSlotPosition(), SLOTP_TWO_HAND) ~= 0
+	return (self:getSlotPosition() & SLOTP_TWO_HAND) ~= 0
 end
 
 function ItemType:isBow()

--- a/data/migrations/35.lua
+++ b/data/migrations/35.lua
@@ -27,8 +27,8 @@ function onUpdateDatabase()
 	if resultId then
 		repeat
 			local playerId = result.getNumber(resultId, "player_id")
-			local outfitId = bit.rshift(result.getNumber(resultId, "value"), 16)
-			local addons = bit.band(result.getNumber(resultId, "value"), 0xFF)
+			local outfitId = result.getNumber(resultId, "value") >> 16
+			local addons = result.getNumber(resultId, "value") & 0xFF
 
 			db.query(string.format("INSERT INTO `player_outfits` (`player_id`, `outfit_id`, `addons`) VALUES (%d, %d, %d)", playerId, outfitId, addons))
 		until not result.next(resultId)
@@ -42,8 +42,7 @@ function onUpdateDatabase()
 				local key = mountRange + ((i-1) / 31)
 				if key == result.getNumber(resultId, "key") then
 					local playerId = result.getNumber(resultId, "player_id")
-					local lshift = bit.lshift(1, ((i-1) % 31))
-					local mount = bit.band(lshift, result.getNumber(resultId, "value"))
+					local mount = (1 << ((i-1) % 31)) & result.getNumber(resultId, "value")
 
 					if mount ~= 0 then
 						db.query(string.format("INSERT INTO `player_mounts` (`player_id`, `mount_id`) VALUES (%d, %d)", playerId, i))

--- a/data/scripts/events/player/default_onMoveItem.lua
+++ b/data/scripts/events/player/default_onMoveItem.lua
@@ -14,16 +14,16 @@ event.onMoveItem = function(self, item, count, fromPosition, toPosition, fromThi
 		return RETURNVALUE_NOERROR
 	end
 
-	if bit.band(toPosition.y, 0x40) == 0 then
+	if (toPosition.y & 0x40) == 0 then
 		local itemType, moveItem = ItemType(item:getId())
-		if bit.band(itemType:getSlotPosition(), SLOTP_TWO_HAND) ~= 0 and toPosition.y == CONST_SLOT_LEFT then
+		if (itemType:getSlotPosition() & SLOTP_TWO_HAND) ~= 0 and toPosition.y == CONST_SLOT_LEFT then
 			local rightItem = self:getSlotItem(CONST_SLOT_RIGHT)
 			if rightItem and not(itemType:isBow() and rightItem:getType():getWeaponType() == WEAPON_QUIVER) then
 				moveItem = self:getSlotItem(CONST_SLOT_RIGHT)
 			end
 		elseif itemType:getWeaponType() == WEAPON_SHIELD and toPosition.y == CONST_SLOT_RIGHT then
 			moveItem = self:getSlotItem(CONST_SLOT_LEFT)
-			if moveItem and bit.band(ItemType(moveItem:getId()):getSlotPosition(), SLOTP_TWO_HAND) == 0 then
+			if moveItem and (ItemType(moveItem:getId()):getSlotPosition() & SLOTP_TWO_HAND) == 0 then
 				return RETURNVALUE_NOERROR
 			end
 		end

--- a/data/scripts/spells/support/levitate.lua
+++ b/data/scripts/spells/support/levitate.lua
@@ -12,7 +12,7 @@ local function levitate(creature, parameter)
 
 			if tile and tile:getGround() and not tile:hasFlag(TILESTATE_IMMOVABLEBLOCKSOLID) then
 				local fromPos = creature:getPosition()
-				local moved = creature:move(tile, bit.bor(FLAG_IGNOREBLOCKITEM, FLAG_IGNOREBLOCKCREATURE))
+				local moved = creature:move(tile, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREBLOCKCREATURE)
 
 				if moved == RETURNVALUE_NOERROR then
 					fromPos:sendMagicEffect(CONST_ME_TELEPORT)

--- a/src/databasemanager.cpp
+++ b/src/databasemanager.cpp
@@ -78,10 +78,6 @@ void DatabaseManager::updateDatabase()
 
 	luaL_openlibs(L);
 
-	// bit operations for Lua, based on bitlib project release 24
-	// bit.bnot, bit.band, bit.bor, bit.bxor, bit.lshift, bit.rshift
-	luaL_register(L, "bit", LuaScriptInterface::luaBitReg);
-
 	// db table
 	luaL_register(L, "db", LuaScriptInterface::luaDatabaseTable);
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1189,11 +1189,6 @@ void LuaScriptInterface::registerFunctions()
 	// isScriptsInterface()
 	lua_register(L, "isScriptsInterface", LuaScriptInterface::luaIsScriptsInterface);
 
-	// bit operations for Lua, based on bitlib project release 24
-	// bit.bnot, bit.band, bit.bor, bit.bxor, bit.lshift, bit.rshift
-	luaL_register(L, "bit", LuaScriptInterface::luaBitReg);
-	lua_pop(L, 1);
-
 	// configManager table
 	luaL_register(L, "configManager", LuaScriptInterface::luaConfigManagerTable);
 	lua_pop(L, 1);
@@ -2289,10 +2284,6 @@ void LuaScriptInterface::registerFunctions()
 
 	// os
 	registerMethod(L, "os", "mtime", LuaScriptInterface::luaSystemTime);
-
-	// table
-	registerMethod(L, "table", "create", LuaScriptInterface::luaTableCreate);
-	registerMethod(L, "table", "pack", LuaScriptInterface::luaTablePack);
 
 	// DB Insert
 	registerClass(L, "DBInsert", "", LuaScriptInterface::luaDBInsertCreate);
@@ -4064,52 +4055,6 @@ int LuaScriptInterface::luaIsScriptsInterface(lua_State* L)
 	return 1;
 }
 
-const luaL_Reg LuaScriptInterface::luaBitReg[] = {
-    //{"tobit", LuaScriptInterface::luaBitToBit},
-    {"bnot", LuaScriptInterface::luaBitNot},
-    {"band", LuaScriptInterface::luaBitAnd},
-    {"bor", LuaScriptInterface::luaBitOr},
-    {"bxor", LuaScriptInterface::luaBitXor},
-    {"lshift", LuaScriptInterface::luaBitLeftShift},
-    {"rshift", LuaScriptInterface::luaBitRightShift},
-    //{"arshift", LuaScriptInterface::luaBitArithmeticalRightShift},
-    //{"rol", LuaScriptInterface::luaBitRotateLeft},
-    //{"ror", LuaScriptInterface::luaBitRotateRight},
-    //{"bswap", LuaScriptInterface::luaBitSwapEndian},
-    //{"tohex", LuaScriptInterface::luaBitToHex},
-    {nullptr, nullptr}};
-
-int LuaScriptInterface::luaBitNot(lua_State* L)
-{
-	tfs::lua::pushNumber(L, ~tfs::lua::getNumber<uint32_t>(L, -1));
-	return 1;
-}
-
-#define MULTIOP(name, op) \
-	int LuaScriptInterface::luaBit##name(lua_State* L) \
-	{ \
-		int n = lua_gettop(L); \
-		uint32_t w = tfs::lua::getNumber<uint32_t>(L, -1); \
-		for (int i = 1; i < n; ++i) w op tfs::lua::getNumber<uint32_t>(L, i); \
-		tfs::lua::pushNumber(L, w); \
-		return 1; \
-	}
-
-MULTIOP(And, &=)
-MULTIOP(Or, |=)
-MULTIOP(Xor, ^=)
-
-#define SHIFTOP(name, op) \
-	int LuaScriptInterface::luaBit##name(lua_State* L) \
-	{ \
-		uint32_t n1 = tfs::lua::getNumber<uint32_t>(L, 1), n2 = tfs::lua::getNumber<uint32_t>(L, 2); \
-		tfs::lua::pushNumber(L, (n1 op n2)); \
-		return 1; \
-	}
-
-SHIFTOP(LeftShift, <<)
-SHIFTOP(RightShift, >>)
-
 const luaL_Reg LuaScriptInterface::luaConfigManagerTable[] = {
     {"getString", LuaScriptInterface::luaConfigManagerGetString},
     {"getNumber", LuaScriptInterface::luaConfigManagerGetNumber},
@@ -4369,31 +4314,6 @@ int LuaScriptInterface::luaSystemTime(lua_State* L)
 	// os.mtime()
 	tfs::lua::pushNumber(L, OTSYS_TIME());
 	return 1;
-}
-
-// table
-int LuaScriptInterface::luaTableCreate(lua_State* L)
-{
-	// table.create(arrayLength, keyLength)
-	lua_createtable(L, tfs::lua::getNumber<int32_t>(L, 1), tfs::lua::getNumber<int32_t>(L, 2));
-	return 1;
-}
-
-int LuaScriptInterface::luaTablePack(lua_State* L)
-{
-	// table.pack(...)
-	int n = lua_gettop(L);         /* number of elements to pack */
-	lua_createtable(L, n, 1);      /* create result table */
-	lua_insert(L, 1);              /* put it at index 1 */
-	for (int i = n; i >= 1; i--) { /* assign elements */
-		lua_rawseti(L, 1, i);
-	}
-	if (luaL_callmeta(L, -1, "__index") != 0) {
-		lua_replace(L, -2);
-	}
-	tfs::lua::pushNumber(L, n);
-	lua_setfield(L, 1, "n"); /* t.n = number of elements */
-	return 1;                /* return table */
 }
 
 // DB Insert

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -145,7 +145,6 @@ public:
 	bool callFunction(int params);
 	void callVoidFunction(int params);
 
-	static const luaL_Reg luaBitReg[7];
 	static const luaL_Reg luaConfigManagerTable[4];
 	static const luaL_Reg luaDatabaseTable[9];
 	static const luaL_Reg luaResultTable[6];
@@ -205,13 +204,6 @@ private:
 
 	static int luaIsScriptsInterface(lua_State* L);
 
-	static int luaBitNot(lua_State* L);
-	static int luaBitAnd(lua_State* L);
-	static int luaBitOr(lua_State* L);
-	static int luaBitXor(lua_State* L);
-	static int luaBitLeftShift(lua_State* L);
-	static int luaBitRightShift(lua_State* L);
-
 	static int luaConfigManagerGetString(lua_State* L);
 	static int luaConfigManagerGetNumber(lua_State* L);
 	static int luaConfigManagerGetBoolean(lua_State* L);
@@ -240,10 +232,6 @@ private:
 
 	// os
 	static int luaSystemTime(lua_State* L);
-
-	// table
-	static int luaTableCreate(lua_State* L);
-	static int luaTablePack(lua_State* L);
 
 	// DB Insert
 	static int luaDBInsertCreate(lua_State* L);


### PR DESCRIPTION
This pull request removes Lua bitwise and table utility functions from the `LuaScriptInterface`, in favor of using standard Lua libraries.