### PR TITLE
fix(monster): correct follow/attack logic on onThink

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -747,7 +747,7 @@ void Monster::onThink(uint32_t interval)
 					}
 				} else if (attackedCreature.get() == this) {
 					removeFollowCreature();
-				} else if (tfs::owner_equal(attackedCreature, getFollowCreature())) {
+				} else if (!tfs::owner_equal(attackedCreature, getFollowCreature())) {
 					// This happens just after a master orders an attack, so lets follow it as well.
 					setFollowCreature(attackedCreature);
 				}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes the monster AI behavior in onThink, specifically handling how monsters follow their master and select targets. The previous logic could incorrectly set or remove the follow target, causing monsters to ignore their master’s orders or fail to attack valid targets.

#1

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
