### PR TITLE
feat(monsters): expose lowercase monster name via MonsterType

### DIFF
--- a/src/lua/modules/game.cpp
+++ b/src/lua/modules/game.cpp
@@ -606,6 +606,7 @@ int luaGameCreateMonsterType(lua_State* L)
 		monsterType = &g_monsters.monsters[boost::algorithm::to_lower_copy(name)];
 		monsterType->name = name;
 		monsterType->nameDescription = "a " + name;
+		monsterType->monsterName = boost::algorithm::to_lower_copy(name);
 	} else {
 		monsterType->info.lootItems.clear();
 		monsterType->info.attackSpells.clear();

--- a/src/lua/modules/monsters.cpp
+++ b/src/lua/modules/monsters.cpp
@@ -656,6 +656,18 @@ int luaMonsterTypeNameDescription(lua_State* L)
 	return 1;
 }
 
+int32_t luaMonsterTypeMonsterName(lua_State* L)
+{
+	// monsterType:monsterName()
+	MonsterType* monsterType = tfs::lua::getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		tfs::lua::pushString(L, monsterType->monsterName);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int luaMonsterTypeHealth(lua_State* L)
 {
 	// get: monsterType:health() set: monsterType:health(health)
@@ -1694,6 +1706,7 @@ void tfs::lua::registerMonsters(LuaScriptInterface& lsi)
 
 	lsi.registerMethod("MonsterType", "name", luaMonsterTypeName);
 	lsi.registerMethod("MonsterType", "nameDescription", luaMonsterTypeNameDescription);
+	lsi.registerMethod("MonsterType", "monsterName", luaMonsterTypeMonsterName);
 
 	lsi.registerMethod("MonsterType", "health", luaMonsterTypeHealth);
 	lsi.registerMethod("MonsterType", "maxHealth", luaMonsterTypeMaxHealth);

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -814,6 +814,7 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 		mType->info = {};
 	}
 
+	mType->monsterName = monsterName;
 	mType->name = attr.as_string();
 
 	if ((attr = monsterNode.attribute("nameDescription"))) {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -188,6 +188,7 @@ public:
 
 	std::string name;
 	std::string nameDescription;
+	std::string monsterName;
 
 	MonsterInfo info;
 	BestiaryInfo bestiaryInfo;


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Introduces a persistent and normalized monster name field to `MonsterType`, making the original monster name available at runtime and exposed to Lua. A new monsterName member is stored as a lowercase copy of the XML-defined name during monster type loading, ensuring consistency for lookups, comparisons and scripting usage.

A new Lua method `MonsterType:monsterName` is added, allowing scripts to retrieve the normalized monster name directly from the `MonsterType` object. This avoids relying on display names or descriptions and provides a stable identifier for logic that depends on monster typing.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monster types now expose their name as a lowercase string field accessible through Lua scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->