### PR TITLE
chore(luascript): remove lua version checks for 5.4

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -9,11 +9,6 @@
 #include "game.h"
 #include "pugicast.h"
 
-#if LUA_VERSION_NUM >= 502
-#undef lua_strlen
-#define lua_strlen lua_rawlen
-#endif
-
 extern Game g_game;
 
 namespace {
@@ -55,7 +50,7 @@ std::string getGlobalString(lua_State* L, const char* identifier, const char* de
 		return defaultValue;
 	}
 
-	size_t len = lua_strlen(L, -1);
+	size_t len = lua_rawlen(L, -1);
 	std::string ret(lua_tostring(L, -1), len);
 	lua_pop(L, 1);
 	return ret;
@@ -83,7 +78,7 @@ bool getGlobalBoolean(lua_State* L, const char* identifier, const bool defaultVa
 			return defaultValue;
 		}
 
-		size_t len = lua_strlen(L, -1);
+		size_t len = lua_rawlen(L, -1);
 		std::string ret(lua_tostring(L, -1), len);
 		lua_pop(L, 1);
 		return booleanString(ret);

--- a/src/databasemanager.cpp
+++ b/src/databasemanager.cpp
@@ -79,10 +79,14 @@ void DatabaseManager::updateDatabase()
 	luaL_openlibs(L);
 
 	// db table
-	luaL_register(L, "db", LuaScriptInterface::luaDatabaseTable);
+	luaL_newlib(L, LuaScriptInterface::luaDatabaseTable);
+	lua_pushvalue(L, -1);
+	lua_setglobal(L, "db");
 
 	// result table
-	luaL_register(L, "result", LuaScriptInterface::luaResultTable);
+	luaL_newlib(L, LuaScriptInterface::luaResultTable);
+	lua_pushvalue(L, -1);
+	lua_setglobal(L, "result");
 
 	int32_t version = getDatabaseVersion();
 	do {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1193,15 +1193,21 @@ void LuaScriptInterface::registerFunctions()
 	lua_register(L, "isScriptsInterface", LuaScriptInterface::luaIsScriptsInterface);
 
 	// configManager table
-	luaL_register(L, "configManager", LuaScriptInterface::luaConfigManagerTable);
+	luaL_newlib(L, LuaScriptInterface::luaConfigManagerTable);
+	lua_pushvalue(L, -1);
+	lua_setglobal(L, "configManager");
 	lua_pop(L, 1);
 
 	// db table
-	luaL_register(L, "db", LuaScriptInterface::luaDatabaseTable);
+	luaL_newlib(L, LuaScriptInterface::luaDatabaseTable);
+	lua_pushvalue(L, -1);
+	lua_setglobal(L, "db");
 	lua_pop(L, 1);
 
 	// result table
-	luaL_register(L, "result", LuaScriptInterface::luaResultTable);
+	luaL_newlib(L, LuaScriptInterface::luaResultTable);
+	lua_pushvalue(L, -1);
+	lua_setglobal(L, "result");
 	lua_pop(L, 1);
 
 	/* New functions */

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -8,7 +8,7 @@
 #include "position.h"
 
 #define luaL_register(L, libname, l) (luaL_newlib(L, l), lua_pushvalue(L, -1), lua_setglobal(L, libname))
-#define lua_equal(L, i1, i2) lua_compare(L, (i1), (i2), LUA_OPEQ)
+
 class AreaCombat;
 class Combat;
 class Container;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -7,16 +7,8 @@
 #include "enums.h"
 #include "position.h"
 
-#if LUA_VERSION_NUM >= 502
-#ifndef LUA_COMPAT_ALL
-#ifndef LUA_COMPAT_MODULE
 #define luaL_register(L, libname, l) (luaL_newlib(L, l), lua_pushvalue(L, -1), lua_setglobal(L, libname))
-#endif
-#undef lua_equal
 #define lua_equal(L, i1, i2) lua_compare(L, (i1), (i2), LUA_OPEQ)
-#endif
-#endif
-
 class AreaCombat;
 class Combat;
 class Container;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -7,8 +7,6 @@
 #include "enums.h"
 #include "position.h"
 
-#define luaL_register(L, libname, l) (luaL_newlib(L, l), lua_pushvalue(L, -1), lua_setglobal(L, libname))
-
 class AreaCombat;
 class Combat;
 class Container;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Simplifies the Lua scripting interface by removing version-specific macros and checks that were only needed for older Lua
versions. Since the project now targets Lua 5.4 exclusively, the code keeps only the relevant macros and removes all conditional compilation related to older versions.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
