### PR TITLE
refactor(events): prefix event names with class type

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -1017,43 +1017,42 @@ Weapon = {}
 
 ---@class Event
 ---@field register fun(self:Event, triggerIndex?:integer):boolean
----@field onChangeOutfit fun(creature:Creature, outfit: Outfit_t):boolean
----@field onAreaCombat fun(creature:Creature, tile:Tile, aggresive:boolean): integer
----@field onTargetCombat fun(creature:Creature, target:Creature): integer
----@field onHear fun(creature:Creature, speaker:Creature, words:string, type:integer):nil
----@field onChangeZone fun(creature:Creature, fromZone:integer, toZone:integer):nil
----@field onUpdateStorage fun(creature:Creature, key:integer, value?:integer, oldValue?:integer, isSpawn?:boolean):nil
----@field onJoin fun(party:Party, player:Player):boolean
----@field onLeave fun(party:Party, player:Player):boolean
----@field onDisband fun(party:Party):boolean
----@field onShareExperience fun(party:Party, exp:integer, rawExp:integer):integer
----@field onInvite fun(party:Party, player:Player):boolean
----@field onRevokeInvitation fun(party:Party, player:Player):boolean
----@field onPassLeadership fun(party:Party, player:Player):boolean
----@field onLook fun(player:Player, thing:Thing, position:Position, distance:integer):nil
----@field onLookInBattleList fun(player:Player, creature:Creature, distance:integer):nil
----@field onLookInTrade fun(player:Player, partner:Player, item:Item, distance:integer):nil
----@field onLookInShop fun(player:Player, itemType:ItemType, count:integer):nil
----@field onMoveItem fun(player:Player, item:Item, count:integer, fromPosition:Position, toPosition:Position, fromThing?:Thing, toThing?:Thing):integer
----@field onItemMoved fun(player:Player, item:Item, count:integer, fromPosition:Position, toPosition:Position, fromThing?:Thing, toThing?:Thing):nil
----@field onMoveCreature fun(player:Player, creature:Creature, fromPosition:Position, toPosition:Position):boolean
----@field onReportRuleViolation fun(player:Player, targetName:string, reportType:integer, reportReason:integer, comment:string, translation:string):nil
----@field onTurn fun(player:Player, direction:integer):boolean
----@field onTradeRequest fun(player:Player, target:Player, item:Item):boolean
----@field onTradeAccept fun(player:Player, target:Player, item:Item, targetItem:Item):boolean
----@field onTradeCompleted fun(player:Player, target:Player, item:Item, targetItem:Item, isSuccess:boolean):nil
----@field onPodiumRequest fun(player:Player, item:Item):nil
----@field onPodiumEdit fun(player:Player, item:Item, outfit:Outfit, direction:integer, isVisible:boolean):nil
----@field onGainExperience fun(player:Player, source?:Creature, exp:integer, rawExp:integer, sendText:boolean):integer
----@field onLoseExperience fun(player:Player, exp:integer):integer
----@field onGainSkillTries fun(player:Player, skill:integer, tries:integer, artificial?:boolean):integer
----@field onNetworkMessage fun(player:Player, recvByte:integer, msg:NetworkMessage):nil
----@field onUpdateInventory fun(player:Player, item:Item, slot:integer, equip?:boolean):nil
----@field onRotateItem fun(player:Player, item:Item)
----@field onSpellCheck fun(player:Player, spell:Spell):boolean
----@field onDropLoot fun(monster:Monster, corpse?:Container):nil
----@field onSpawn fun(monster:Monster, position:Position, startup:boolean, artificial:boolean):nil
----@field onReload fun(player:Player, reloadType:integer):nil
+---@field onCreatureChangeOutfit fun(creature:Creature, outfit: Outfit_t):boolean
+---@field onCreatureAreaCombat fun(creature:Creature, tile:Tile, aggresive:boolean): integer
+---@field onCreatureTargetCombat fun(creature:Creature, target:Creature): integer
+---@field onCreatureHear fun(creature:Creature, speaker:Creature, words:string, type:integer):nil
+---@field onCreatureChangeZone fun(creature:Creature, fromZone:integer, toZone:integer):nil
+---@field onCreatureUpdateStorage fun(creature:Creature, key:integer, value?:integer, oldValue?:integer, isSpawn?:boolean):nil
+---@field onPartyJoin fun(party:Party, player:Player):boolean
+---@field onPartyLeave fun(party:Party, player:Player):boolean
+---@field onPartyDisband fun(party:Party):boolean
+---@field onPartyShareExperience fun(party:Party, exp:integer, rawExp:integer):integer
+---@field onPartyInvite fun(party:Party, player:Player):boolean
+---@field onPartyRevokeInvitation fun(party:Party, player:Player):boolean
+---@field onPartyPassLeadership fun(party:Party, player:Player):boolean
+---@field onPlayerLook fun(player:Player, thing:Thing, position:Position, distance:integer):nil
+---@field onPlayerLookInBattleList fun(player:Player, creature:Creature, distance:integer):nil
+---@field onPlayerLookInTrade fun(player:Player, partner:Player, item:Item, distance:integer):nil
+---@field onPlayerLookInShop fun(player:Player, itemType:ItemType, count:integer):nil
+---@field onPlayerMoveItem fun(player:Player, item:Item, count:integer, fromPosition:Position, toPosition:Position, fromThing?:Thing, toThing?:Thing):integer
+---@field onPlayerItemMoved fun(player:Player, item:Item, count:integer, fromPosition:Position, toPosition:Position, fromThing?:Thing, toThing?:Thing):nil
+---@field onPlayerMoveCreature fun(player:Player, creature:Creature, fromPosition:Position, toPosition:Position):boolean
+---@field onPlayerReportRuleViolation fun(player:Player, targetName:string, reportType:integer, reportReason:integer, comment:string, translation:string):nil
+---@field onPlayerTurn fun(player:Player, direction:integer):boolean
+---@field onPlayerTradeRequest fun(player:Player, target:Player, item:Item):boolean
+---@field onPlayerTradeAccept fun(player:Player, target:Player, item:Item, targetItem:Item):boolean
+---@field onPlayerTradeCompleted fun(player:Player, target:Player, item:Item, targetItem:Item, isSuccess:boolean):nil
+---@field onPlayerPodiumRequest fun(player:Player, item:Item):nil
+---@field onPlayerPodiumEdit fun(player:Player, item:Item, outfit:Outfit, direction:integer, isVisible:boolean):nil
+---@field onPlayerGainExperience fun(player:Player, source?:Creature, exp:integer, rawExp:integer, sendText:boolean):integer
+---@field onPlayerLoseExperience fun(player:Player, exp:integer):integer
+---@field onPlayerGainSkillTries fun(player:Player, skill:integer, tries:integer, artificial?:boolean):integer
+---@field onPlayerNetworkMessage fun(player:Player, recvByte:integer, msg:NetworkMessage):nil
+---@field onPlayerUpdateInventory fun(player:Player, item:Item, slot:integer, equip?:boolean):nil
+---@field onPlayerRotateItem fun(player:Player, item:Item)
+---@field onPlayerSpellCheck fun(player:Player, spell:Spell):boolean
+---@field onMonsterDropLoot fun(monster:Monster, corpse?:Container):nil
+---@field onMonsterSpawn fun(monster:Monster, position:Position, startup:boolean, artificial:boolean):nil
 ---@operator call():Event
 Event = {}
 EventCallback = Event()

--- a/data/scripts/events/creature.lua
+++ b/data/scripts/events/creature.lua
@@ -1,41 +1,41 @@
 function Creature:onChangeOutfit(outfit)
-	if Event.onChangeMount and not Event.onChangeMount(self, outfit.lookMount) then
+	if Event.onCreatureChangeMount and not Event.onCreatureChangeMount(self, outfit.lookMount) then
 		return false
 	end
-	if Event.onChangeOutfit and not Event.onChangeOutfit(self, outfit) then
+	if Event.onCreatureChangeOutfit and not Event.onCreatureChangeOutfit(self, outfit) then
 		return false
 	end
 	return true
 end
 
 function Creature:onAreaCombat(tile, isAggressive)
-	if Event.onAreaCombat then
-		return Event.onAreaCombat(self, tile, isAggressive)
+	if Event.onCreatureAreaCombat then
+		return Event.onCreatureAreaCombat(self, tile, isAggressive)
 	end
 	return RETURNVALUE_NOERROR
 end
 
 function Creature:onTargetCombat(target)
-	if Event.onTargetCombat then
-		return Event.onTargetCombat(self, target)
+	if Event.onCreatureTargetCombat then
+		return Event.onCreatureTargetCombat(self, target)
 	end
 	return RETURNVALUE_NOERROR
 end
 
 function Creature:onHear(speaker, words, type)
-	if Event.onHear then
-		Event.onHear(self, speaker, words, type)
+	if Event.onCreatureHear then
+		Event.onCreatureHear(self, speaker, words, type)
 	end
 end
 
 function Creature:onChangeZone(fromZone, toZone)
-	if Event.onChangeZone then
-		Event.onChangeZone(self, fromZone, toZone)
+	if Event.onCreatureChangeZone then
+		Event.onCreatureChangeZone(self, fromZone, toZone)
 	end
 end
 
 function Creature:onUpdateStorage(key, value, oldValue, isSpawn)
-	if Event.onUpdateStorage then
-		Event.onUpdateStorage(self, key, value, oldValue, isSpawn)
+	if Event.onCreatureUpdateStorage then
+		Event.onCreatureUpdateStorage(self, key, value, oldValue, isSpawn)
 	end
 end

--- a/data/scripts/events/monster.lua
+++ b/data/scripts/events/monster.lua
@@ -1,7 +1,8 @@
 function Monster:onDropLoot(corpse)
-	if Event.onDropLoot then
-		Event.onDropLoot(self, corpse)
+	if Event.onMonsterDropLoot then
+		Event.onMonsterDropLoot(self, corpse)
 	end
+
 	local player = Player(corpse:getCorpseOwner())
 	if player then
 		player:updateKillTracker(self, corpse)
@@ -9,8 +10,8 @@ function Monster:onDropLoot(corpse)
 end
 
 function Monster:onSpawn(position, startup, artificial)
-	if Event.onSpawn then
-		return Event.onSpawn(self, position, startup, artificial)
+	if Event.onMonsterSpawn then
+		return Event.onMonsterSpawn(self, position, startup, artificial)
 	end
 	return true
 end

--- a/data/scripts/events/monster/default_onDropLoot.lua
+++ b/data/scripts/events/monster/default_onDropLoot.lua
@@ -1,6 +1,6 @@
 local event = Event()
 
-event.onDropLoot = function(self, corpse)
+event.onMonsterDropLoot = function(self, corpse)
 	if configManager.getNumber(configKeys.RATE_LOOT) == 0 then
 		return
 	end

--- a/data/scripts/events/party.lua
+++ b/data/scripts/events/party.lua
@@ -1,41 +1,41 @@
 function Party:onJoin(player)
-	if Event.onJoin then
-		return Event.onJoin(self, player)
+	if Event.onPartyJoin then
+		return Event.onPartyJoin(self, player)
 	end
 	return true
 end
 
 function Party:onLeave(player)
-	if Event.onLeave then
-		return Event.onLeave(self, player)
+	if Event.onPartyLeave then
+		return Event.onPartyLeave(self, player)
 	end
 	return true
 end
 
 function Party:onDisband()
-	if Event.onDisband then
-		return Event.onDisband(self)
+	if Event.onPartyDisband then
+		return Event.onPartyDisband(self)
 	end
 	return true
 end
 
 function Party:onInvite(player)
-	if Event.onInvite then
-		return Event.onInvite(self, player)
+	if Event.onPartyInvite then
+		return Event.onPartyInvite(self, player)
 	end
 	return true
 end
 
 function Party:onRevokeInvitation(player)
-	if Event.onRevokeInvitation then
-		return Event.onRevokeInvitation(self, player)
+	if Event.onPartyRevokeInvitation then
+		return Event.onPartyRevokeInvitation(self, player)
 	end
 	return true
 end
 
 function Party:onPassLeadership(player)
-	if Event.onPassLeadership then
-		return Event.onPassLeadership(self, player)
+	if Event.onPartyPassLeadership then
+		return Event.onPartyPassLeadership(self, player)
 	end
 	return true
 end
@@ -63,5 +63,8 @@ function Party:onShareExperience(exp)
 	end
 
 	exp = math.ceil((exp * sharedExperienceMultiplier) / (#self:getMembers() + 1))
-	return Event.onShareExperience and Event.onShareExperience(self, exp, rawExp) or exp
+	if Event.onPartyShareExperience then
+		return Event.onPartyShareExperience(self, exp, rawExp)
+	end
+	return exp
 end

--- a/data/scripts/events/player.lua
+++ b/data/scripts/events/player.lua
@@ -1,98 +1,97 @@
 function Player:onBrowseField(position)
-	if Event.onBrowseField then
-		return Event.onBrowseField(self, position)
+	if Event.onPlayerBrowseField then
+		return Event.onPlayerBrowseField(self, position)
 	end
 	return true
 end
 
 function Player:onLook(thing, position, distance)
-	if Event.onLook then
-		Event.onLook(self, thing, position, distance)
+	if Event.onPlayerLook then
+		Event.onPlayerLook(self, thing, position, distance)
 	end
 end
 
 function Player:onLookInBattleList(creature, distance)
-	if Event.onLookInBattleList then
-		Event.onLookInBattleList(self, creature, distance)
+	if Event.onPlayerLookInBattleList then
+		Event.onPlayerLookInBattleList(self, creature, distance)
 	end
 end
 
 function Player:onLookInTrade(partner, item, distance)
-	if Event.onLookInTrade then
-		Event.onLookInTrade(self, partner, item, distance)
+	if Event.onPlayerLookInTrade then
+		Event.onPlayerLookInTrade(self, partner, item, distance)
 	end
 end
 
 function Player:onLookInShop(itemType, count)
-	if Event.onLookInShop then
-		Event.onLookInShop(self, itemType, count)
+	if Event.onPlayerLookInShop then
+		Event.onPlayerLookInShop(self, itemType, count)
 	end
 end
 
 function Player:onLookInMarket(itemType)
-	if Event.onLookInMarket then
-		Event.onLookInMarket(self, itemType)
+	if Event.onPlayerLookInMarket then
+		Event.onPlayerLookInMarket(self, itemType)
 	end
 end
 
 function Player:onMoveItem(item, count, fromPosition, toPosition, fromThing, toThing)
-	if Event.onMoveItem then
-		return Event.onMoveItem(self, item, count, fromPosition, toPosition, fromThing, toThing)
+	if Event.onPlayerMoveItem then
+		return Event.onPlayerMoveItem(self, item, count, fromPosition, toPosition, fromThing, toThing)
 	end
 	return RETURNVALUE_NOERROR
 end
 
 function Player:onItemMoved(item, count, fromPosition, toPosition, fromThing, toThing)
-	if Event.onItemMoved then
-		Event.onItemMoved(self, item, count, fromPosition, toPosition, fromThing, toThing)
+	if Event.onPlayerItemMoved then
+		Event.onPlayerItemMoved(self, item, count, fromPosition, toPosition, fromThing, toThing)
 	end
 end
 
 function Player:onMoveCreature(creature, fromPosition, toPosition)
-	if Event.onMoveCreature then
-		return Event.onMoveCreature(self, creature, fromPosition, toPosition)
+	if Event.onPlayerMoveCreature then
+		return Event.onPlayerMoveCreature(self, creature, fromPosition, toPosition)
 	end
 	return true
 end
 
 function Player:onReportRuleViolation(targetName, reportType, reportReason, comment, translation)
-	if Event.onReportRuleViolation then
-		Event.onReportRuleViolation(self, targetName, reportType, reportReason, comment, translation)
+	if Event.onPlayerReportRuleViolation then
+		Event.onPlayerReportRuleViolation(self, targetName, reportType, reportReason, comment, translation)
 	end
 end
 
 function Player:onRotateItem(item)
-	local onRotateItem = EventCallback.onRotateItem
-	if onRotateItem then
-		return onRotateItem(self, item)
+	if Event.onPlayerRotateItem then
+		return Event.onPlayerRotateItem(self, item)
 	end
 	return true
 end
 
 function Player:onTurn(direction)
-	if Event.onTurn then
-		return Event.onTurn(self, direction)
+	if Event.onPlayerTurn then
+		return Event.onPlayerTurn(self, direction)
 	end
 	return true
 end
 
 function Player:onTradeRequest(target, item)
-	if Event.onTradeRequest then
-		return Event.onTradeRequest(self, target, item)
+	if Event.onPlayerTradeRequest then
+		return Event.onPlayerTradeRequest(self, target, item)
 	end
 	return true
 end
 
 function Player:onTradeAccept(target, item, targetItem)
-	if Event.onTradeAccept then
-		return Event.onTradeAccept(self, target, item, targetItem)
+	if Event.onPlayerTradeAccept then
+		return Event.onPlayerTradeAccept(self, target, item, targetItem)
 	end
 	return true
 end
 
 function Player:onTradeCompleted(target, item, targetItem, isSuccess)
-	if Event.onTradeCompleted then
-		Event.onTradeCompleted(self, target, item, targetItem, isSuccess)
+	if Event.onPlayerTradeCompleted then
+		Event.onPlayerTradeCompleted(self, target, item, targetItem, isSuccess)
 	end
 end
 
@@ -185,30 +184,28 @@ function Player:onPodiumEdit(item, outfit, direction, isVisible)
 end
 
 function Player:onGainExperience(source, exp, rawExp, sendText)
-	if Event.onGainExperience then
-		return Event.onGainExperience(self, source, exp, rawExp, sendText)
+	if Event.onPlayerGainExperience then
+		return Event.onPlayerGainExperience(self, source, exp, rawExp, sendText)
 	end
 	return exp
 end
 
 function Player:onLoseExperience(exp)
-	if Event.onLoseExperience then
-		return Event.onLoseExperience(self, exp)
+	if Event.onPlayerLoseExperience then
+		return Event.onPlayerLoseExperience(self, exp)
 	end
 	return exp
 end
 
 function Player:onGainSkillTries(skill, tries)
-	if not APPLY_SKILL_MULTIPLIER then
-		return Event.onGainSkillTries and Event.onGainSkillTries(self, skill, tries) or tries
+	if APPLY_SKILL_MULTIPLIER then
+		tries = tries * configManager.getNumber(skill == SKILL_MAGLEVEL and configKeys.RATE_MAGIC or configKeys.RATE_SKILL)
 	end
 
-	if skill == SKILL_MAGLEVEL then
-		tries = tries * configManager.getNumber(configKeys.RATE_MAGIC)
-		return Event.onGainSkillTries and Event.onGainSkillTries(self, skill, tries) or tries
+	if Event.onPlayerGainSkillTries then
+		return Event.onPlayerGainSkillTries(self, skill, tries)
 	end
-	tries = tries * configManager.getNumber(configKeys.RATE_SKILL)
-	return Event.onGainSkillTries and Event.onGainSkillTries(self, skill, tries) or tries
+	return tries
 end
 
 function Player:onWrapItem(item)
@@ -238,9 +235,10 @@ function Player:onWrapItem(item)
 		return
 	end
 
-	if not Event.onWrapItem or Event.onWrapItem(self, item) then
+	if not Event.onPlayerWrapItem or Event.onPlayerWrapItem(self, item) then
 		local oldId = item:getId()
 		item:remove(1)
+
 		local item = tile:addItem(wrapId)
 		if item then
 			item:setAttribute("wrapid", oldId)
@@ -249,8 +247,8 @@ function Player:onWrapItem(item)
 end
 
 function Player:onInventoryUpdate(item, slot, equip)
-	if Event.onInventoryUpdate then
-		Event.onInventoryUpdate(self, item, slot, equip)
+	if Event.onPlayerInventoryUpdate then
+		Event.onPlayerInventoryUpdate(self, item, slot, equip)
 	end
 end
 
@@ -265,8 +263,8 @@ function Player:onNetworkMessage(recvByte, msg)
 end
 
 function Player:onSpellCheck(spell)
-	if Event.onSpellCheck then
-		return Event.onSpellCheck(self, spell)
+	if Event.onPlayerSpellCheck then
+		return Event.onPlayerSpellCheck(self, spell)
 	end
 	return true
 end

--- a/data/scripts/events/player/default_onGainExperience.lua
+++ b/data/scripts/events/player/default_onGainExperience.lua
@@ -35,32 +35,32 @@ end
 
 local default = Event()
 
-function default.onGainExperience(player, source, exp, rawExp, sendText)
+default.onPlayerGainExperience = function(self, source, exp, rawExp, sendText)
 	if not source or source:isPlayer() then
 		return exp
 	end
 
-	local level = player:getLevel()
+	local level = self:getLevel()
 
 	-- Soul regeneration
-	local vocation = player:getVocation()
-	if player:getSoul() < vocation:getMaxSoul() and exp >= level then
+	local vocation = self:getVocation()
+	if self:getSoul() < vocation:getMaxSoul() and exp >= level then
 		soulCondition:setParameter(CONDITION_PARAM_SOULTICKS, vocation:getSoulGainTicks() * 1000)
-		player:addCondition(soulCondition)
+		self:addCondition(soulCondition)
 	end
 
 	-- Apply experience stage multiplier
 	exp = exp * Game.getExperienceStage(level)
 
 	-- Apply low level bonus
-	exp = exp * (1 + player:calculateLowLevelBonus(level) / 100)
+	exp = exp * (1 + self:calculateLowLevelBonus(level) / 100)
 
 	-- Stamina modifier
 	if configManager.getBoolean(configKeys.STAMINA_SYSTEM) then
-		useStamina(player)
+		useStamina(self)
 
-		local staminaMinutes = player:getStamina()
-		if staminaMinutes > 2340 and player:isPremium() then
+		local staminaMinutes = self:getStamina()
+		if staminaMinutes > 2340 and self:isPremium() then
 			exp = exp * 1.5
 		elseif staminaMinutes <= 840 then
 			exp = exp * 0.5
@@ -76,16 +76,16 @@ default:register()
 
 local message = Event()
 
-function message.onGainExperience(player, source, exp, rawExp, sendText)
+message.onPlayerGainExperience = function(self, source, exp, rawExp, sendText)
 	if sendText and exp ~= 0 then
-		local pos = player:getPosition()
+		local pos = self:getPosition()
 		local expString = exp .. (exp ~= 1 and " experience points." or " experience point.")
-		player:sendTextMessage(MESSAGE_EXPERIENCE, "You gained " .. expString, pos, exp, TEXTCOLOR_WHITE_EXP)
+		self:sendTextMessage(MESSAGE_EXPERIENCE, "You gained " .. expString, pos, exp, TEXTCOLOR_WHITE_EXP)
 
 		local spectators = Game.getSpectators(pos, false, true)
 		for _, spectator in ipairs(spectators) do
-			if spectator ~= player then
-				spectator:sendTextMessage(MESSAGE_EXPERIENCE_OTHERS, player:getName() .. " gained " .. expString)
+			if spectator ~= self then
+				spectator:sendTextMessage(MESSAGE_EXPERIENCE_OTHERS, self:getName() .. " gained " .. expString)
 			end
 		end
 	end

--- a/data/scripts/events/player/default_onLook.lua
+++ b/data/scripts/events/player/default_onLook.lua
@@ -1,6 +1,6 @@
 local event = Event()
 
-event.onLook = function(self, thing, position, distance, description)
+event.onPlayerLook = function(self, thing, position, distance, description)
 	local description = "You see " .. thing:getDescription(distance)
 	if self:getGroup():getAccess() then
 		if thing:isItem() then

--- a/data/scripts/events/player/default_onLookInBattleList.lua
+++ b/data/scripts/events/player/default_onLookInBattleList.lua
@@ -1,6 +1,6 @@
 local event = Event()
 
-event.onLookInBattleList = function(self, creature, distance)
+event.onPlayerLookInBattleList = function(self, creature, distance)
 	local description = "You see " .. creature:getDescription(distance)
 	if self:getGroup():getAccess() then
 		local str = "%s\nHealth: %d / %d"

--- a/data/scripts/events/player/default_onLookInMarket.lua
+++ b/data/scripts/events/player/default_onLookInMarket.lua
@@ -3,7 +3,7 @@ local showDefWeaponTypes = {WEAPON_CLUB, WEAPON_SWORD, WEAPON_AXE, WEAPON_DISTAN
 
 local event = Event()
 
-event.onLookInMarket = function(self, itemType)
+event.onPlayerLookInMarket = function(self, itemType)
 	local response = NetworkMessage()
 	response:addByte(0xF8)
 	response:addU16(itemType:getClientId())

--- a/data/scripts/events/player/default_onLookInShop.lua
+++ b/data/scripts/events/player/default_onLookInShop.lua
@@ -1,6 +1,6 @@
 local event = Event()
 
-event.onLookInShop = function(self, itemType, count)
+event.onPlayerLookInShop = function(self, itemType, count)
 	local description = "You see " .. itemType:getItemDescription()
 	if self:getGroup():getAccess() then
 		description = string.format("%s\nItem ID: %d", description, itemType:getId())

--- a/data/scripts/events/player/default_onLookInTrade.lua
+++ b/data/scripts/events/player/default_onLookInTrade.lua
@@ -1,6 +1,6 @@
 local event = Event()
 
-event.onLookInTrade = function(self, partner, item, distance)
+event.onPlayerLookInTrade = function(self, partner, item, distance)
 	local description = "You see " .. item:getDescription(distance)
 	if self:getGroup():getAccess() then
 		description = string.format("%s\nItem ID: %d", description, item:getId())

--- a/data/scripts/events/player/default_onMoveItem.lua
+++ b/data/scripts/events/player/default_onMoveItem.lua
@@ -1,6 +1,6 @@
 local event = Event()
 
-event.onMoveItem = function(self, item, count, fromPosition, toPosition, fromThing, toThing)
+event.onPlayerMoveItem = function(self, item, count, fromPosition, toPosition, fromThing, toThing)
 	if item:getAttribute("wrapid") ~= 0 then
 		local tile = Tile(toPosition)
 		if (fromPosition.x ~= CONTAINER_POSITION and toPosition.x ~= CONTAINER_POSITION) or tile and not tile:getHouse() then

--- a/data/scripts/events/player/default_onReportRuleViolation.lua
+++ b/data/scripts/events/player/default_onReportRuleViolation.lua
@@ -9,7 +9,7 @@ end
 
 local event = Event()
 
-event.onReportRuleViolation = function(self, targetName, reportType, reportReason, comment, translation)
+event.onPlayerReportRuleViolation = function(self, targetName, reportType, reportReason, comment, translation)
 	local name = self:getName()
 	if hasPendingReport(name, targetName, reportType) then
 		self:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your report is being processed.")

--- a/data/scripts/events/player/default_onRotateItem.lua
+++ b/data/scripts/events/player/default_onRotateItem.lua
@@ -1,6 +1,6 @@
 local ec = Event()
 
-ec.onRotateItem = function(self, item)
+ec.onPlayerRotateItem = function(self, item)
 	local newId = item:getType():getRotateTo()
 	if newId ~= 0 then
 		item:transform(newId)

--- a/data/scripts/events/player/default_onUpdateStorage.lua
+++ b/data/scripts/events/player/default_onUpdateStorage.lua
@@ -2,12 +2,12 @@ local lastQuestUpdate = {}
 
 local ec = Event()
 
-ec.onUpdateStorage = function(creature, key, value, oldValue, isSpawn)
+ec.onCreatureUpdateStorage = function(self, key, value, oldValue, isSpawn)
 	if isSpawn then
 		return
 	end
 
-	local player = Player(creature:getId())
+	local player = Player(self:getId())
 	if not player then
 		return
 	end

--- a/data/scripts/lib/event_callbacks.lua
+++ b/data/scripts/lib/event_callbacks.lua
@@ -22,46 +22,46 @@ end})
 --@ Definitions of valid Event types to hook according to the given field name
 --@ The fields within the assigned table, allow to save arbitrary information
 -- Creature
-ec.onChangeOutfit = {}
-ec.onChangeMount = {}
-ec.onAreaCombat = {returnValue=true}
-ec.onTargetCombat = {returnValue=true}
-ec.onHear = {}
-ec.onChangeZone = {}
-ec.onUpdateStorage = {}
+ec.onCreatureChangeOutfit = {}
+ec.onCreatureChangeMount = {}
+ec.onCreatureAreaCombat = {returnValue=true}
+ec.onCreatureTargetCombat = {returnValue=true}
+ec.onCreatureHear = {}
+ec.onCreatureChangeZone = {}
+ec.onCreatureUpdateStorage = {}
 -- Party
-ec.onJoin = {}
-ec.onLeave = {}
-ec.onDisband = {}
-ec.onShareExperience = {}
-ec.onInvite = {}
-ec.onRevokeInvitation = {}
-ec.onPassLeadership = {}
+ec.onPartyJoin = {}
+ec.onPartyLeave = {}
+ec.onPartyDisband = {}
+ec.onPartyShareExperience = {}
+ec.onPartyInvite = {}
+ec.onPartyRevokeInvitation = {}
+ec.onPartyPassLeadership = {}
 -- Player
-ec.onBrowseField = {}
-ec.onLook = {}
-ec.onLookInBattleList = {}
-ec.onLookInTrade = {}
-ec.onLookInShop = {}
-ec.onLookInMarket = {}
-ec.onTradeRequest = {}
-ec.onTradeAccept = {}
-ec.onTradeCompleted = {}
-ec.onMoveItem = {returnValue=true}
-ec.onItemMoved = {}
-ec.onMoveCreature = {}
-ec.onReportRuleViolation = {}
-ec.onRotateItem = {}
-ec.onTurn = {}
-ec.onGainExperience = {[3] = 1}
-ec.onLoseExperience = {[2] = 1}
-ec.onGainSkillTries = {[3] = 1}
-ec.onWrapItem = {}
-ec.onInventoryUpdate = {}
-ec.onSpellCheck = {}
+ec.onPlayerBrowseField = {}
+ec.onPlayerLook = {}
+ec.onPlayerLookInBattleList = {}
+ec.onPlayerLookInTrade = {}
+ec.onPlayerLookInShop = {}
+ec.onPlayerLookInMarket = {}
+ec.onPlayerTradeRequest = {}
+ec.onPlayerTradeAccept = {}
+ec.onPlayerTradeCompleted = {}
+ec.onPlayerMoveItem = {returnValue=true}
+ec.onPlayerItemMoved = {}
+ec.onPlayerMoveCreature = {}
+ec.onPlayerReportRuleViolation = {}
+ec.onPlayerRotateItem = {}
+ec.onPlayerTurn = {}
+ec.onPlayerGainExperience = {[3] = 1}
+ec.onPlayerLoseExperience = {[2] = 1}
+ec.onPlayerGainSkillTries = {[3] = 1}
+ec.onPlayerWrapItem = {}
+ec.onPlayerInventoryUpdate = {}
+ec.onPlayerSpellCheck = {}
 -- Monster
-ec.onDropLoot = {}
-ec.onSpawn = {}
+ec.onMonsterDropLoot = {}
+ec.onMonsterSpawn = {}
 
 local EventMeta = {
 	__newindex = function(self, key, callback)

--- a/data/scripts/monsters/cobra_flask.lua
+++ b/data/scripts/monsters/cobra_flask.lua
@@ -2,13 +2,13 @@ local cobras = {"cobra scout", "cobra vizier", "cobra assassin"}
 
 local event = Event()
 
-function event.onSpawn(monster, position, startup, artificial)
-	if table.contains(cobras, monster:getName():lower()) then
+event.onMonsterSpawn = function(self, position, startup, artificial)
+	if table.contains(cobras, self:getName():lower()) then
 		local storage = Game.getStorageValue(GlobalStorageKeys.cobraBastionFlask)
 		if storage then
 			if storage >= os.time() then
-				monster:setHealth(monster:getMaxHealth() * 0.75)
-				monster:getPosition():sendMagicEffect(CONST_ME_GREEN_RINGS)
+				self:setHealth(self:getMaxHealth() * 0.75)
+				self:getPosition():sendMagicEffect(CONST_ME_GREEN_RINGS)
 			else
 				Game.setStorageValue(GlobalStorageKeys.cobraBastionFlask, nil)
 			end

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -734,16 +734,16 @@ void onLookInTrade(const std::shared_ptr<Player>& player, const std::shared_ptr<
 	scriptInterface.callVoidFunction(4);
 }
 
-bool onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemType, uint8_t count)
+void onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemType, uint8_t count)
 {
 	// Player:onLookInShop(itemType, count) or Player.onLookInShop(self, itemType, count)
 	if (playerHandlers.onLookInShop == -1) {
-		return true;
+		return;
 	}
 
 	if (!tfs::lua::reserveScriptEnv()) {
 		std::cout << "[Error - tfs::events::player::onLookInShop] Call stack overflow" << std::endl;
-		return false;
+		return;
 	}
 
 	const auto env = tfs::lua::getScriptEnv();
@@ -760,19 +760,19 @@ bool onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemTyp
 
 	tfs::lua::pushNumber(L, count);
 
-	return scriptInterface.callFunction(3);
+	scriptInterface.callVoidFunction(3);
 }
 
-bool onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemType)
+void onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemType)
 {
 	// Player:onLookInMarket(itemType) or Player.onLookInMarket(self, itemType)
 	if (playerHandlers.onLookInMarket == -1) {
-		return true;
+		return;
 	}
 
 	if (!tfs::lua::reserveScriptEnv()) {
 		std::cout << "[Error - tfs::events::player::onLookInMarket] Call stack overflow" << std::endl;
-		return false;
+		return;
 	}
 
 	const auto env = tfs::lua::getScriptEnv();
@@ -787,7 +787,7 @@ bool onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemT
 	tfs::lua::pushUserdata(L, itemType);
 	tfs::lua::setMetatable(L, -1, "ItemType");
 
-	return scriptInterface.callFunction(2);
+	scriptInterface.callVoidFunction(2);
 }
 
 ReturnValue onMoveItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, uint16_t count,

--- a/src/events.h
+++ b/src/events.h
@@ -65,8 +65,8 @@ void onLookInBattleList(const std::shared_ptr<Player>& player, const std::shared
                         int32_t lookDistance);
 void onLookInTrade(const std::shared_ptr<Player>& player, const std::shared_ptr<Player>& partner,
                    const std::shared_ptr<Item>& item, int32_t lookDistance);
-bool onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemType, uint8_t count);
-bool onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemType);
+void onLookInShop(const std::shared_ptr<Player>& player, const ItemType* itemType, uint8_t count);
+void onLookInMarket(const std::shared_ptr<Player>& player, const ItemType* itemType);
 ReturnValue onMoveItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, uint16_t count,
                        const Position& fromPosition, const Position& toPosition,
                        const std::shared_ptr<Thing>& fromThing, const std::shared_ptr<Thing>& toThing);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Change standardizes event callback names by introducing an explicit class prefix for all event types (Creature, Party, Player, Monster). The previous generic names were ambiguous and could collide or become unclear as the event system grows. By prefixing events (e.g. onCreatureChangeOutfit, onPlayerMoveItem), the API becomes more explicit, self-documenting, and easier to reason about when reading scripts or debugging callbacks.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
