### PR TITLE
refactor(house): expose houses as values view and simplify iteration

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -495,7 +495,7 @@ public:
 	std::shared_ptr<House> addHouse(uint32_t id);
 	std::shared_ptr<House> getHouseById(uint32_t id);
 	std::shared_ptr<House> getHouseByPlayerId(uint32_t playerId);
-	const auto& getHouses() const { return houses; }
+	auto getHouses() const { return houses | std::views::values; }
 	void payHouses(RentPeriod_t rentPeriod) const;
 
 private:

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -150,7 +150,7 @@ bool IOMapSerialize::saveHouseItems()
 	DBInsert stmt("INSERT INTO `tile_store` (`house_id`, `data`) VALUES ");
 
 	PropWriteStream stream;
-	for (auto&& house : g_game.getHouses() | std::views::values | std::views::as_const) {
+	for (auto&& house : g_game.getHouses() | std::views::as_const) {
 		// save house items
 		for (auto&& tile : house->getTiles() | tfs::views::lock_weak_ptrs | std::views::as_const) {
 			saveTile(stream, tile);
@@ -269,7 +269,7 @@ bool IOMapSerialize::saveHouseInfo()
 		return false;
 	}
 
-	for (auto&& house : g_game.getHouses() | std::views::values | std::views::as_const) {
+	for (auto&& house : g_game.getHouses() | std::views::as_const) {
 		if (const auto& result =
 		        db.storeQuery(std::format("SELECT `id` FROM `houses` WHERE `id` = {:d}", house->getId()))) {
 			db.executeQuery(std::format(
@@ -288,7 +288,7 @@ bool IOMapSerialize::saveHouseInfo()
 
 	DBInsert stmt("INSERT INTO `house_lists` (`house_id` , `listid` , `list`) VALUES ");
 
-	for (auto&& house : g_game.getHouses() | std::views::values | std::views::as_const) {
+	for (auto&& house : g_game.getHouses() | std::views::as_const) {
 		std::string listText;
 		if (house->getAccessList(GUEST_LIST, listText) && !listText.empty()) {
 			if (!stmt.addRow(std::format("{:d}, {:d}, {:s}", house->getId(), std::to_underlying(GUEST_LIST),

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4651,11 +4651,11 @@ int LuaScriptInterface::luaGameGetTowns(lua_State* L)
 int LuaScriptInterface::luaGameGetHouses(lua_State* L)
 {
 	// Game.getHouses()
-	const auto& houses = g_game.getHouses();
+	const auto& houses = g_game.getHouses() | std::ranges::to<std::vector>();
 	lua_createtable(L, houses.size(), 0);
 
 	int index = 0;
-	for (auto&& house : houses | std::views::values | std::views::as_const) {
+	for (auto&& house : houses | std::views::as_const) {
 		tfs::lua::pushSharedPtr(L, house);
 		tfs::lua::setMetatable(L, -1, "House");
 		lua_rawseti(L, -2, ++index);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactors the Game house API to expose houses as a values view instead of the underlying container. By returning a view directly, call sites no longer need to manually apply std::views::values, resulting in cleaner and more consistent iteration. Luascript ode was updated to explicitly materialize the view into a vector when the container size is required, preserving existing behavior.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
