### PR TITLE
refactor(creature): rename player accessor to asPlayer

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -75,7 +75,7 @@ CombatDamage Combat::getCombatDamage(const std::shared_ptr<Creature>& creature,
 		int32_t min, max;
 		if (creature->getCombatValues(min, max)) {
 			damage.primary.value = normal_random(min, max);
-		} else if (const auto& player = creature->getPlayer()) {
+		} else if (const auto& player = creature->asPlayer()) {
 			if (params.valueCallback) {
 				params.valueCallback->getMinMaxValues(player, damage);
 			} else if (formulaType == COMBAT_FORMULA_LEVELMAGIC) {
@@ -120,11 +120,11 @@ static bool isProtected(const std::shared_ptr<const Player>& attacker, const std
 
 bool Combat::isPlayerCombat(const std::shared_ptr<const Creature>& target)
 {
-	if (target->getPlayer()) {
+	if (target->asPlayer()) {
 		return true;
 	}
 
-	if (target->isSummon() && target->getMaster()->getPlayer()) {
+	if (target->isSummon() && target->getMaster()->asPlayer()) {
 		return true;
 	}
 
@@ -160,19 +160,19 @@ ReturnValue Combat::canTargetCreature(const std::shared_ptr<Player>& attacker, c
 	}
 
 	if (attacker->hasFlag(PlayerFlag_CannotUseCombat) || !target->isAttackable()) {
-		if (target->getPlayer()) {
+		if (target->asPlayer()) {
 			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 		}
 		return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 	}
 
-	if (target->getPlayer()) {
-		if (isProtected(attacker, target->getPlayer())) {
+	if (target->asPlayer()) {
+		if (isProtected(attacker, target->asPlayer())) {
 			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 		}
 
 		if (attacker->hasSecureMode() && !Combat::isInPvpZone(attacker, target) &&
-		    attacker->getCombatSkull(target->getPlayer()) == SKULL_NONE) {
+		    attacker->getCombatSkull(target->asPlayer()) == SKULL_NONE) {
 			return RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS;
 		}
 	}
@@ -204,7 +204,7 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& caster, const s
 			return RETURNVALUE_FIRSTGOUPSTAIRS;
 		}
 
-		if (const auto& player = caster->getPlayer()) {
+		if (const auto& player = caster->asPlayer()) {
 			if (player->hasFlag(PlayerFlag_IgnoreProtectionZone)) {
 				return RETURNVALUE_NOERROR;
 			}
@@ -230,12 +230,12 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const
 		return tfs::events::creature::onTargetCombat(attacker, target);
 	}
 
-	if (const auto& targetPlayer = target->getPlayer()) {
+	if (const auto& targetPlayer = target->asPlayer()) {
 		if (targetPlayer->hasFlag(PlayerFlag_CannotBeAttacked)) {
 			return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 		}
 
-		if (const auto& attackerPlayer = attacker->getPlayer()) {
+		if (const auto& attackerPlayer = attacker->asPlayer()) {
 			if (attackerPlayer->hasFlag(PlayerFlag_CannotAttackPlayer)) {
 				return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 			}
@@ -255,7 +255,7 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const
 		}
 
 		if (attacker->isSummon()) {
-			if (const auto& masterAttackerPlayer = attacker->getMaster()->getPlayer()) {
+			if (const auto& masterAttackerPlayer = attacker->getMaster()->asPlayer()) {
 				if (masterAttackerPlayer->hasFlag(PlayerFlag_CannotAttackPlayer)) {
 					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 				}
@@ -270,21 +270,21 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const
 			}
 		}
 	} else if (target->getMonster()) {
-		if (const auto& attackerPlayer = attacker->getPlayer()) {
+		if (const auto& attackerPlayer = attacker->asPlayer()) {
 			if (attackerPlayer->hasFlag(PlayerFlag_CannotAttackMonster)) {
 				return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 			}
 
-			if (target->isSummon() && target->getMaster()->getPlayer() && target->getZone() == ZONE_NOPVP) {
+			if (target->isSummon() && target->getMaster()->asPlayer() && target->getZone() == ZONE_NOPVP) {
 				return RETURNVALUE_ACTIONNOTPERMITTEDINANOPVPZONE;
 			}
 		} else if (attacker->getMonster()) {
 			const auto& targetMaster = target->getMaster();
 
-			if (!targetMaster || !targetMaster->getPlayer()) {
+			if (!targetMaster || !targetMaster->asPlayer()) {
 				const auto& attackerMaster = attacker->getMaster();
 
-				if (!attackerMaster || !attackerMaster->getPlayer()) {
+				if (!attackerMaster || !attackerMaster->asPlayer()) {
 					return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 				}
 			}
@@ -292,14 +292,14 @@ ReturnValue Combat::canDoCombat(const std::shared_ptr<Creature>& attacker, const
 	}
 
 	if (g_game.getWorldType() == WORLD_TYPE_NO_PVP) {
-		if (attacker->getPlayer() || (attacker->isSummon() && attacker->getMaster()->getPlayer())) {
-			if (target->getPlayer()) {
+		if (attacker->asPlayer() || (attacker->isSummon() && attacker->getMaster()->asPlayer())) {
+			if (target->asPlayer()) {
 				if (!isInPvpZone(attacker, target)) {
 					return RETURNVALUE_YOUMAYNOTATTACKTHISPLAYER;
 				}
 			}
 
-			if (target->isSummon() && target->getMaster()->getPlayer()) {
+			if (target->isSummon() && target->getMaster()->asPlayer()) {
 				if (!isInPvpZone(attacker, target)) {
 					return RETURNVALUE_YOUMAYNOTATTACKTHISCREATURE;
 				}
@@ -500,9 +500,9 @@ static void combatTileEffects(const SpectatorVec& spectators, const std::shared_
 		if (caster) {
 			std::shared_ptr<Player> casterPlayer;
 			if (caster->isSummon()) {
-				casterPlayer = caster->getMaster()->getPlayer();
+				casterPlayer = caster->getMaster()->asPlayer();
 			} else {
-				casterPlayer = caster->getPlayer();
+				casterPlayer = caster->asPlayer();
 			}
 
 			if (casterPlayer) {
@@ -560,7 +560,7 @@ void Combat::addDistanceEffect(const std::shared_ptr<Creature>& caster, const Po
 			return;
 		}
 
-		const auto& player = caster->getPlayer();
+		const auto& player = caster->asPlayer();
 		if (!player) {
 			return;
 		}
@@ -730,7 +730,7 @@ void Combat::doTargetCombat(const std::shared_ptr<Creature>& caster, const std::
 		addDistanceEffect(caster, caster->getPosition(), target->getPosition(), params.distanceEffect);
 	}
 
-	const auto& casterPlayer = caster ? caster->getPlayer() : nullptr;
+	const auto& casterPlayer = caster ? caster->asPlayer() : nullptr;
 
 	bool success = false;
 	if (damage.primary.type != COMBAT_MANADRAIN) {
@@ -740,7 +740,7 @@ void Combat::doTargetCombat(const std::shared_ptr<Creature>& caster, const std::
 		}
 
 		if (casterPlayer) {
-			const auto& targetPlayer = target ? target->getPlayer() : nullptr;
+			const auto& targetPlayer = target ? target->asPlayer() : nullptr;
 			if (targetPlayer && casterPlayer != targetPlayer && targetPlayer->getSkull() != SKULL_BLACK &&
 			    damage.primary.type != COMBAT_HEALING) {
 				damage.primary.value /= 2;
@@ -829,7 +829,7 @@ void Combat::doAreaCombat(const std::shared_ptr<Creature>& caster, const Positio
 	const auto& tiles =
 	    caster ? getCombatArea(caster->getPosition(), position, area) : getCombatArea(position, position, area);
 
-	const auto& casterPlayer = caster ? caster->getPlayer() : nullptr;
+	const auto& casterPlayer = caster ? caster->asPlayer() : nullptr;
 	int32_t criticalPrimary = 0;
 	int32_t criticalSecondary = 0;
 	if (!damage.critical && damage.primary.type != COMBAT_HEALING && casterPlayer &&
@@ -905,7 +905,7 @@ void Combat::doAreaCombat(const std::shared_ptr<Creature>& caster, const Positio
 		                                  // or not, so we can't modify the initial damage.
 		bool playerCombatReduced = false;
 		if ((damageCopy.primary.value < 0 || damageCopy.secondary.value < 0) && caster) {
-			const auto& targetPlayer = creature->getPlayer();
+			const auto& targetPlayer = creature->asPlayer();
 			if (casterPlayer && targetPlayer && casterPlayer != targetPlayer &&
 			    targetPlayer->getSkull() != SKULL_BLACK) {
 				damageCopy.primary.value /= 2;
@@ -1324,7 +1324,7 @@ void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 	}
 
 	// no-pvp fields must not damage players
-	if (!isLoadedFromMap() && creature->getPlayer() &&
+	if (!isLoadedFromMap() && creature->asPlayer() &&
 	    (id == ITEM_FIREFIELD_NOPVP || id == ITEM_FIREFIELD_NOPVP_MEDIUM || id == ITEM_POISONFIELD_NOPVP ||
 	     id == ITEM_ENERGYFIELD_NOPVP)) {
 		if (!creature->isInGhostMode()) {
@@ -1341,13 +1341,13 @@ void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 
 			if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
 				if (const auto& owner = g_game.getCreatureByID(ownerId)) {
-					if (owner->getPlayer() || (owner->isSummon() && owner->getMaster()->getPlayer())) {
+					if (owner->asPlayer() || (owner->isSummon() && owner->getMaster()->asPlayer())) {
 						harmfulField = false;
 					}
 				}
 			}
 
-			if (const auto& targetPlayer = creature->getPlayer(); !harmfulField && targetPlayer) {
+			if (const auto& targetPlayer = creature->asPlayer(); !harmfulField && targetPlayer) {
 				if (const auto& attackerPlayer = g_game.getPlayerByID(ownerId)) {
 					if (isProtected(attackerPlayer, targetPlayer)) {
 						harmfulField = false;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -393,7 +393,7 @@ void ConditionAttributes::addCondition(const std::shared_ptr<Creature>& creature
 		memcpy(statsPercent, conditionAttrs.statsPercent, sizeof(statsPercent));
 		disableDefense = conditionAttrs.disableDefense;
 
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			updatePercentSkills(player);
 			updateSkills(player);
 			updatePercentStats(player);
@@ -447,7 +447,7 @@ bool ConditionAttributes::startCondition(const std::shared_ptr<Creature>& creatu
 
 	creature->setUseDefense(!disableDefense);
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		updatePercentSkills(player);
 		updateSkills(player);
 		updatePercentStats(player);
@@ -539,7 +539,7 @@ bool ConditionAttributes::executeCondition(const std::shared_ptr<Creature>& crea
 
 void ConditionAttributes::endCondition(const std::shared_ptr<Creature>& creature)
 {
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		bool needUpdateSkills = false;
 
 		for (int32_t i = SKILL_FIRST; i <= SKILL_LAST; ++i) {
@@ -900,7 +900,7 @@ bool ConditionRegeneration::executeCondition(const std::shared_ptr<Creature>& cr
 		realHealthGain = creature->getHealth() - realHealthGain;
 
 		if (isBuff && realHealthGain > 0) {
-			if (const auto& player = creature->getPlayer()) {
+			if (const auto& player = creature->asPlayer()) {
 				std::string healString =
 				    std::to_string(realHealthGain) + (realHealthGain != 1 ? " hitpoints." : " hitpoint.");
 
@@ -917,7 +917,7 @@ bool ConditionRegeneration::executeCondition(const std::shared_ptr<Creature>& cr
 					message.type = MESSAGE_HEALED_OTHERS;
 					message.text = player->getName() + " was healed for " + healString;
 					for (const auto& spectator : spectators) {
-						assert(spectator->getPlayer() != nullptr);
+						assert(spectator->asPlayer() != nullptr);
 						std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 					}
 				}
@@ -928,7 +928,7 @@ bool ConditionRegeneration::executeCondition(const std::shared_ptr<Creature>& cr
 	if (internalManaTicks >= manaTicks) {
 		internalManaTicks = 0;
 
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			int32_t realManaGain = player->getMana();
 			player->changeMana(manaGain);
 			realManaGain = player->getMana() - realManaGain;
@@ -949,7 +949,7 @@ bool ConditionRegeneration::executeCondition(const std::shared_ptr<Creature>& cr
 					message.type = MESSAGE_HEALED_OTHERS;
 					message.text = player->getName() + " gained " + manaGainString + " mana.";
 					for (const auto& spectator : spectators) {
-						assert(spectator->getPlayer() != nullptr);
+						assert(spectator->asPlayer() != nullptr);
 						std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 					}
 				}
@@ -1047,7 +1047,7 @@ bool ConditionSoul::executeCondition(const std::shared_ptr<Creature>& creature, 
 
 	internalSoulTicks += interval;
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		if (player->getZone() != ZONE_PROTECTION) {
 			if (internalSoulTicks >= soulTicks) {
 				internalSoulTicks = 0;
@@ -1418,7 +1418,7 @@ bool ConditionDamage::doDamage(const std::shared_ptr<Creature>& creature, int32_
 	damage.primary.type = ConditionToDamageType(conditionType);
 
 	const auto& attacker = g_game.getCreatureByID(owner);
-	if (field && creature->getPlayer() && attacker && attacker->getPlayer()) {
+	if (field && creature->asPlayer() && attacker && attacker->asPlayer()) {
 		damage.primary.value = static_cast<int32_t>(std::round(damage.primary.value / 2.));
 	}
 
@@ -1930,7 +1930,7 @@ void ConditionSpellCooldown::addCondition(const std::shared_ptr<Creature>& creat
 		setTicks(condition->getTicks());
 
 		if (subId != 0 && ticks > 0) {
-			if (const auto& player = creature->getPlayer()) {
+			if (const auto& player = creature->asPlayer()) {
 				player->sendSpellCooldown(subId, ticks);
 			}
 		}
@@ -1944,7 +1944,7 @@ bool ConditionSpellCooldown::startCondition(const std::shared_ptr<Creature>& cre
 	}
 
 	if (subId != 0 && ticks > 0) {
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			player->sendSpellCooldown(subId, ticks);
 		}
 	}
@@ -1957,7 +1957,7 @@ void ConditionSpellGroupCooldown::addCondition(const std::shared_ptr<Creature>& 
 		setTicks(condition->getTicks());
 
 		if (subId != 0 && ticks > 0) {
-			if (const auto& player = creature->getPlayer()) {
+			if (const auto& player = creature->asPlayer()) {
 				player->sendSpellGroupCooldown(static_cast<SpellGroup_t>(subId), ticks);
 			}
 		}
@@ -1971,7 +1971,7 @@ bool ConditionSpellGroupCooldown::startCondition(const std::shared_ptr<Creature>
 	}
 
 	if (subId != 0 && ticks > 0) {
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			player->sendSpellGroupCooldown(static_cast<SpellGroup_t>(subId), ticks);
 		}
 	}
@@ -2035,7 +2035,7 @@ bool ConditionManaShield::startCondition(const std::shared_ptr<Creature>& creatu
 		return false;
 	}
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		const auto& conditionManaShield = static_cast<const ConditionManaShield&>(*this);
 		manaShield = conditionManaShield.manaShield;
 		maxManaShield = conditionManaShield.manaShield;
@@ -2047,14 +2047,14 @@ bool ConditionManaShield::startCondition(const std::shared_ptr<Creature>& creatu
 
 void ConditionManaShield::endCondition(const std::shared_ptr<Creature>& creature)
 {
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		player->sendStats();
 	}
 }
 
 void ConditionManaShield::addCondition(const std::shared_ptr<Creature>& creature, const Condition* addCondition)
 {
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		endCondition(player);
 		setTicks(addCondition->getTicks());
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -56,7 +56,7 @@ bool Container::hasContainerParent() const
 
 	if (hasParent()) {
 		if (const auto& creature = getParent()->asCreature()) {
-			return !creature->getPlayer();
+			return !creature->asPlayer();
 		}
 	}
 	return true;
@@ -147,13 +147,13 @@ void Container::onAddContainerItem(const std::shared_ptr<Item>& item)
 
 	// send to client
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->sendAddContainerItem(getContainer(), item);
 	}
 
 	// event methods
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->onAddContainerItem(item);
 	}
 }
@@ -166,13 +166,13 @@ void Container::onUpdateContainerItem(uint32_t index, const std::shared_ptr<Item
 
 	// send to client
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->sendUpdateContainerItem(getContainer(), index, newItem);
 	}
 
 	// event methods
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->onUpdateContainerItem(getContainer(), oldItem, newItem);
 	}
 }
@@ -184,13 +184,13 @@ void Container::onRemoveContainerItem(uint32_t index, const std::shared_ptr<Item
 
 	// send change to client
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->sendRemoveContainerItem(getContainer(), index);
 	}
 
 	// event methods
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->onRemoveContainerItem(getContainer(), item);
 	}
 }
@@ -273,7 +273,7 @@ ReturnValue Container::queryAdd(int32_t index, const std::shared_ptr<const Thing
 	if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto& tile = topParent->getTile()) {
 			if (const auto& houseTile = tile->getHouseTile()) {
-				if (!topParent->asCreature() && !houseTile->getHouse()->isInvited(actor->getPlayer())) {
+				if (!topParent->asCreature() && !houseTile->getHouse()->isInvited(actor->asPlayer())) {
 					return RETURNVALUE_PLAYERISNOTINVITED;
 				}
 			}
@@ -364,7 +364,7 @@ ReturnValue Container::queryRemove(const std::shared_ptr<const Thing>& thing, ui
 		const auto& topParent = getTopParent();
 		if (const auto& tile = topParent->getTile()) {
 			if (const auto& houseTile = tile->getHouseTile()) {
-				if (!topParent->asCreature() && !houseTile->getHouse()->isInvited(actor->getPlayer())) {
+				if (!topParent->asCreature() && !houseTile->getHouse()->isInvited(actor->asPlayer())) {
 					return RETURNVALUE_PLAYERISNOTINVITED;
 				}
 			}
@@ -636,7 +636,7 @@ void Container::postAddNotification(const std::shared_ptr<Thing>& thing, const s
 			tile->postAddNotification(thing, oldParent, index, LINK_NEAR);
 		}
 	} else if (const auto& creature = topParent->asCreature()) {
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			// Container is inside a player's inventory
 			player->postAddNotification(thing, oldParent, index, LINK_TOPPARENT);
 		}
@@ -656,7 +656,7 @@ void Container::postRemoveNotification(const std::shared_ptr<Thing>& thing,
 			tile->postRemoveNotification(thing, newParent, index, LINK_NEAR);
 		}
 	} else if (const auto& creature = topParent->asCreature()) {
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			// Container is inside a player's inventory
 			player->postRemoveNotification(thing, newParent, index, LINK_TOPPARENT);
 		}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -157,7 +157,7 @@ void Creature::onWalk()
 		if (getNextStep(dir, flags)) {
 			ReturnValue ret = g_game.internalMoveCreature(asCreature(), dir, flags);
 			if (ret != RETURNVALUE_NOERROR) {
-				if (const auto& player = getPlayer()) {
+				if (const auto& player = asPlayer()) {
 					player->sendCancelMessage(ret);
 					player->sendCancelWalk();
 				}
@@ -221,7 +221,7 @@ bool Creature::getNextStep(Direction& dir, uint32_t&)
 
 void Creature::startAutoWalk()
 {
-	if (const auto& player = getPlayer(); player && player->isMovementBlocked()) {
+	if (const auto& player = asPlayer(); player && player->isMovementBlocked()) {
 		player->sendCancelWalk();
 		return;
 	}
@@ -231,7 +231,7 @@ void Creature::startAutoWalk()
 
 void Creature::startAutoWalk(Direction direction)
 {
-	if (const auto& player = getPlayer(); player && player->isMovementBlocked()) {
+	if (const auto& player = asPlayer(); player && player->isMovementBlocked()) {
 		player->sendCancelWalk();
 		return;
 	}
@@ -246,7 +246,7 @@ void Creature::startAutoWalk(const std::vector<Direction>& listDir)
 		return;
 	}
 
-	if (const auto& player = getPlayer(); player && player->isMovementBlocked()) {
+	if (const auto& player = asPlayer(); player && player->isMovementBlocked()) {
 		player->sendCancelWalk();
 		return;
 	}
@@ -293,7 +293,7 @@ void Creature::updateIcons() const
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, true, true);
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->sendUpdateCreatureIcons(asCreature());
 	}
 }
@@ -433,8 +433,8 @@ void Creature::onDeath()
 
 			if (attacker.get() != this) {
 				uint64_t gainExp = getGainedExperience(attacker);
-				if (const auto& attackerPlayer = attacker->getPlayer()) {
-					attackerPlayer->removeAttacked(getPlayer());
+				if (const auto& attackerPlayer = attacker->asPlayer()) {
+					attackerPlayer->removeAttacked(asPlayer());
 
 					if (const auto& party = attackerPlayer->getParty()) {
 						if (party->isSharedExperienceActive() && party->isSharedExperienceEnabled()) {
@@ -642,7 +642,7 @@ BlockType_t Creature::blockHit(const std::shared_ptr<Creature>& attacker, Combat
 	}
 
 	if (attacker) {
-		if (const auto& attackerPlayer = attacker->getPlayer()) {
+		if (const auto& attackerPlayer = attacker->asPlayer()) {
 			for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
 				if (!attackerPlayer->isItemAbilityEnabled(static_cast<slots_t>(slot))) {
 					continue;
@@ -669,7 +669,7 @@ BlockType_t Creature::blockHit(const std::shared_ptr<Creature>& attacker, Combat
 			attacker->onAttackedCreature(asCreature());
 			attacker->onAttackedCreatureBlockHit(blockType);
 			if (const auto& master = attacker->getMaster()) {
-				if (const auto& masterPlayer = master->getPlayer()) {
+				if (const auto& masterPlayer = master->asPlayer()) {
 					masterPlayer->onAttackedCreature(asCreature());
 				}
 			}
@@ -677,7 +677,7 @@ BlockType_t Creature::blockHit(const std::shared_ptr<Creature>& attacker, Combat
 	}
 
 	if (combatType != COMBAT_HEALING) {
-		if (const auto& player = getPlayer()) {
+		if (const auto& player = asPlayer()) {
 			player->addInFightTicks();
 		}
 	}
@@ -699,7 +699,7 @@ void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 	creature->addFollower(asCreature());
 	onAttackedCreature(creature);
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		player->addInFightTicks();
 	}
 
@@ -952,7 +952,7 @@ void Creature::onGainExperience(uint64_t gainExp, const std::shared_ptr<Creature
 	message.primary.value = gainExp;
 
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 	}
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -99,8 +99,8 @@ public:
 		return std::static_pointer_cast<const Creature>(shared_from_this());
 	}
 
-	virtual std::shared_ptr<Player> getPlayer() { return nullptr; }
-	virtual std::shared_ptr<const Player> getPlayer() const { return nullptr; }
+	virtual std::shared_ptr<Player> asPlayer() { return nullptr; }
+	virtual std::shared_ptr<const Player> asPlayer() const { return nullptr; }
 	virtual std::shared_ptr<Npc> getNpc() { return nullptr; }
 	virtual std::shared_ptr<const Npc> getNpc() const { return nullptr; }
 	virtual std::shared_ptr<Monster> getMonster() { return nullptr; }

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -48,7 +48,7 @@ void House::setOwner(uint32_t guid, bool updateDatabase /* = true*/,
 		for (const auto& tile : tiles | tfs::views::lock_weak_ptrs) {
 			if (const CreatureVector* creatures = tile->getCreatures()) {
 				for (int32_t i = creatures->size(); --i >= 0;) {
-					kickPlayer(nullptr, (*creatures)[i]->getPlayer());
+					kickPlayer(nullptr, (*creatures)[i]->asPlayer());
 				}
 			}
 		}
@@ -183,7 +183,7 @@ void House::setAccessList(uint32_t listId, std::string_view textlist)
 	for (const auto& tile : tiles | tfs::views::lock_weak_ptrs) {
 		if (CreatureVector* creatures = tile->getCreatures()) {
 			for (int32_t i = creatures->size(); --i >= 0;) {
-				const auto& player = (*creatures)[i]->getPlayer();
+				const auto& player = (*creatures)[i]->asPlayer();
 				if (player && !isInvited(player)) {
 					kickPlayer(nullptr, player);
 				}

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -60,7 +60,7 @@ ReturnValue HouseTile::queryAdd(int32_t index, const std::shared_ptr<const Thing
                                 uint32_t flags, const std::shared_ptr<Creature>& actor /* = nullptr*/) const
 {
 	if (const auto& creature = thing->asCreature()) {
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			const auto& house = getHouse();
 			if (!house) {
 				return RETURNVALUE_NOTPOSSIBLE;
@@ -83,7 +83,7 @@ ReturnValue HouseTile::queryAdd(int32_t index, const std::shared_ptr<const Thing
 				return RETURNVALUE_NOTPOSSIBLE;
 			}
 
-			if (!house->isInvited(actor->getPlayer())) {
+			if (!house->isInvited(actor->asPlayer())) {
 				return RETURNVALUE_PLAYERISNOTINVITED;
 			}
 		}
@@ -95,7 +95,7 @@ std::shared_ptr<Thing> HouseTile::queryDestination(int32_t& index, const std::sh
                                                    std::shared_ptr<Item>& destItem, uint32_t& flags)
 {
 	if (const auto& creature = thing->asCreature()) {
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			const auto& house = getHouse();
 			if (house && !house->isInvited(player)) {
 				const Position& entryPos = house->getEntryPosition();
@@ -135,7 +135,7 @@ ReturnValue HouseTile::queryRemove(const std::shared_ptr<const Thing>& thing, ui
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
-		if (!house->isInvited(actor->getPlayer())) {
+		if (!house->isInvited(actor->asPlayer())) {
 			return RETURNVALUE_PLAYERISNOTINVITED;
 		}
 	}

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -334,7 +334,7 @@ std::shared_ptr<const Player> Item::getHoldingPlayer() const
 	}
 
 	if (const auto& creature = topParent->asCreature()) {
-		return creature->getPlayer();
+		return creature->asPlayer();
 	}
 	return nullptr;
 }

--- a/src/lua/meta.cpp
+++ b/src/lua/meta.cpp
@@ -64,7 +64,7 @@ void setItemMetatable(lua_State* L, int32_t index, const std::shared_ptr<const I
 
 void setCreatureMetatable(lua_State* L, int32_t index, const std::shared_ptr<const Creature>& creature)
 {
-	if (creature->getPlayer()) {
+	if (creature->asPlayer()) {
 		luaL_getmetatable(L, "Player");
 	} else if (creature->getMonster()) {
 		luaL_getmetatable(L, "Monster");

--- a/src/lua/modules/creature.cpp
+++ b/src/lua/modules/creature.cpp
@@ -529,7 +529,7 @@ int luaCreatureSetHealth(lua_State* L)
 	creature->setHealth(std::min<int32_t>(tfs::lua::getNumber<uint32_t>(L, 2), creature->getMaxHealth()));
 	g_game.addCreatureHealth(creature);
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		player->sendStats();
 	}
 	tfs::lua::pushBoolean(L, true);
@@ -580,7 +580,7 @@ int luaCreatureSetMaxHealth(lua_State* L)
 	creature->setHealth(std::min<int32_t>(creature->getHealth(), creature->getMaxHealth()));
 	g_game.addCreatureHealth(creature);
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		player->sendStats();
 	}
 	tfs::lua::pushBoolean(L, true);
@@ -783,7 +783,7 @@ int luaCreatureRemove(lua_State* L)
 		return 1;
 	}
 
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		player->kickPlayer(true);
 	} else {
 		g_game.removeCreature(creature);

--- a/src/lua/modules/player.cpp
+++ b/src/lua/modules/player.cpp
@@ -136,7 +136,7 @@ int luaPlayerIsPlayer(lua_State* L)
 {
 	// player:isPlayer()
 	if (const auto& creature = tfs::lua::getCreature(L, 1)) {
-		tfs::lua::pushBoolean(L, creature->getPlayer() != nullptr);
+		tfs::lua::pushBoolean(L, creature->asPlayer() != nullptr);
 	} else {
 		lua_pushnil(L);
 	}
@@ -2042,7 +2042,7 @@ int luaPlayerSetGhostMode(lua_State* L)
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, true, true);
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 
 		const auto& spectatorPlayer = std::static_pointer_cast<Player>(spectator);
 		if (spectatorPlayer != player && !spectatorPlayer->isAccessPlayer()) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -200,7 +200,7 @@ void Map::removeTile(uint16_t x, uint16_t y, uint8_t z)
 	if (const auto& tile = floor->tiles[x & FLOOR_MASK][y & FLOOR_MASK]) {
 		if (const CreatureVector* creatures = tile->getCreatures()) {
 			for (int32_t i = creatures->size(); --i >= 0;) {
-				if (const auto& player = (*creatures)[i]->getPlayer()) {
+				if (const auto& player = (*creatures)[i]->asPlayer()) {
 					g_game.internalTeleport(player, player->getTown()->templePosition, false, FLAG_NOLIMIT);
 				} else {
 					g_game.removeCreature((*creatures)[i]);
@@ -307,7 +307,7 @@ void Map::moveCreature(const std::shared_ptr<Creature>& creature, const std::sha
 
 	std::vector<int32_t> oldStackPosVector;
 	for (const auto& spectator : spectators) {
-		if (const auto& tmpPlayer = spectator->getPlayer()) {
+		if (const auto& tmpPlayer = spectator->asPlayer()) {
 			if (tmpPlayer->canSeeCreature(creature)) {
 				oldStackPosVector.push_back(oldTile->getClientIndexOfCreature(tmpPlayer, creature));
 			} else {
@@ -348,7 +348,7 @@ void Map::moveCreature(const std::shared_ptr<Creature>& creature, const std::sha
 	// send to client
 	size_t i = 0;
 	for (const auto& spectator : spectators) {
-		if (const auto& tmpPlayer = spectator->getPlayer()) {
+		if (const auto& tmpPlayer = spectator->asPlayer()) {
 			// Use the correct stackpos
 			int32_t stackpos = oldStackPosVector[i++];
 			if (stackpos != -1) {
@@ -399,7 +399,7 @@ void Map::getSpectatorsInternal(SpectatorVec& spectators, const Position& center
 		for (int_fast32_t nx = startx1; nx <= endx2; nx += FLOOR_SIZE) {
 			if (leafE) {
 				for (auto&& creature : leafE->creatures | std::views::filter([onlyPlayers](const auto& creature) {
-					                       return !onlyPlayers || creature->getPlayer() != nullptr;
+					                       return !onlyPlayers || creature->asPlayer() != nullptr;
 				                       })) {
 					const Position& cpos = creature->getPosition();
 					if (minRangeZ > cpos.z || maxRangeZ < cpos.z) {
@@ -472,7 +472,7 @@ void Map::getSpectators(SpectatorVec& spectators, const Position& centerPos, boo
 				} else {
 					const SpectatorVec& cachedSpectators = it->second;
 					for (const auto& spectator : cachedSpectators) {
-						if (spectator->getPlayer()) {
+						if (spectator->asPlayer()) {
 							spectators.emplace(spectator);
 						}
 					}
@@ -691,7 +691,7 @@ const std::shared_ptr<Tile> Map::canWalkTo(const std::shared_ptr<const Creature>
 		}
 
 		uint32_t flags = FLAG_PATHFINDING;
-		if (!creature->getPlayer()) {
+		if (!creature->asPlayer()) {
 			flags |= FLAG_IGNOREFIELDDAMAGE;
 		}
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -377,17 +377,17 @@ void Monster::onCreatureEnter(const std::shared_ptr<Creature>& creature)
 
 bool Monster::isFriend(const std::shared_ptr<const Creature>& creature) const
 {
-	if (isSummon() && getMaster()->getPlayer()) {
-		const auto& masterPlayer = getMaster()->getPlayer();
+	if (isSummon() && getMaster()->asPlayer()) {
+		const auto& masterPlayer = getMaster()->asPlayer();
 		std::shared_ptr<const Player> tmpPlayer = nullptr;
 
-		if (creature->getPlayer()) {
-			tmpPlayer = creature->getPlayer();
+		if (creature->asPlayer()) {
+			tmpPlayer = creature->asPlayer();
 		} else {
 			const auto& creatureMaster = creature->getMaster();
 
-			if (creatureMaster && creatureMaster->getPlayer()) {
-				tmpPlayer = creatureMaster->getPlayer();
+			if (creatureMaster && creatureMaster->asPlayer()) {
+				tmpPlayer = creatureMaster->asPlayer();
 			}
 		}
 
@@ -403,13 +403,13 @@ bool Monster::isFriend(const std::shared_ptr<const Creature>& creature) const
 
 bool Monster::isOpponent(const std::shared_ptr<const Creature>& creature) const
 {
-	if (isSummon() && getMaster()->getPlayer()) {
+	if (isSummon() && getMaster()->asPlayer()) {
 		if (creature != getMaster()) {
 			return true;
 		}
 	} else {
-		if ((creature->getPlayer() && !creature->getPlayer()->hasFlag(PlayerFlag_IgnoredByMonsters)) ||
-		    (creature->getMaster() && creature->getMaster()->getPlayer())) {
+		if ((creature->asPlayer() && !creature->asPlayer()->hasFlag(PlayerFlag_IgnoredByMonsters)) ||
+		    (creature->getMaster() && creature->getMaster()->asPlayer())) {
 			return true;
 		}
 	}
@@ -778,7 +778,7 @@ void Monster::onAttacking(uint32_t interval)
 		return;
 	}
 
-	if (const auto& player = attackedCreature->getPlayer()) {
+	if (const auto& player = attackedCreature->asPlayer()) {
 		player->addInFightTicks();
 	}
 
@@ -1164,7 +1164,7 @@ bool Monster::getNextStep(Direction& direction, uint32_t& flags)
 			result = getRandomStep(getPosition(), direction);
 		}
 	} else if ((isSummon() && isMasterInRange) || getFollowCreature() || walkingToSpawn) {
-		if (!hasFollowPath && getMaster() && !getMaster()->getPlayer()) {
+		if (!hasFollowPath && getMaster() && !getMaster()->asPlayer()) {
 			randomStepping = true;
 			result = getRandomStep(getPosition(), direction);
 		} else {
@@ -1845,11 +1845,11 @@ std::shared_ptr<Item> Monster::getCorpse(const std::shared_ptr<Creature>& lastHi
 	}
 
 	if (mostDamageCreature) {
-		if (mostDamageCreature->getPlayer()) {
+		if (mostDamageCreature->asPlayer()) {
 			corpse->setCorpseOwner(mostDamageCreature->getID());
 		} else {
 			const auto& mostDamageCreatureMaster = mostDamageCreature->getMaster();
-			if (mostDamageCreatureMaster && mostDamageCreatureMaster->getPlayer()) {
+			if (mostDamageCreatureMaster && mostDamageCreatureMaster->asPlayer()) {
 				corpse->setCorpseOwner(mostDamageCreatureMaster->getID());
 			}
 		}

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -80,7 +80,7 @@ void Npc::reload()
 	SpectatorVec players;
 	g_game.map.getSpectators(players, getPosition(), true, true);
 	for (const auto& player : players) {
-		assert(player->getPlayer() != nullptr);
+		assert(player->asPlayer() != nullptr);
 		spectators.insert(std::static_pointer_cast<Player>(player));
 	}
 
@@ -236,7 +236,7 @@ void Npc::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, Magi
 		SpectatorVec players;
 		g_game.map.getSpectators(players, getPosition(), true, true);
 		for (const auto& player : players) {
-			assert(player->getPlayer() != nullptr);
+			assert(player->asPlayer() != nullptr);
 			spectators.insert(std::static_pointer_cast<Player>(player));
 		}
 
@@ -250,7 +250,7 @@ void Npc::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, Magi
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureAppear(creature);
 		}
-	} else if (const auto& player = creature->getPlayer()) {
+	} else if (const auto& player = creature->asPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureAppear(creature);
 		}
@@ -269,7 +269,7 @@ void Npc::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLog
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureDisappear(creature);
 		}
-	} else if (const auto& player = creature->getPlayer()) {
+	} else if (const auto& player = creature->asPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureDisappear(creature);
 		}
@@ -285,13 +285,13 @@ void Npc::onCreatureMove(const std::shared_ptr<Creature>& creature, const std::s
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
-	if (creature.get() == this || creature->getPlayer()) {
+	if (creature.get() == this || creature->asPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureMove(creature, oldPos, newPos);
 		}
 
 		if (creature.get() != this) {
-			const auto& player = creature->getPlayer();
+			const auto& player = creature->asPlayer();
 
 			// if player is now in range, add to spectators list, otherwise erase
 			if (player->canSee(getPosition())) {
@@ -312,7 +312,7 @@ void Npc::onCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses 
 	}
 
 	// only players for script events
-	if (const auto& player = creature->getPlayer()) {
+	if (const auto& player = creature->asPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureSay(player, type, text);
 		}

--- a/src/player.h
+++ b/src/player.h
@@ -105,8 +105,8 @@ public:
 	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
 	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	std::shared_ptr<Player> getPlayer() override { return std::static_pointer_cast<Player>(shared_from_this()); }
-	std::shared_ptr<const Player> getPlayer() const override
+	std::shared_ptr<Player> asPlayer() override { return std::static_pointer_cast<Player>(shared_from_this()); }
+	std::shared_ptr<const Player> asPlayer() const override
 	{
 		return std::static_pointer_cast<const Player>(shared_from_this());
 	}
@@ -585,7 +585,7 @@ public:
 	                     const std::shared_ptr<const Item>& item)
 	{
 		if (client) {
-			int32_t stackpos = tile->getStackposOfItem(getPlayer(), item);
+			int32_t stackpos = tile->getStackposOfItem(asPlayer(), item);
 			if (stackpos != -1) {
 				client->sendAddTileItem(pos, stackpos, item);
 			}
@@ -595,7 +595,7 @@ public:
 	                        const std::shared_ptr<const Item>& item)
 	{
 		if (client) {
-			int32_t stackpos = tile->getStackposOfItem(getPlayer(), item);
+			int32_t stackpos = tile->getStackposOfItem(asPlayer(), item);
 			if (stackpos != -1) {
 				client->sendUpdateTileItem(pos, stackpos, item);
 			}
@@ -610,9 +610,8 @@ public:
 	void sendUpdateTileCreature(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client) {
-			client->sendUpdateTileCreature(creature->getPosition(),
-			                               creature->getTile()->getClientIndexOfCreature(getPlayer(), creature),
-			                               creature);
+			client->sendUpdateTileCreature(
+			    creature->getPosition(), creature->getTile()->getClientIndexOfCreature(asPlayer(), creature), creature);
 		}
 	}
 	void sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos, int32_t stackpos)
@@ -650,7 +649,7 @@ public:
 	                     MagicEffectClasses magicEffect = CONST_ME_NONE)
 	{
 		if (client) {
-			client->sendAddCreature(creature, pos, creature->getTile()->getClientIndexOfCreature(getPlayer(), creature),
+			client->sendAddCreature(creature, pos, creature->getTile()->getClientIndexOfCreature(asPlayer(), creature),
 			                        magicEffect);
 		}
 	}
@@ -664,7 +663,7 @@ public:
 	void sendCreatureTurn(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client && canSeeCreature(creature)) {
-			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(getPlayer(), creature);
+			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(asPlayer(), creature);
 			if (stackpos != -1) {
 				client->sendCreatureTurn(creature, stackpos);
 			}
@@ -701,7 +700,7 @@ public:
 			return;
 		}
 
-		if (creature->getPlayer()) {
+		if (creature->asPlayer()) {
 			if (visible) {
 				client->sendCreatureOutfit(creature, creature->getCurrentOutfit());
 			} else {
@@ -711,7 +710,7 @@ public:
 		} else if (canSeeInvisibility()) {
 			client->sendCreatureOutfit(creature, creature->getCurrentOutfit());
 		} else {
-			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(getPlayer(), creature);
+			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(asPlayer(), creature);
 			if (stackpos == -1) {
 				return;
 			}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1626,7 +1626,7 @@ void ProtocolGame::sendCreatureShield(const std::shared_ptr<const Creature>& cre
 	NetworkMessage msg;
 	msg.addByte(0x91);
 	msg.add<uint32_t>(creature->getID());
-	msg.addByte(player->getPartyShield(creature->getPlayer()));
+	msg.addByte(player->getPartyShield(creature->asPlayer()));
 	writeToOutputBuffer(msg);
 }
 
@@ -2417,7 +2417,7 @@ void ProtocolGame::sendCreatureSay(const std::shared_ptr<const Creature>& creatu
 	msg.addByte(0x00); // "(Traded)" suffix after player name
 
 	// Add level only for players
-	if (const auto& speaker = creature->getPlayer()) {
+	if (const auto& speaker = creature->asPlayer()) {
 		msg.add<uint16_t>(speaker->getLevel());
 	} else {
 		msg.add<uint16_t>(0x00);
@@ -2450,7 +2450,7 @@ void ProtocolGame::sendToChannel(const std::shared_ptr<const Creature>& creature
 		msg.addByte(0x00); // "(Traded)" suffix after player name
 
 		// Add level only for players
-		if (const auto& speaker = creature->getPlayer()) {
+		if (const auto& speaker = creature->asPlayer()) {
 			msg.add<uint16_t>(speaker->getLevel());
 		} else {
 			msg.add<uint16_t>(0x00);
@@ -3377,7 +3377,7 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const std::shared_ptr<const 
 
 	if (creatureType == CREATURETYPE_MONSTER) {
 		if (const auto& master = creature->getMaster()) {
-			if (const auto& masterPlayer = master->getPlayer()) {
+			if (const auto& masterPlayer = master->asPlayer()) {
 				masterId = master->getID();
 				creatureType = CREATURETYPE_SUMMON_OWN;
 			}
@@ -3427,7 +3427,7 @@ void ProtocolGame::AddCreature(NetworkMessage& msg, const std::shared_ptr<const 
 
 	msg.addByte(player->getCombatSkull(creature));
 
-	const auto& otherPlayer = creature->getPlayer();
+	const auto& otherPlayer = creature->asPlayer();
 	msg.addByte(player->getPartyShield(otherPlayer));
 
 	if (!known) {

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -249,7 +249,7 @@ bool Spawn::findPlayer(const Position& pos)
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, pos, false, true);
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		if (!std::static_pointer_cast<Player>(spectator)->hasFlag(PlayerFlag_IgnoredByMonsters)) {
 			return true;
 		}

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -723,7 +723,7 @@ bool Spell::playerRuneSpellCheck(const std::shared_ptr<Player>& player, const Po
 	}
 
 	if (aggressive && needTarget && topVisibleCreature && player->hasSecureMode()) {
-		if (const auto& targetPlayer = topVisibleCreature->getPlayer()) {
+		if (const auto& targetPlayer = topVisibleCreature->asPlayer()) {
 			if (targetPlayer != player && player->getCombatSkull(targetPlayer) == SKULL_NONE &&
 			    !Combat::isInPvpZone(player, targetPlayer)) {
 				player->sendCancelMessage(RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -242,7 +242,7 @@ std::shared_ptr<Creature> Tile::getTopVisibleCreature(const std::shared_ptr<cons
 		} else {
 			for (const auto& tileCreature : *creatures) {
 				if (!tileCreature->isInvisible()) {
-					const auto& player = tileCreature->getPlayer();
+					const auto& player = tileCreature->asPlayer();
 					if (!player || !player->isInGhostMode()) {
 						return tileCreature;
 					}
@@ -266,7 +266,7 @@ std::shared_ptr<const Creature> Tile::getBottomVisibleCreature(const std::shared
 		} else {
 			for (const auto& tileCreature : *creatures | std::views::reverse) {
 				if (!tileCreature->isInvisible()) {
-					const auto& player = tileCreature->getPlayer();
+					const auto& player = tileCreature->asPlayer();
 					if (!player || !player->isInGhostMode()) {
 						return tileCreature;
 					}
@@ -358,7 +358,7 @@ void Tile::onAddTileItem(const std::shared_ptr<Item>& item)
 
 	// send to client
 	for (const auto& spectator : spectators) {
-		if (const auto& spectatorPlayer = spectator->getPlayer()) {
+		if (const auto& spectatorPlayer = spectator->asPlayer()) {
 			spectatorPlayer->sendAddTileItem(asTile(), tilePos, item);
 		}
 	}
@@ -397,7 +397,7 @@ void Tile::onUpdateTileItem(const std::shared_ptr<Item>& oldItem, const ItemType
 
 	// send to client
 	for (const auto& spectator : spectators) {
-		if (const auto& spectatorPlayer = spectator->getPlayer()) {
+		if (const auto& spectatorPlayer = spectator->asPlayer()) {
 			spectatorPlayer->sendUpdateTileItem(asTile(), tilePos, newItem);
 		}
 	}
@@ -425,7 +425,7 @@ void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<in
 	// send to client
 	size_t i = 0;
 	for (const auto& spectator : spectators) {
-		if (const auto& spectatorPlayer = spectator->getPlayer()) {
+		if (const auto& spectatorPlayer = spectator->asPlayer()) {
 			spectatorPlayer->sendRemoveTileThing(tilePos, oldStackPosVector[i++]);
 		}
 	}
@@ -480,7 +480,7 @@ ReturnValue Tile::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, u
 			if (const CreatureVector* creatures = getCreatures()) {
 				if (monster->canPushCreatures() && !monster->isSummon()) {
 					for (const auto& tileCreature : *creatures) {
-						if (const auto& tilePlayer = tileCreature->getPlayer()) {
+						if (const auto& tilePlayer = tileCreature->asPlayer()) {
 							if (tilePlayer->isInGhostMode()) {
 								continue;
 							}
@@ -488,7 +488,7 @@ ReturnValue Tile::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, u
 
 						const auto& creatureMonster = tileCreature->getMonster();
 						if (!creatureMonster || !tileCreature->isPushable() ||
-						    (creatureMonster->isSummon() && creatureMonster->getMaster()->getPlayer())) {
+						    (creatureMonster->isSummon() && creatureMonster->getMaster()->asPlayer())) {
 							return RETURNVALUE_NOTPOSSIBLE;
 						}
 					}
@@ -542,7 +542,7 @@ ReturnValue Tile::queryAdd(int32_t, const std::shared_ptr<const Thing>& thing, u
 		}
 
 		const CreatureVector* creatures = getCreatures();
-		if (const auto& player = creature->getPlayer()) {
+		if (const auto& player = creature->asPlayer()) {
 			if (creatures && !creatures->empty() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags) &&
 			    !player->isAccessPlayer()) {
 				for (const auto& tileCreature : *creatures) {
@@ -818,7 +818,7 @@ void Tile::addThing(int32_t, const std::shared_ptr<Thing>& thing)
 {
 	if (const auto& creature = thing->asCreature()) {
 		g_game.map.clearSpectatorCache();
-		if (creature->getPlayer()) {
+		if (creature->asPlayer()) {
 			g_game.map.clearPlayersSpectatorCache();
 		}
 
@@ -1013,7 +1013,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 			auto it = std::find(creatures->begin(), creatures->end(), thing);
 			if (it != creatures->end()) {
 				g_game.map.clearSpectatorCache();
-				if (creature->getPlayer()) {
+				if (creature->asPlayer()) {
 					g_game.map.clearPlayersSpectatorCache();
 				}
 
@@ -1060,7 +1060,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 		SpectatorVec spectators;
 		g_game.map.getSpectators(spectators, getPosition(), true);
 		for (const auto& spectator : spectators) {
-			if (const auto& spectatorPlayer = spectator->getPlayer()) {
+			if (const auto& spectatorPlayer = spectator->asPlayer()) {
 				oldStackPosVector.push_back(getStackposOfItem(spectatorPlayer, item));
 			}
 		}
@@ -1081,7 +1081,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 			SpectatorVec spectators;
 			g_game.map.getSpectators(spectators, getPosition(), true);
 			for (const auto& spectator : spectators) {
-				if (const auto& spectatorPlayer = spectator->getPlayer()) {
+				if (const auto& spectatorPlayer = spectator->asPlayer()) {
 					oldStackPosVector.push_back(getStackposOfItem(spectatorPlayer, item));
 				}
 			}
@@ -1288,7 +1288,7 @@ void Tile::postAddNotification(const std::shared_ptr<Thing>& thing, const std::s
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), true, true);
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 		std::static_pointer_cast<Player>(spectator)->postAddNotification(thing, oldParent, index, LINK_NEAR);
 	}
 
@@ -1325,7 +1325,7 @@ void Tile::postRemoveNotification(const std::shared_ptr<Thing>& thing, const std
 	g_game.map.getSpectators(spectators, tilePos, true, true);
 
 	for (const auto& spectator : spectators) {
-		assert(spectator->getPlayer() != nullptr);
+		assert(spectator->asPlayer() != nullptr);
 
 		if (thingCount > TILE_UPDATE_THRESHOLD) {
 			// If the tile contains more than the defined threshold of things,
@@ -1350,7 +1350,7 @@ void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 
 	if (const auto& creature = thing->asCreature()) {
 		g_game.map.clearSpectatorCache();
-		if (creature->getPlayer()) {
+		if (creature->asPlayer()) {
 			g_game.map.clearPlayersSpectatorCache();
 		}
 

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -734,7 +734,7 @@ int32_t WeaponDistance::getElementDamage(const std::shared_ptr<const Player>& pl
 	int32_t minValue = 0;
 	int32_t maxValue = Weapons::getMaxWeaponDamage(player->getLevel(), attackSkill, attackValue, attackFactor);
 	if (target) {
-		if (target->getPlayer()) {
+		if (target->asPlayer()) {
 			minValue = static_cast<int32_t>(std::ceil(player->getLevel() * 0.1));
 		} else {
 			minValue = static_cast<int32_t>(std::ceil(player->getLevel() * 0.2));
@@ -768,7 +768,7 @@ int32_t WeaponDistance::getWeaponDamage(const std::shared_ptr<const Player>& pla
 
 	int32_t minValue;
 	if (target) {
-		if (target->getPlayer()) {
+		if (target->asPlayer()) {
 			minValue = static_cast<int32_t>(std::ceil(player->getLevel() * 0.1));
 		} else {
 			minValue = static_cast<int32_t>(std::ceil(player->getLevel() * 0.2));


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Replaces the `getPlayer` accessor with a more explicit `asPlayer` method in the `Creature` hierarchy.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
