### PR TITLE
refactor(error): update reportError function to print stack trace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ if (APPLE)
     find_package(Iconv REQUIRED)
 endif()
 
-set(BOOST_REQUIRED_COMPONENTS system iostreams)
+set(BOOST_REQUIRED_COMPONENTS iostreams)
 if (ENABLE_HTTP)
     list(APPEND BOOST_REQUIRED_COMPONENTS json)
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,7 +158,6 @@ set(tfs_MAIN ${CMAKE_CURRENT_LIST_DIR}/otserv.cpp)
 add_library(tfslib ${tfs_SRC})
 target_link_libraries(tfslib PRIVATE
 	Boost::iostreams
-	Boost::system
 	OpenSSL::Crypto
 	pugixml::pugixml
 	simdutf::simdutf

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -246,7 +246,7 @@ bool ChatChannel::executeOnSpeakEvent(const std::shared_ptr<const Player>& playe
 	int size0 = lua_gettop(L);
 	int ret = tfs::lua::protectedCall(L, 3, 1);
 	if (ret != 0) {
-		tfs::lua::reportError(L, tfs::lua::popString(L));
+		tfs::lua::reportError(L, tfs::lua::popString(L), true);
 	} else if (lua_gettop(L) > 0) {
 		if (lua_isboolean(L, -1)) {
 			result = tfs::lua::getBoolean(L, -1);
@@ -258,7 +258,7 @@ bool ChatChannel::executeOnSpeakEvent(const std::shared_ptr<const Player>& playe
 	}
 
 	if ((lua_gettop(L) + 4) != size0) {
-		tfs::lua::reportError(L, "Stack size changed!");
+		tfs::lua::reportError(L, "Stack size changed!", true);
 	}
 	tfs::lua::resetScriptEnv();
 	return result;

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -47,4 +47,3 @@ set(luamodules_SRC
 	)
 
 add_library(luascript OBJECT ${lua_SRC} ${luamodules_SRC})
-target_link_libraries(luascript PRIVATE "$<$<CXX_COMPILER_ID:GNU>:stdc++exp>")

--- a/src/lua/CMakeLists.txt
+++ b/src/lua/CMakeLists.txt
@@ -47,3 +47,4 @@ set(luamodules_SRC
 	)
 
 add_library(luascript OBJECT ${lua_SRC} ${luamodules_SRC})
+target_link_libraries(luascript PRIVATE "$<$<CXX_COMPILER_ID:GNU>:stdc++exp>")

--- a/src/lua/error.cpp
+++ b/src/lua/error.cpp
@@ -61,7 +61,7 @@ int luaErrorHandler(lua_State* L)
 	return 1;
 }
 
-void reportError(lua_State* L, std::string_view error_desc)
+void reportError(lua_State* L, std::string_view error_desc, bool stacktrace /*= false*/)
 {
 	auto [scriptId, luaScriptInterface, callbackId, timerEvent] = getScriptEnv()->getEventInfo();
 
@@ -81,8 +81,13 @@ void reportError(lua_State* L, std::string_view error_desc)
 		std::cout << luaScriptInterface->getFileById(scriptId) << '\n';
 	}
 
-	std::cout << "\nStack trace:\n" << boost::stacktrace::stacktrace() << '\n';
-	std::cout << "\nLua stack trace:\n" << getStackTrace(L, error_desc) << '\n';
+	if (stacktrace) {
+		std::cout << "\nStack trace:\n" << boost::stacktrace::stacktrace() << '\n';
+
+		if (L) {
+			std::cout << "\nLua stack trace:\n" << getStackTrace(L, error_desc) << '\n';
+		}
+	}
 }
 
 } // namespace tfs::lua

--- a/src/lua/error.cpp
+++ b/src/lua/error.cpp
@@ -86,6 +86,8 @@ void reportError(lua_State* L, std::string_view error_desc, bool stacktrace /*= 
 
 		if (L) {
 			std::cout << "\nLua stack trace:\n" << getStackTrace(L, error_desc) << '\n';
+		} else {
+			std::cout << "\n" << error_desc << '\n';
 		}
 	}
 }

--- a/src/lua/error.cpp
+++ b/src/lua/error.cpp
@@ -6,6 +6,8 @@
 #include "env.h"
 #include "script.h"
 
+#include <boost/stacktrace.hpp>
+
 namespace {
 
 std::string getStackTrace(lua_State* L, std::string_view error_desc)
@@ -59,8 +61,7 @@ int luaErrorHandler(lua_State* L)
 	return 1;
 }
 
-void reportError(std::string_view function, std::string_view error_desc, lua_State* L /*= nullptr*/,
-                 bool stack_trace /*= false*/)
+void reportError(lua_State* L, std::string_view error_desc)
 {
 	auto [scriptId, luaScriptInterface, callbackId, timerEvent] = getScriptEnv()->getEventInfo();
 
@@ -80,17 +81,8 @@ void reportError(std::string_view function, std::string_view error_desc, lua_Sta
 		std::cout << luaScriptInterface->getFileById(scriptId) << '\n';
 	}
 
-	if (!function.empty()) {
-		std::cout << function << "(). ";
-	}
-
-	if (L && stack_trace) {
-		std::cout << getStackTrace(L, error_desc) << '\n';
-	} else {
-		std::cout << error_desc << '\n';
-	}
+	std::cout << "\nStack trace:\n" << boost::stacktrace::stacktrace() << '\n';
+	std::cout << "\nLua stack trace:\n" << getStackTrace(L, error_desc) << '\n';
 }
-
-void reportError(lua_State* L, std::string_view error_desc) { reportError(__FUNCTION__, error_desc, L, true); }
 
 } // namespace tfs::lua

--- a/src/lua/error.h
+++ b/src/lua/error.h
@@ -23,7 +23,6 @@ std::string getErrorDesc(ErrorCode_t code);
 
 int luaErrorHandler(lua_State* L);
 
-void reportError(std::string_view function, std::string_view error_desc, lua_State* L, bool stack_trace);
 void reportError(lua_State* L, std::string_view error_desc);
 
 } // namespace tfs::lua

--- a/src/lua/error.h
+++ b/src/lua/error.h
@@ -23,6 +23,6 @@ std::string getErrorDesc(ErrorCode_t code);
 
 int luaErrorHandler(lua_State* L);
 
-void reportError(lua_State* L, std::string_view error_desc);
+void reportError(lua_State* L, std::string_view error_desc, bool stacktrace = false);
 
 } // namespace tfs::lua

--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -521,7 +521,7 @@ int32_t LuaScriptInterface::loadFile(const std::string& file, const std::shared_
 	// execute it
 	ret = tfs::lua::protectedCall(L, 0, 0);
 	if (ret != 0) {
-		tfs::lua::reportError(L, tfs::lua::popString(L));
+		tfs::lua::reportError(L, tfs::lua::popString(L), true);
 		tfs::lua::resetScriptEnv();
 		return -1;
 	}
@@ -672,14 +672,14 @@ bool LuaScriptInterface::callFunction(int params)
 	bool result = false;
 	int size = lua_gettop(L);
 	if (tfs::lua::protectedCall(L, params, 1) != 0) {
-		tfs::lua::reportError(L, tfs::lua::getString(L, -1));
+		tfs::lua::reportError(L, tfs::lua::getString(L, -1), true);
 	} else {
 		result = tfs::lua::getBoolean(L, -1);
 	}
 
 	lua_pop(L, 1);
 	if ((lua_gettop(L) + params + 1) != size) {
-		tfs::lua::reportError(L, "Stack size changed!");
+		tfs::lua::reportError(L, "Stack size changed!", true);
 	}
 
 	tfs::lua::resetScriptEnv();
@@ -690,11 +690,11 @@ void LuaScriptInterface::callVoidFunction(int params)
 {
 	int size = lua_gettop(L);
 	if (tfs::lua::protectedCall(L, params, 0) != 0) {
-		tfs::lua::reportError(L, tfs::lua::popString(L));
+		tfs::lua::reportError(L, tfs::lua::popString(L), true);
 	}
 
 	if ((lua_gettop(L) + params + 1) != size) {
-		tfs::lua::reportError(L, "Stack size changed!");
+		tfs::lua::reportError(L, "Stack size changed!", true);
 	}
 
 	tfs::lua::resetScriptEnv();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
     "boost-container",
     "boost-iostreams",
     "boost-lockfree",
+    "boost-stacktrace",
     "boost-system",
     {
       "name": "libiconv",


### PR DESCRIPTION
This pull request focuses on improving Lua error reporting. The most significant changes update the error reporting mechanism to provide both native and Lua stack traces.

The Boost.System stub compiled library has been removed; it has been header-only since release 1.69, which is older than our minimum required version of 1.71.

**Error reporting improvements:**

* Refactored the `tfs::lua::reportError` function to always require a `lua_State*` parameter and to print both the native (using `boost::stacktrace`) and Lua stack traces for better debugging. Removed the previous overloads and unused parameters. (`src/lua/error.cpp`, `src/lua/error.h`) [[1]](diffhunk://#diff-5d7182f3863b4f8ba3473d32ca824ea5d54e907b9d6ca7fb308ff027dddcba09L62-R64) [[2]](diffhunk://#diff-5d7182f3863b4f8ba3473d32ca824ea5d54e907b9d6ca7fb308ff027dddcba09L83-L96) [[3]](diffhunk://#diff-650f52c230e1307accce5af759c5f4421ebb5a466acc9c7aba43ceff1cee5915L26-L28)
* Updated all calls to `tfs::lua::reportError` throughout the codebase to use the new function signature, ensuring the Lua state is always provided. (`src/chat.cpp`, `src/creatureevent.cpp`, `src/lua/script.cpp`) [[1]](diffhunk://#diff-05b72e91cd007d2a58dfa07d6e289a78012b7239fcee50b5929730d47f41dfaaL249-R249) [[2]](diffhunk://#diff-05b72e91cd007d2a58dfa07d6e289a78012b7239fcee50b5929730d47f41dfaaL261-R261) [[3]](diffhunk://#diff-2fe3cea625f77ca0180d88b4cbfef36ca08c44c6643783760e619d6de4f70ff1L565-R565) [[4]](diffhunk://#diff-2fe3cea625f77ca0180d88b4cbfef36ca08c44c6643783760e619d6de4f70ff1L609-R609) [[5]](diffhunk://#diff-f6ad9e9d816e4dd99f6b312c47de151e76921a5659fe6a115bbaba0ffaffc177L528-R528) [[6]](diffhunk://#diff-f6ad9e9d816e4dd99f6b312c47de151e76921a5659fe6a115bbaba0ffaffc177L679-R686) [[7]](diffhunk://#diff-f6ad9e9d816e4dd99f6b312c47de151e76921a5659fe6a115bbaba0ffaffc177L697-R701)
* Added `boost/stacktrace` as a dependency and included it in the error reporting implementation. (`src/lua/error.cpp`, `vcpkg.json`) [[1]](diffhunk://#diff-5d7182f3863b4f8ba3473d32ca824ea5d54e907b9d6ca7fb308ff027dddcba09R9-R10) [[2]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283R8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting: failures now include explicit stack-trace output (C++ and Lua traces where available) and clearer contextual information to aid debugging and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->