### PR TITLE
fix(lua): implement shared pointer deletion for Lua objects

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -348,6 +348,10 @@ setCombatCallback = Combat.setCallback
 setCombatFormula = Combat.setFormula
 setCombatParam = Combat.setParameter
 
+Combat.delete = function(...)
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.delete is deprecated and will be removed in the future")
+end
+
 Combat.setCondition = function(...)
 	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
 	Combat.addCondition(...)

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -116,6 +116,14 @@ T* getUserdata(lua_State* L, int32_t arg)
 
 // SharedPtr helpers
 template <class T>
+int luaSharedPtrDelete(lua_State* L)
+{
+	auto& ptr = tfs::lua::getSharedPtr<T>(L, 1);
+	std::destroy_at(std::addressof(ptr));
+	return 0;
+}
+
+template <class T>
 std::shared_ptr<T>& getSharedPtr(lua_State* L, int32_t arg)
 {
 	return *static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -124,7 +124,7 @@ std::shared_ptr<T>& getSharedPtr(lua_State* L, int32_t arg)
 template <class T>
 int luaSharedPtrDelete(lua_State* L)
 {
-	auto& ptr = tfs::lua::getSharedPtr<T>(L, 1);
+	auto& ptr = getSharedPtr<T>(L, 1);
 	std::destroy_at(std::addressof(ptr));
 	return 0;
 }

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -116,17 +116,17 @@ T* getUserdata(lua_State* L, int32_t arg)
 
 // SharedPtr helpers
 template <class T>
+std::shared_ptr<T>& getSharedPtr(lua_State* L, int32_t arg)
+{
+	return *static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));
+}
+
+template <class T>
 int luaSharedPtrDelete(lua_State* L)
 {
 	auto& ptr = tfs::lua::getSharedPtr<T>(L, 1);
 	std::destroy_at(std::addressof(ptr));
 	return 0;
-}
-
-template <class T>
-std::shared_ptr<T>& getSharedPtr(lua_State* L, int32_t arg)
-{
-	return *static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));
 }
 
 template <class T>

--- a/src/lua/modules/combat.cpp
+++ b/src/lua/modules/combat.cpp
@@ -25,15 +25,6 @@ int luaCombatCreate(lua_State* L)
 	return 1;
 }
 
-int luaCombatDelete(lua_State* L)
-{
-	Combat_ptr& combat = tfs::lua::getSharedPtr<Combat>(L, 1);
-	if (combat) {
-		combat.reset();
-	}
-	return 0;
-}
-
 int luaCombatSetParameter(lua_State* L)
 {
 	// combat:setParameter(key, value)
@@ -619,8 +610,7 @@ void tfs::lua::registerCombat(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Combat", "", luaCombatCreate);
 	lsi.registerMetaMethod("Combat", "__eq", tfs::lua::luaUserdataCompare);
-	lsi.registerMetaMethod("Combat", "__gc", luaCombatDelete);
-	lsi.registerMethod("Combat", "delete", luaCombatDelete);
+	lsi.registerMetaMethod("Combat", "__gc", tfs::lua::luaSharedPtrDelete<Combat>);
 
 	lsi.registerMethod("Combat", "setParameter", luaCombatSetParameter);
 	lsi.registerMethod("Combat", "getParameter", luaCombatGetParameter);

--- a/src/lua/modules/container.cpp
+++ b/src/lua/modules/container.cpp
@@ -334,6 +334,7 @@ void tfs::lua::registerContainer(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Container", "Item", luaContainerCreate);
 	lsi.registerMetaMethod("Container", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Container", "__gc", tfs::lua::luaSharedPtrDelete<Container>);
 
 	lsi.registerMethod("Container", "getSize", luaContainerGetSize);
 	lsi.registerMethod("Container", "getCapacity", luaContainerGetCapacity);

--- a/src/lua/modules/creature.cpp
+++ b/src/lua/modules/creature.cpp
@@ -1175,6 +1175,7 @@ void tfs::lua::registerCreature(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Creature", "", luaCreatureCreate);
 	lsi.registerMetaMethod("Creature", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Creature", "__gc", tfs::lua::luaSharedPtrDelete<Creature>);
 
 	lsi.registerMethod("Creature", "getEvents", luaCreatureGetEvents);
 	lsi.registerMethod("Creature", "registerEvent", luaCreatureRegisterEvent);

--- a/src/lua/modules/guild.cpp
+++ b/src/lua/modules/guild.cpp
@@ -156,6 +156,7 @@ void tfs::lua::registerGuild(LuaScriptInterface& lsi)
 {
 	lsi.registerClass("Guild", "", luaGuildCreate);
 	lsi.registerMetaMethod("Guild", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Guild", "__gc", tfs::lua::luaSharedPtrDelete<Guild>);
 
 	lsi.registerMethod("Guild", "getId", luaGuildGetId);
 	lsi.registerMethod("Guild", "getName", luaGuildGetName);

--- a/src/lua/modules/house.cpp
+++ b/src/lua/modules/house.cpp
@@ -476,6 +476,7 @@ void tfs::lua::registerHouse(LuaScriptInterface& lsi)
 
 	lsi.registerClass("House", "", luaHouseCreate);
 	lsi.registerMetaMethod("House", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("House", "__gc", tfs::lua::luaSharedPtrDelete<House>);
 
 	lsi.registerMethod("House", "getId", luaHouseGetId);
 	lsi.registerMethod("House", "getName", luaHouseGetName);

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -817,7 +817,7 @@ void tfs::lua::registerItem(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Item", "", luaItemCreate);
 	lsi.registerMetaMethod("Item", "__eq", tfs::lua::luaUserdataCompare);
-	lsi.registerMetaMethod("Tile", "__gc", tfs::lua::luaSharedPtrDelete<Item>);
+	lsi.registerMetaMethod("Item", "__gc", tfs::lua::luaSharedPtrDelete<Item>);
 
 	lsi.registerMethod("Item", "isItem", luaItemIsItem);
 

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -817,6 +817,7 @@ void tfs::lua::registerItem(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Item", "", luaItemCreate);
 	lsi.registerMetaMethod("Item", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Tile", "__gc", tfs::lua::luaSharedPtrDelete<Item>);
 
 	lsi.registerMethod("Item", "isItem", luaItemIsItem);
 

--- a/src/lua/modules/monster.cpp
+++ b/src/lua/modules/monster.cpp
@@ -482,6 +482,7 @@ void tfs::lua::registerMonster(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Monster", "Creature", luaMonsterCreate);
 	lsi.registerMetaMethod("Monster", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Monster", "__gc", tfs::lua::luaSharedPtrDelete<Monster>);
 
 	lsi.registerMethod("Monster", "isMonster", luaMonsterIsMonster);
 

--- a/src/lua/modules/npc.cpp
+++ b/src/lua/modules/npc.cpp
@@ -143,6 +143,7 @@ void tfs::lua::registerNpc(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Npc", "Creature", luaNpcCreate);
 	lsi.registerMetaMethod("Npc", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Npc", "__gc", tfs::lua::luaSharedPtrDelete<Npc>);
 
 	lsi.registerMethod("Npc", "isNpc", luaNpcIsNpc);
 

--- a/src/lua/modules/party.cpp
+++ b/src/lua/modules/party.cpp
@@ -264,6 +264,7 @@ void tfs::lua::registerParty(LuaScriptInterface& lsi)
 {
 	lsi.registerClass("Party", "", luaPartyCreate);
 	lsi.registerMetaMethod("Party", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Party", "__gc", tfs::lua::luaSharedPtrDelete<Party>);
 
 	lsi.registerMethod("Party", "disband", luaPartyDisband);
 

--- a/src/lua/modules/player.cpp
+++ b/src/lua/modules/player.cpp
@@ -2479,6 +2479,7 @@ void tfs::lua::registerPlayer(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Player", "Creature", luaPlayerCreate);
 	lsi.registerMetaMethod("Player", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Player", "__gc", tfs::lua::luaSharedPtrDelete<Player>);
 
 	lsi.registerMethod("Player", "isPlayer", luaPlayerIsPlayer);
 

--- a/src/lua/modules/podium.cpp
+++ b/src/lua/modules/podium.cpp
@@ -111,6 +111,7 @@ void tfs::lua::registerPodium(LuaScriptInterface& lsi)
 {
 	lsi.registerClass("Podium", "Item", luaPodiumCreate);
 	lsi.registerMetaMethod("Podium", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Podium", "__gc", tfs::lua::luaSharedPtrDelete<Podium>);
 
 	lsi.registerMethod("Podium", "getOutfit", luaPodiumGetOutfit);
 	lsi.registerMethod("Podium", "setOutfit", luaPodiumSetOutfit);

--- a/src/lua/modules/teleport.cpp
+++ b/src/lua/modules/teleport.cpp
@@ -54,6 +54,7 @@ void tfs::lua::registerTeleport(LuaScriptInterface& lsi)
 {
 	lsi.registerClass("Teleport", "Item", luaTeleportCreate);
 	lsi.registerMetaMethod("Teleport", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Teleport", "__gc", tfs::lua::luaSharedPtrDelete<Teleport>);
 
 	lsi.registerMethod("Teleport", "getDestination", luaTeleportGetDestination);
 	lsi.registerMethod("Teleport", "setDestination", luaTeleportSetDestination);

--- a/src/lua/modules/tile.cpp
+++ b/src/lua/modules/tile.cpp
@@ -769,6 +769,7 @@ void tfs::lua::registerTile(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Tile", "", luaTileCreate);
 	lsi.registerMetaMethod("Tile", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Tile", "__gc", tfs::lua::luaSharedPtrDelete<Tile>);
 
 	lsi.registerMethod("Tile", "remove", luaTileRemove);
 


### PR DESCRIPTION
Introduced a generic `luaSharedPtrDelete` template function to handle the `__gc` metamethod for all shared pointer-backed Lua objects, ensuring proper destruction and reducing code duplication. (`src/luascript.cpp` [src/luascript.cppR251-R258](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR251-R258))
* Registered the new `__gc` metamethod for classes such as `Tile`, `Item`, `Container`, `Teleport`, `Podium`, `Creature`, `Player`, `Monster`, `Npc`, `House`, and `Combat`, replacing or adding proper cleanup logic for each. (`src/luascript.cpp` [[1]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2389) [[2]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2495) [[3]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2557) [[4]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2575-R2583) [[5]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2595) [[6]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2688) [[7]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2893) [[8]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR2936) [[9]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaR3011) [[10]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL3117-R3136)

**API consistency and cleanup:**

* Standardized the use of `getSharedPtr` instead of `getRawSharedPtr` in various Lua API functions for `Item` and `Creature` manipulation, simplifying pointer access and mutation. (`src/luascript.cpp` [[1]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL6610-R6628) [[2]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL6640-R6657) [[3]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL7031-R7043) [[4]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL7083-R7089) [[5]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL7093-R7099) [[6]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL7139-R7139) [[7]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL8439-R8439) [[8]](diffhunk://#diff-62aa9c61dc49a0decc4065f0bf8a8038a56aea325a2c496a048e7657abd03ccaL8457-R8451)
* Removed the now-unnecessary `getRawSharedPtr` template function from the codebase. (`src/luascript.h` [src/luascript.hL1455-L1459](diffhunk://#diff-598839b71fc10f5de97308acde2eb45c1f014514679c625191046eb611288538L1455-L1459))