### PR TITLE
fix(lua): move timer events to script environment

### DIFF
--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -41,9 +41,6 @@ LuaEnvironment g_luaEnvironment;
 
 namespace {
 
-std::unordered_map<uint32_t, LuaTimerEventDesc> timerEvents;
-uint32_t lastEventTimerId = 1;
-
 bool getArea(lua_State* L, std::vector<uint32_t>& vec, uint32_t& rows)
 {
 	lua_pushnil(L);
@@ -441,11 +438,11 @@ int luaAddEvent(lua_State* L)
 	eventDesc.function = luaL_ref(L, LUA_REGISTRYINDEX);
 	eventDesc.scriptId = tfs::lua::getScriptEnv()->getScriptId();
 
-	auto& lastTimerEventId = lastEventTimerId;
+	auto& lastTimerEventId = g_luaEnvironment.lastEventTimerId;
 	eventDesc.eventId = g_scheduler.addEvent(
 	    createSchedulerTask(delay, [=]() { g_luaEnvironment.executeTimerEvent(lastTimerEventId); }));
 
-	timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
+	g_luaEnvironment.timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
 	tfs::lua::pushNumber(L, lastTimerEventId++);
 	return 1;
 }
@@ -455,7 +452,7 @@ int luaStopEvent(lua_State* L)
 	// stopEvent(eventid)
 	uint32_t eventId = tfs::lua::getNumber<uint32_t>(L, 1);
 
-	auto& events = timerEvents;
+	auto& events = g_luaEnvironment.timerEvents;
 	auto it = events.find(eventId);
 	if (it == events.end()) {
 		tfs::lua::pushBoolean(L, false);

--- a/src/lua/script.h
+++ b/src/lua/script.h
@@ -117,6 +117,9 @@ public:
 
 	void executeTimerEvent(uint32_t eventIndex);
 
+	std::unordered_map<uint32_t, LuaTimerEventDesc> timerEvents;
+	uint32_t lastEventTimerId = 1;
+
 private:
 	std::unordered_map<uint32_t, Combat_ptr> combatMap;
 	std::unordered_map<uint32_t, AreaCombat*> areaMap;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Move Lua timer events back to the script environment to ensure proper lifetime management and prevent invalid access during Lua state shutdown. This fixes crashes caused by timer callbacks referencing destroyed Lua states and restores the expected ownership model, where timers are tied to the environment that created them.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
