### PR TITLE
refactor(creature): rename npc accessor to asNpc

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -101,8 +101,8 @@ public:
 
 	virtual std::shared_ptr<Player> getPlayer() { return nullptr; }
 	virtual std::shared_ptr<const Player> getPlayer() const { return nullptr; }
-	virtual std::shared_ptr<Npc> getNpc() { return nullptr; }
-	virtual std::shared_ptr<const Npc> getNpc() const { return nullptr; }
+	virtual std::shared_ptr<Npc> asNpc() { return nullptr; }
+	virtual std::shared_ptr<const Npc> asNpc() const { return nullptr; }
 	virtual std::shared_ptr<Monster> getMonster() { return nullptr; }
 	virtual std::shared_ptr<const Monster> getMonster() const { return nullptr; }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -508,7 +508,7 @@ bool Game::internalPlaceCreature(const std::shared_ptr<Creature>& creature, cons
 		mappedPlayerGuids[player->getGUID()] = player;
 		wildcardTree.insert(lowercase_name);
 		players[player->getID()] = player;
-	} else if (const auto& npc = creature->getNpc()) {
+	} else if (const auto& npc = creature->asNpc()) {
 		npcs[npc->getID()] = npc;
 	} else if (const auto& monster = creature->getMonster()) {
 		monsters[monster->getID()] = monster;
@@ -593,7 +593,7 @@ bool Game::removeCreature(const std::shared_ptr<Creature>& creature, bool isLogo
 		mappedPlayerGuids.erase(player->getGUID());
 		wildcardTree.remove(lowercase_name);
 		players.erase(player->getID());
-	} else if (const auto& npc = creature->getNpc()) {
+	} else if (const auto& npc = creature->asNpc()) {
 		npcs.erase(npc->getID());
 	} else if (const auto& monster = creature->getMonster()) {
 		monsters.erase(monster->getID());
@@ -772,7 +772,7 @@ void Game::playerMoveCreature(const std::shared_ptr<Player>& player, const std::
 				}
 			}
 
-			if (const auto& movingNpc = movingCreature->getNpc()) {
+			if (const auto& movingNpc = movingCreature->asNpc()) {
 				if (!Spawns::isInZone(movingNpc->getMasterPos(), movingNpc->getMasterRadius(), toPos)) {
 					player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 					return;
@@ -2020,7 +2020,7 @@ void Game::playerCloseNpcChannel(uint32_t playerId)
 	SpectatorVec spectators;
 	map.getSpectators(spectators, player->getPosition());
 	for (const auto& spectator : spectators) {
-		if (const auto& npc = spectator->getNpc()) {
+		if (const auto& npc = spectator->asNpc()) {
 			npc->onPlayerCloseChannel(player);
 		}
 	}
@@ -3646,7 +3646,7 @@ void Game::playerSpeakToNpc(const std::shared_ptr<Player>& player, const std::st
 	SpectatorVec spectators;
 	map.getSpectators(spectators, player->getPosition());
 	for (const auto& spectator : spectators) {
-		if (spectator->getNpc()) {
+		if (spectator->asNpc()) {
 			spectator->onCreatureSay(player, TALKTYPE_PRIVATE_PN, text);
 		}
 	}

--- a/src/lua/modules/npc.cpp
+++ b/src/lua/modules/npc.cpp
@@ -46,7 +46,7 @@ int luaNpcIsNpc(lua_State* L)
 {
 	// npc:isNpc()
 	if (const auto& creature = tfs::lua::getCreature(L, 1)) {
-		tfs::lua::pushBoolean(L, creature->getNpc() != nullptr);
+		tfs::lua::pushBoolean(L, creature->asNpc() != nullptr);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -93,7 +93,7 @@ void Npc::reload()
 
 	// Simulate that the creature is placed on the map again.
 	if (npcEventHandler) {
-		npcEventHandler->onCreatureAppear(getNpc());
+		npcEventHandler->onCreatureAppear(asNpc());
 	}
 }
 
@@ -145,7 +145,7 @@ bool Npc::loadFromXml()
 
 	if ((attr = npcNode.attribute("skull"))) {
 		setSkull(getSkullType(boost::algorithm::to_lower_copy<std::string>(attr.as_string())));
-		g_game.updateCreatureSkull(getNpc());
+		g_game.updateCreatureSkull(asNpc());
 	}
 
 	pugi::xml_node healthNode = npcNode.child("health");
@@ -193,7 +193,7 @@ bool Npc::loadFromXml()
 
 	pugi::xml_attribute scriptFile = npcNode.attribute("script");
 	if (scriptFile) {
-		auto handler = std::make_unique<NpcEventsHandler>(scriptFile.as_string(), getNpc());
+		auto handler = std::make_unique<NpcEventsHandler>(scriptFile.as_string(), asNpc());
 		if (!handler->isLoaded()) {
 			return false;
 		}
@@ -339,13 +339,13 @@ void Npc::onThink(uint32_t interval)
 	}
 }
 
-void Npc::doSay(const std::string& text) { g_game.internalCreatureSay(getNpc(), TALKTYPE_SAY, text, false); }
+void Npc::doSay(const std::string& text) { g_game.internalCreatureSay(asNpc(), TALKTYPE_SAY, text, false); }
 
 void Npc::doSayToPlayer(const std::shared_ptr<Player>& player, const std::string& text)
 {
 	if (player) {
-		player->sendCreatureSay(getNpc(), TALKTYPE_PRIVATE_NP, text);
-		player->onCreatureSay(getNpc(), TALKTYPE_PRIVATE_NP, text);
+		player->sendCreatureSay(asNpc(), TALKTYPE_PRIVATE_NP, text);
+		player->onCreatureSay(asNpc(), TALKTYPE_PRIVATE_NP, text);
 	}
 }
 
@@ -427,7 +427,7 @@ bool Npc::canWalkTo(const Position& fromPos, Direction dir) const
 	}
 
 	const auto& tile = g_game.map.getTile(toPos);
-	if (!tile || tile->queryAdd(0, getNpc(), 1, 0) != RETURNVALUE_NOERROR) {
+	if (!tile || tile->queryAdd(0, asNpc(), 1, 0) != RETURNVALUE_NOERROR) {
 		return false;
 	}
 
@@ -493,7 +493,7 @@ void Npc::turnToCreature(const std::shared_ptr<Creature>& creature)
 			dir = DIRECTION_SOUTH;
 		}
 	}
-	g_game.internalCreatureTurn(getNpc(), dir);
+	g_game.internalCreatureTurn(asNpc(), dir);
 }
 
 void Npc::setCreatureFocus(const std::shared_ptr<Creature>& creature)

--- a/src/npc.h
+++ b/src/npc.h
@@ -95,8 +95,8 @@ public:
 	Npc(const Npc&) = delete;
 	Npc& operator=(const Npc&) = delete;
 
-	std::shared_ptr<Npc> getNpc() override { return std::static_pointer_cast<Npc>(shared_from_this()); }
-	std::shared_ptr<const Npc> getNpc() const override
+	std::shared_ptr<Npc> asNpc() override { return std::static_pointer_cast<Npc>(shared_from_this()); }
+	std::shared_ptr<const Npc> asNpc() const override
 	{
 		return std::static_pointer_cast<const Npc>(shared_from_this());
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3445,7 +3445,7 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const std::shared_ptr<const 
 		msg.addByte(otherPlayer ? otherPlayer->getVocation()->getClientId() : 0x00);
 	}
 
-	if (const auto npc = creature->getNpc()) {
+	if (const auto npc = creature->asNpc()) {
 		msg.addByte(npc->getSpeechBubble());
 	} else {
 		msg.addByte(SPEECHBUBBLE_NONE);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Replaces the `getNpc` accessor with a more explicit `asNpc` method in the `Creature` hierarchy.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
