### PR TITLE
refactor(creature): rename monster accessor to asMonster

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -269,7 +269,7 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const
 				}
 			}
 		}
-	} else if (target->getMonster()) {
+	} else if (target->asMonster()) {
 		if (const auto& attackerPlayer = attacker->getPlayer()) {
 			if (attackerPlayer->hasFlag(PlayerFlag_CannotAttackMonster)) {
 				return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
@@ -278,7 +278,7 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const
 			if (target->isSummon() && target->getMaster()->getPlayer() && target->getZone() == ZONE_NOPVP) {
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			}
-		} else if (attacker->getMonster()) {
+		} else if (attacker->asMonster()) {
 			const auto& targetMaster = target->getMaster();
 
 			if (!targetMaster || !targetMaster->getPlayer()) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -485,7 +485,7 @@ bool Creature::dropCorpse(const std::shared_ptr<Creature>& lastHitCreature,
                           const std::shared_ptr<Creature>& mostDamageCreature, bool lastHitUnjustified,
                           bool mostDamageUnjustified)
 {
-	if (!lootDrop && getMonster()) {
+	if (!lootDrop && asMonster()) {
 		if (!master.expired()) {
 			// scripting event - onDeath
 			const CreatureEventList& deathEvents = getCreatureEvents(CREATURE_EVENT_DEATH);
@@ -1228,7 +1228,7 @@ int64_t Creature::getStepDuration() const
 	double duration = std::floor(1000 * groundSpeed / calculatedStepSpeed);
 	int64_t stepDuration = std::ceil(duration / 50) * 50;
 
-	const auto& monster = this->getMonster();
+	const auto& monster = this->asMonster();
 	if (monster && monster->isTargetNearby() && !monster->isFleeing() && !monster->getMaster()) {
 		stepDuration *= 2;
 	}

--- a/src/creature.h
+++ b/src/creature.h
@@ -103,8 +103,8 @@ public:
 	virtual std::shared_ptr<const Player> getPlayer() const { return nullptr; }
 	virtual std::shared_ptr<Npc> getNpc() { return nullptr; }
 	virtual std::shared_ptr<const Npc> getNpc() const { return nullptr; }
-	virtual std::shared_ptr<Monster> getMonster() { return nullptr; }
-	virtual std::shared_ptr<const Monster> getMonster() const { return nullptr; }
+	virtual std::shared_ptr<Monster> asMonster() { return nullptr; }
+	virtual std::shared_ptr<const Monster> asMonster() const { return nullptr; }
 
 	virtual const std::string& getName() const = 0;
 	virtual const std::string& getNameDescription() const = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -510,7 +510,7 @@ bool Game::internalPlaceCreature(const std::shared_ptr<Creature>& creature, cons
 		players[player->getID()] = player;
 	} else if (const auto& npc = creature->getNpc()) {
 		npcs[npc->getID()] = npc;
-	} else if (const auto& monster = creature->getMonster()) {
+	} else if (const auto& monster = creature->asMonster()) {
 		monsters[monster->getID()] = monster;
 	}
 
@@ -595,7 +595,7 @@ bool Game::removeCreature(const std::shared_ptr<Creature>& creature, bool isLogo
 		players.erase(player->getID());
 	} else if (const auto& npc = creature->getNpc()) {
 		npcs.erase(npc->getID());
-	} else if (const auto& monster = creature->getMonster()) {
+	} else if (const auto& monster = creature->asMonster()) {
 		monsters.erase(monster->getID());
 	}
 

--- a/src/lua/meta.cpp
+++ b/src/lua/meta.cpp
@@ -66,7 +66,7 @@ void setCreatureMetatable(lua_State* L, int32_t index, const std::shared_ptr<con
 {
 	if (creature->getPlayer()) {
 		luaL_getmetatable(L, "Player");
-	} else if (creature->getMonster()) {
+	} else if (creature->asMonster()) {
 		luaL_getmetatable(L, "Monster");
 	} else {
 		luaL_getmetatable(L, "Npc");

--- a/src/lua/modules/monster.cpp
+++ b/src/lua/modules/monster.cpp
@@ -41,7 +41,7 @@ int luaMonsterIsMonster(lua_State* L)
 {
 	// monster:isMonster()
 	if (const auto& creature = tfs::lua::getCreature(L, 1)) {
-		tfs::lua::pushBoolean(L, creature->getMonster() != nullptr);
+		tfs::lua::pushBoolean(L, creature->asMonster() != nullptr);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -996,7 +996,7 @@ uint16_t AStarNodes::getTileWalkCost(const std::shared_ptr<const Creature>& crea
 
 	if (const auto& field = tile->getFieldItem()) {
 		CombatType_t combatType = field->getCombatType();
-		const auto& monster = creature->getMonster();
+		const auto& monster = creature->asMonster();
 		if (!creature->isImmune(combatType) && !creature->hasCondition(DamageToConditionType(combatType)) &&
 		    (monster && !monster->canWalkOnFieldType(combatType))) {
 			cost += MAP_NORMALWALKCOST * 18;

--- a/src/monster.h
+++ b/src/monster.h
@@ -37,8 +37,8 @@ public:
 	Monster(const Monster&) = delete;
 	Monster& operator=(const Monster&) = delete;
 
-	std::shared_ptr<Monster> getMonster() override { return std::static_pointer_cast<Monster>(shared_from_this()); }
-	std::shared_ptr<const Monster> getMonster() const override
+	std::shared_ptr<Monster> asMonster() override { return std::static_pointer_cast<Monster>(shared_from_this()); }
+	std::shared_ptr<const Monster> asMonster() const override
 	{
 		return std::static_pointer_cast<const Monster>(shared_from_this());
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3592,7 +3592,7 @@ void Player::onAttackedCreatureDrainHealth(const std::shared_ptr<Creature>& targ
 		return;
 	}
 
-	const auto& targetMonster = target->getMonster();
+	const auto& targetMonster = target->asMonster();
 	if (!targetMonster || !targetMonster->isHostile()) {
 		return;
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3460,7 +3460,7 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const std::shared_ptr<const 
 void ProtocolGame::AddCreatureIcons(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature)
 {
 	const auto& creatureIcons = creature->getIcons();
-	if (const auto& monster = creature->getMonster()) {
+	if (const auto& monster = creature->asMonster()) {
 		const auto& monsterIcons = monster->getSpecialIcons();
 		msg.addByte(creatureIcons.size() + monsterIcons.size());
 		for (const auto& [iconId, level] : monsterIcons) {

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -472,7 +472,7 @@ ReturnValue Tile::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, u
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
-		if (const auto& monster = creature->getMonster()) {
+		if (const auto& monster = creature->asMonster()) {
 			if (hasFlag(TILESTATE_PROTECTIONZONE | TILESTATE_FLOORCHANGE | TILESTATE_TELEPORT)) {
 				return RETURNVALUE_NOTPOSSIBLE;
 			}
@@ -486,7 +486,7 @@ ReturnValue Tile::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, u
 							}
 						}
 
-						const auto& creatureMonster = tileCreature->getMonster();
+						const auto& creatureMonster = tileCreature->asMonster();
 						if (!creatureMonster || !tileCreature->isPushable() ||
 						    (creatureMonster->isSummon() && creatureMonster->getMaster()->getPlayer())) {
 							return RETURNVALUE_NOTPOSSIBLE;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Replaces the `getMonster` accessor with a more explicit `asMonster` method in the `Creature` hierarchy.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
