### PR TITLE
fix(views): remove as_const after lock_weak_ptrs to avoid invalid shared_ptr

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -37,7 +37,7 @@ void PrivateChatChannel::invitePlayer(const std::shared_ptr<const Player>& playe
 
 	player->sendTextMessage(MESSAGE_INFO_DESCR, std::format("{:s} has been invited.", invitePlayer->getName()));
 
-	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 		user->sendChannelEvent(id, invitePlayer->getName(), CHANNELEVENT_INVITE);
 	}
 }
@@ -55,14 +55,14 @@ void PrivateChatChannel::excludePlayer(const std::shared_ptr<const Player>& play
 
 	excludePlayer->sendClosePrivate(id);
 
-	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 		user->sendChannelEvent(id, excludePlayer->getName(), CHANNELEVENT_EXCLUDE);
 	}
 }
 
 void PrivateChatChannel::closeChannel() const
 {
-	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 		user->sendClosePrivate(id);
 	}
 }
@@ -86,7 +86,7 @@ bool ChatChannel::addUser(const std::shared_ptr<Player>& player)
 	}
 
 	if (!publicChannel) {
-		for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 			user->sendChannelEvent(id, player->getName(), CHANNELEVENT_JOIN);
 		}
 	}
@@ -105,7 +105,7 @@ bool ChatChannel::removeUser(const std::shared_ptr<const Player>& player)
 	users.erase(iter);
 
 	if (!publicChannel) {
-		for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 			user->sendChannelEvent(id, player->getName(), CHANNELEVENT_LEAVE);
 		}
 	}
@@ -121,7 +121,7 @@ bool ChatChannel::hasUser(const std::shared_ptr<const Player>& player)
 
 void ChatChannel::sendToAll(const std::string& message, SpeakClasses type) const
 {
-	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 		user->sendChannelMessage("", message, type, id);
 	}
 }
@@ -132,7 +132,7 @@ bool ChatChannel::talk(const std::shared_ptr<const Player>& fromPlayer, SpeakCla
 		return false;
 	}
 
-	for (auto&& user : users | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& user : users | std::views::values | tfs::views::lock_weak_ptrs) {
 		user->sendToChannel(fromPlayer, type, text, id);
 	}
 	return true;
@@ -301,7 +301,7 @@ bool Chat::load()
 			}
 
 			UsersMap tempUserMap = std::move(channel.users);
-			for (auto&& player : tempUserMap | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+			for (const auto& player : tempUserMap | std::views::values | tfs::views::lock_weak_ptrs) {
 				channel.addUser(player);
 			}
 			continue;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -153,7 +153,7 @@ void Game::saveGameState()
 
 	std::cout << "Saving server..." << std::endl;
 
-	for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs) {
 		player->setLoginPosition(player->getPosition());
 		IOLoginData::savePlayer(player);
 	}
@@ -417,7 +417,7 @@ std::shared_ptr<Npc> Game::getNpcByName(const std::string& name)
 		return nullptr;
 	}
 
-	for (auto&& npc : npcs | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& npc : npcs | std::views::values | tfs::views::lock_weak_ptrs) {
 		if (boost::iequals(name, npc->getName())) {
 			return npc;
 		}
@@ -431,7 +431,7 @@ std::shared_ptr<Player> Game::getPlayerByName(const std::string& name)
 		return nullptr;
 	}
 
-	for (auto&& player : players | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& player : players | std::views::values | tfs::views::lock_weak_ptrs) {
 		if (boost::iequals(name, player->getName())) {
 			return player;
 		}
@@ -481,7 +481,7 @@ ReturnValue Game::getPlayerByNameWildcard(const std::string& s, std::shared_ptr<
 
 std::shared_ptr<Player> Game::getPlayerByAccount(uint32_t acc)
 {
-	for (auto&& player : getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs) {
 		if (player->getAccount() == acc) {
 			return player;
 		}
@@ -1893,7 +1893,7 @@ bool Game::playerBroadcastMessage(const std::shared_ptr<Player>& player, const s
 
 	std::cout << "> " << player->getName() << " broadcasted: \"" << text << "\"." << std::endl;
 
-	for (auto&& onlinePlayer : getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& onlinePlayer : getPlayers() | tfs::views::lock_weak_ptrs) {
 		onlinePlayer->sendPrivateMessage(player, TALKTYPE_BROADCAST, text);
 	}
 
@@ -4757,7 +4757,7 @@ void Game::cleanup()
 void Game::broadcastMessage(const std::string& text, MessageClasses type) const
 {
 	std::cout << "> Broadcasted message: \"" << text << "\"." << std::endl;
-	for (auto&& player : getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs) {
 		player->sendTextMessage(type, text);
 	}
 }

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -152,7 +152,7 @@ bool IOMapSerialize::saveHouseItems()
 	PropWriteStream stream;
 	for (auto&& house : g_game.getHouses() | std::views::values | std::views::as_const) {
 		// save house items
-		for (auto&& tile : house->getTiles() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (const auto& tile : house->getTiles() | tfs::views::lock_weak_ptrs) {
 			saveTile(stream, tile);
 
 			if (auto attributes = stream.getStream(); !attributes.empty()) {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4456,7 +4456,7 @@ int LuaScriptInterface::luaGameGetPlayers(lua_State* L)
 	lua_createtable(L, players.size(), 0);
 
 	int index = 0;
-	for (auto&& player : players) {
+	for (const auto& player : players) {
 		tfs::lua::pushSharedPtr(L, player);
 		tfs::lua::setMetatable(L, -1, "Player");
 		lua_rawseti(L, -2, ++index);
@@ -4471,7 +4471,7 @@ int LuaScriptInterface::luaGameGetNpcs(lua_State* L)
 	lua_createtable(L, npcs.size(), 0);
 
 	int index = 0;
-	for (auto&& npc : npcs) {
+	for (const auto& npc : npcs) {
 		tfs::lua::pushSharedPtr(L, npc);
 		tfs::lua::setMetatable(L, -1, "Npc");
 		lua_rawseti(L, -2, ++index);
@@ -4486,7 +4486,7 @@ int LuaScriptInterface::luaGameGetMonsters(lua_State* L)
 	lua_createtable(L, monsters.size(), 0);
 
 	int index = 0;
-	for (auto&& monster : monsters) {
+	for (const auto& monster : monsters) {
 		tfs::lua::pushSharedPtr(L, monster);
 		tfs::lua::setMetatable(L, -1, "Monster");
 		lua_rawseti(L, -2, ++index);
@@ -8505,7 +8505,7 @@ int LuaScriptInterface::luaCreatureGetSummons(lua_State* L)
 		return 1;
 	}
 
-	const auto summons = creature->getSummons() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
+	const auto& summons = creature->getSummons() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 	lua_createtable(L, summons.size(), 0);
 
 	int index = 0;
@@ -10691,14 +10691,14 @@ int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 	}
 
 	if (player->isInGhostMode()) {
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+		for (const auto& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (!onlinePlayer->isAccessPlayer()) {
 				onlinePlayer->notifyStatusChange(player, VIPSTATUS_OFFLINE);
 			}
 		}
 		IOLoginData::updateOnlineStatus(player->getGUID(), false);
 	} else {
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+		for (const auto& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (!onlinePlayer->isAccessPlayer()) {
 				onlinePlayer->notifyStatusChange(player, VIPSTATUS_ONLINE);
 			}
@@ -15774,7 +15774,7 @@ int LuaScriptInterface::luaPartyGetMembers(lua_State* L)
 		return 1;
 	}
 
-	const auto members = party->getMembers() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
+	const auto& members = party->getMembers() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 	lua_createtable(L, members.size(), 0);
 
 	int index = 0;
@@ -15808,7 +15808,7 @@ int LuaScriptInterface::luaPartyGetInvitees(lua_State* L)
 		return 1;
 	}
 
-	const auto invitees = party->getInvitees() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
+	const auto& invitees = party->getInvitees() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 	lua_createtable(L, invitees.size(), 0);
 
 	int index = 0;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -949,7 +949,7 @@ void Monster::onThinkDefense(uint32_t interval)
 		}
 	}
 
-	const auto summons = getSummons() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
+	const auto& summons = getSummons() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 	if (!isSummon() && summons.size() < mType->info.maxSummons && hasFollowPath) {
 		for (const summonBlock_t& summonBlock : mType->info.summons) {
 			if (summonBlock.speed > defenseTicks) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -15,11 +15,11 @@ uint32_t Npc::npcAutoID = 0x20000000;
 
 void Npcs::reload()
 {
-	for (auto&& npc : g_game.getNpcs() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& npc : g_game.getNpcs() | tfs::views::lock_weak_ptrs) {
 		npc->closeAllShopWindows();
 	}
 
-	for (auto&& npc : g_game.getNpcs() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& npc : g_game.getNpcs() | tfs::views::lock_weak_ptrs) {
 		npc->reload();
 	}
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1055,7 +1055,7 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+		for (const auto& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (onlinePlayer != getPlayer()) {
 				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_ONLINE);
 			}
@@ -1202,7 +1202,7 @@ void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		for (auto&& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
+		for (const auto& onlinePlayer : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (onlinePlayer != getPlayer()) {
 				onlinePlayer->notifyStatusChange(getPlayer(), VIPSTATUS_OFFLINE);
 			}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1842,7 +1842,7 @@ void ProtocolGame::sendChannel(uint16_t channelId, const std::string& channelNam
 
 	if (channelUsers) {
 		msg.add<uint16_t>(channelUsers->size());
-		for (auto&& user : *channelUsers | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (const auto& user : *channelUsers | std::views::values | tfs::views::lock_weak_ptrs) {
 			msg.addString(user->getName());
 		}
 	} else {
@@ -1851,7 +1851,7 @@ void ProtocolGame::sendChannel(uint16_t channelId, const std::string& channelNam
 
 	if (invitedUsers) {
 		msg.add<uint16_t>(invitedUsers->size());
-		for (auto&& user : *invitedUsers | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (const auto& user : *invitedUsers | std::views::values | tfs::views::lock_weak_ptrs) {
 			msg.addString(user->getName());
 		}
 	} else {

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -111,7 +111,7 @@ void ProtocolStatus::sendStatusString()
 	uint32_t maxPlayersPerIp = getNumber(ConfigManager::STATUS_COUNT_MAX_PLAYERS_PER_IP);
 	if (maxPlayersPerIp > 0) {
 		std::map<Connection::Address, uint32_t> playersPerIp;
-		for (auto&& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::views::as_const) {
+		for (const auto& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (!player->getIP().is_unspecified()) {
 				++playersPerIp[player->getIP()];
 			}
@@ -209,7 +209,7 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 
 		const auto& players = g_game.getPlayers() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>();
 		output->add<uint32_t>(players.size());
-		for (auto&& player : players) {
+		for (const auto& player : players) {
 			output->addString(player->getName());
 			output->add<uint32_t>(player->getLevel());
 		}

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -239,7 +239,7 @@ void Spawn::startSpawnCheck()
 
 Spawn::~Spawn()
 {
-	for (auto&& monster : spawnedMap | std::views::values | tfs::views::lock_weak_ptrs | std::views::as_const) {
+	for (const auto& monster : spawnedMap | std::views::values | tfs::views::lock_weak_ptrs) {
 		monster->setSpawn(nullptr);
 	}
 }


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes an issue caused by combining `tfs::views::lock_weak_ptrs` with `std::views::as_const`. The view creates new shared_ptr instances through a transform operation. Applying as_const afterward invalidates the resulting pointer type and leads to compilation errors. The fix removes unnecessary uses of `as_const` in pipelines that include` lock_weak_ptrs`, preserving correct ownership semantics and preventing runtime failures.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
