### PR TITLE
fix(luascript): validate thing before checking moveable

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3765,7 +3765,8 @@ int LuaScriptInterface::luaDoChallengeCreature(lua_State* L)
 int LuaScriptInterface::luaIsValidUID(lua_State* L)
 {
 	// isValidUID(uid)
-	tfs::lua::pushBoolean(L, tfs::lua::getScriptEnv()->getThingByUID(tfs::lua::getNumber<uint32_t>(L, -1)) != nullptr);
+	const auto& thing = tfs::lua::getScriptEnv()->getThingByUID(tfs::lua::getNumber<uint32_t>(L, -1));
+	tfs::lua::pushBoolean(L, thing != nullptr);
 	return 1;
 }
 
@@ -3782,6 +3783,12 @@ int LuaScriptInterface::luaIsMoveable(lua_State* L)
 	// isMoveable(uid)
 	// isMovable(uid)
 	const auto& thing = tfs::lua::getScriptEnv()->getThingByUID(tfs::lua::getNumber<uint32_t>(L, -1));
+	if (!thing) {
+		reportErrorFunc(L, tfs::lua::getErrorDesc(LUA_ERROR_THING_NOT_FOUND));
+		tfs::lua::pushBoolean(L, false);
+		return 1;
+	}
+
 	if (const auto& item = thing->asItem()) {
 		tfs::lua::pushBoolean(L, item->isPushable());
 	} else if (const auto& creature = thing->asCreature()) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes the interface to properly handle invalid UIDs. Previously, functions like luaIsMoveable and luaIsValidUID could access null pointers if a non-existent UID was provided, which could lead to crashes or undefined behavior. luaIsMoveable checks if the thing exists before performing any operations. If the UID is invalid, it reports an error and safely returns false. luaIsValidUID was also simplified for clarity by caching the retrieved object.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
