### PR TITLE
feat(lua): move player record to lua

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -86,7 +86,7 @@ configManager = {}
 ---@field getClientVersion fun(): string
 ---@field reload fun(reloadType: number): boolean
 ---@field getPlayerRecord fun(): integer
----@field setPlayerRecord fun(record: integer): nil
+---@field setPlayerRecord fun(record: integer): boolean
 Game = {}
 
 ---@class Variant

--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -85,6 +85,8 @@ configManager = {}
 ---@field startEvent fun(eventName: string): boolean
 ---@field getClientVersion fun(): string
 ---@field reload fun(reloadType: number): boolean
+---@field getPlayerRecord fun(): integer
+---@field setPlayerRecord fun(record: integer): nil
 Game = {}
 
 ---@class Variant
@@ -947,7 +949,6 @@ MoveEvent = {}
 ---
 ---@field time fun(self:GlobalEvent, time:string):boolean -- "hh:mm:ss"
 ---@field interval fun(self:GlobalEvent, interval:integer):boolean
----@field onRecord fun(current:integer, old:integer):boolean
 ---@field onThink fun(interval:integer):boolean
 ---@field onTime fun(interval:integer):boolean
 ---@operator call(string):GlobalEvent

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -184,10 +184,6 @@ do
 			self:type("timer")
 			self:onTime(value)
 			return
-		elseif key == "onRecord" then
-			self:type("record")
-			self:onRecord(value)
-			return
 		end
 		rawset(self, key, value)
 	end
@@ -245,7 +241,7 @@ do
 end
 
 function pushThing(thing)
-	local t = {uid = 0, itemid = 0, type = 0, actionid = 0}
+	local t = { uid = 0, itemid = 0, type = 0, actionid = 0 }
 	if thing then
 		if thing:isItem() then
 			t.uid = thing:getUniqueId()
@@ -277,25 +273,35 @@ setCombatFormula = Combat.setFormula
 setCombatParam = Combat.setParameter
 
 Combat.delete = function(...)
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.delete is deprecated and will be removed in the future")
+	print("[Warning - " ..
+	debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.delete is deprecated and will be removed in the future")
 end
 
 Combat.setCondition = function(...)
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
+	print("[Warning - " ..
+	debug.getinfo(2).source:match("@?(.*)") ..
+	"] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
 	Combat.addCondition(...)
 end
 
 setCombatCondition = function(...)
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future")
+	print("[Warning - " ..
+	debug.getinfo(2).source:match("@?(.*)") ..
+	"] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future")
 	Combat.addCondition(...)
 end
 
 function doTargetCombatHealth(...) return doTargetCombat(...) end
+
 function doAreaCombatHealth(...) return doAreaCombat(...) end
+
 doCombatAreaHealth = doAreaCombatHealth
-function doTargetCombatMana(cid, target, min, max, effect) return doTargetCombat(cid, target, COMBAT_MANADRAIN, min, max, effect) end
+function doTargetCombatMana(cid, target, min, max, effect) return doTargetCombat(cid, target, COMBAT_MANADRAIN, min, max,
+		effect) end
+
 doCombatAreaMana = doTargetCombatMana
-function doAreaCombatMana(cid, pos, area, min, max, effect) return doAreaCombat(cid, COMBAT_MANADRAIN, pos, area, min, max, effect) end
+function doAreaCombatMana(cid, pos, area, min, max, effect) return doAreaCombat(cid, COMBAT_MANADRAIN, pos, area, min,
+		max, effect) end
 
 createConditionObject = Condition
 setConditionParam = Condition.setParameter
@@ -306,27 +312,91 @@ addOutfitCondition = Condition.setOutfit
 function doCombat(cid, combat, var) return combat:execute(cid, var) end
 
 function isCreature(cid) return Creature(cid) end
+
 function isPlayer(cid) return Player(cid) end
+
 function isMonster(cid) return Monster(cid) end
-function isSummon(cid) local c = Creature(cid) return c and c:getMaster() end
+
+function isSummon(cid)
+	local c = Creature(cid)
+	return c and c:getMaster()
+end
+
 function isNpc(cid) return Npc(cid) end
+
 function isItem(uid) return Item(uid) end
+
 function isContainer(uid) return Container(uid) end
 
-function getCreatureName(cid) local c = Creature(cid) return c and c:getName() or false end
-function getCreatureStorage(uid, key) local c = Creature(uid) return c and c:getStorageValue(key) or false end
-function getCreatureHealth(cid) local c = Creature(cid) return c and c:getHealth() or false end
-function getCreatureMaxHealth(cid) local c = Creature(cid) return c and c:getMaxHealth() or false end
-function getCreatureMana(cid) local c = Creature(cid) return c and c:getMana() or false end
-function getCreatureMaxMana(cid) local c = Creature(cid) return c and c:getMaxMana() or false end
-function getCreaturePosition(cid) local c = Creature(cid) return c and c:getPosition() or false end
-function getCreatureOutfit(cid) local c = Creature(cid) return c and c:getOutfit() or false end
-function getCreatureSpeed(cid) local c = Creature(cid) return c and c:getSpeed() or false end
-function getCreatureBaseSpeed(cid) local c = Creature(cid) return c and c:getBaseSpeed() or false end
-function getCreatureLookDirection(cid) local c = Creature(cid) return c and c:getDirection() or false end
-function getCreatureHideHealth(cid) local c = Creature(cid) return c and c:isHealthHidden() or false end
-function getCreatureSkullType(cid) local c = Creature(cid) return c and c:getSkull() or false end
-function getCreatureNoMove(cid) local c = Creature(cid) return c and c:isMovementBlocked() or false end
+function getCreatureName(cid)
+	local c = Creature(cid)
+	return c and c:getName() or false
+end
+
+function getCreatureStorage(uid, key)
+	local c = Creature(uid)
+	return c and c:getStorageValue(key) or false
+end
+
+function getCreatureHealth(cid)
+	local c = Creature(cid)
+	return c and c:getHealth() or false
+end
+
+function getCreatureMaxHealth(cid)
+	local c = Creature(cid)
+	return c and c:getMaxHealth() or false
+end
+
+function getCreatureMana(cid)
+	local c = Creature(cid)
+	return c and c:getMana() or false
+end
+
+function getCreatureMaxMana(cid)
+	local c = Creature(cid)
+	return c and c:getMaxMana() or false
+end
+
+function getCreaturePosition(cid)
+	local c = Creature(cid)
+	return c and c:getPosition() or false
+end
+
+function getCreatureOutfit(cid)
+	local c = Creature(cid)
+	return c and c:getOutfit() or false
+end
+
+function getCreatureSpeed(cid)
+	local c = Creature(cid)
+	return c and c:getSpeed() or false
+end
+
+function getCreatureBaseSpeed(cid)
+	local c = Creature(cid)
+	return c and c:getBaseSpeed() or false
+end
+
+function getCreatureLookDirection(cid)
+	local c = Creature(cid)
+	return c and c:getDirection() or false
+end
+
+function getCreatureHideHealth(cid)
+	local c = Creature(cid)
+	return c and c:isHealthHidden() or false
+end
+
+function getCreatureSkullType(cid)
+	local c = Creature(cid)
+	return c and c:getSkull() or false
+end
+
+function getCreatureNoMove(cid)
+	local c = Creature(cid)
+	return c and c:isMovementBlocked() or false
+end
 
 function getCreatureTarget(cid)
 	local c = Creature(cid)
@@ -361,47 +431,179 @@ end
 
 getCreaturePos = getCreaturePosition
 
-function doCreatureAddHealth(cid, health) local c = Creature(cid) return c and c:addHealth(health) or false end
-function doCreatureAddMana(cid, mana) local c = Creature(cid) return c and c:addMana(mana) or false end
-function doRemoveCreature(cid) local c = Creature(cid) return c and c:remove() or false end
-function doCreatureSetStorage(uid, key, value) local c = Creature(uid) return c and c:setStorageValue(key, value) or false end
-function doCreatureSetLookDir(cid, direction) local c = Creature(cid) return c and c:setDirection(direction) or false end
-function doCreatureSetSkullType(cid, skull) local c = Creature(cid) return c and c:setSkull(skull) or false end
-function setCreatureMaxHealth(cid, health) local c = Creature(cid) return c and c:setMaxHealth(health) or false end
-function setCreatureMaxMana(cid, mana) local c = Creature(cid) return c and c:setMaxMana(mana) or false end
-function doCreatureSetHideHealth(cid, hide) local c = Creature(cid) return c and c:setHiddenHealth(hide) or false end
-function doCreatureSetNoMove(cid, block) local c = Creature(cid) return c and c:setMovementBlocked(block) or false end
-function doCreatureSay(cid, text, type, ...) local c = Creature(cid) return c and c:say(text, type, ...) or false end
-function doCreatureChangeOutfit(cid, outfit) local c = Creature(cid) return c and c:setOutfit(outfit) or false end
-function doSetCreatureDropLoot(cid, doDrop) local c = Creature(cid) return c and c:setDropLoot(doDrop) or false end
+function doCreatureAddHealth(cid, health)
+	local c = Creature(cid)
+	return c and c:addHealth(health) or false
+end
+
+function doCreatureAddMana(cid, mana)
+	local c = Creature(cid)
+	return c and c:addMana(mana) or false
+end
+
+function doRemoveCreature(cid)
+	local c = Creature(cid)
+	return c and c:remove() or false
+end
+
+function doCreatureSetStorage(uid, key, value)
+	local c = Creature(uid)
+	return c and c:setStorageValue(key, value) or false
+end
+
+function doCreatureSetLookDir(cid, direction)
+	local c = Creature(cid)
+	return c and c:setDirection(direction) or false
+end
+
+function doCreatureSetSkullType(cid, skull)
+	local c = Creature(cid)
+	return c and c:setSkull(skull) or false
+end
+
+function setCreatureMaxHealth(cid, health)
+	local c = Creature(cid)
+	return c and c:setMaxHealth(health) or false
+end
+
+function setCreatureMaxMana(cid, mana)
+	local c = Creature(cid)
+	return c and c:setMaxMana(mana) or false
+end
+
+function doCreatureSetHideHealth(cid, hide)
+	local c = Creature(cid)
+	return c and c:setHiddenHealth(hide) or false
+end
+
+function doCreatureSetNoMove(cid, block)
+	local c = Creature(cid)
+	return c and c:setMovementBlocked(block) or false
+end
+
+function doCreatureSay(cid, text, type, ...)
+	local c = Creature(cid)
+	return c and c:say(text, type, ...) or false
+end
+
+function doCreatureChangeOutfit(cid, outfit)
+	local c = Creature(cid)
+	return c and c:setOutfit(outfit) or false
+end
+
+function doSetCreatureDropLoot(cid, doDrop)
+	local c = Creature(cid)
+	return c and c:setDropLoot(doDrop) or false
+end
+
 doCreatureSetDropLoot = doSetCreatureDropLoot
-function doChangeSpeed(cid, delta) local c = Creature(cid) return c and c:changeSpeed(delta) or false end
-function doAddCondition(cid, conditionId) local c = Creature(cid) return c and c:addCondition(conditionId) or false end
-function doRemoveCondition(cid, conditionType, subId) local c = Creature(cid) return c and (c:removeCondition(conditionType, CONDITIONID_COMBAT, subId) or c:removeCondition(conditionType, CONDITIONID_DEFAULT, subId) or true) end
-function getCreatureCondition(cid, type, subId) local c = Creature(cid) return c and c:hasCondition(type, subId) or false end
+function doChangeSpeed(cid, delta)
+	local c = Creature(cid)
+	return c and c:changeSpeed(delta) or false
+end
+
+function doAddCondition(cid, conditionId)
+	local c = Creature(cid)
+	return c and c:addCondition(conditionId) or false
+end
+
+function doRemoveCondition(cid, conditionType, subId)
+	local c = Creature(cid)
+	return c and
+	(c:removeCondition(conditionType, CONDITIONID_COMBAT, subId) or c:removeCondition(conditionType, CONDITIONID_DEFAULT, subId) or true)
+end
+
+function getCreatureCondition(cid, type, subId)
+	local c = Creature(cid)
+	return c and c:hasCondition(type, subId) or false
+end
 
 doCreatureSetLookDirection = doCreatureSetLookDir
 doSetCreatureDirection = doCreatureSetLookDir
 
-function getPlayerByName(name) local p = Player(name) return p and p:getId() or false end
-function getIPByPlayerName(name) local p = Player(name) return p and p:getIp() or false end
-function getPlayerGUID(cid) local p = Player(cid) return p and p:getGuid() or false end
-function getPlayerNameDescription(cid, distance) local p = Player(cid) return p and p:getDescription(distance) or false end
-function getPlayerSpecialDescription() debugPrint("Deprecated function, use Player:onLook event instead.") return true end
-function getPlayerAccountId(cid) local p = Player(cid) return p and p:getAccountId() or false end
+function getPlayerByName(name)
+	local p = Player(name)
+	return p and p:getId() or false
+end
+
+function getIPByPlayerName(name)
+	local p = Player(name)
+	return p and p:getIp() or false
+end
+
+function getPlayerGUID(cid)
+	local p = Player(cid)
+	return p and p:getGuid() or false
+end
+
+function getPlayerNameDescription(cid, distance)
+	local p = Player(cid)
+	return p and p:getDescription(distance) or false
+end
+
+function getPlayerSpecialDescription()
+	debugPrint("Deprecated function, use Player:onLook event instead.")
+	return true
+end
+
+function getPlayerAccountId(cid)
+	local p = Player(cid)
+	return p and p:getAccountId() or false
+end
+
 getPlayerAccount = getPlayerAccountId
-function getPlayerIp(cid) local p = Player(cid) return p and p:getIp() or false end
-function getPlayerAccountType(cid) local p = Player(cid) return p and p:getAccountType() or false end
-function getPlayerLastLoginSaved(cid) local p = Player(cid) return p and p:getLastLoginSaved() or false end
+function getPlayerIp(cid)
+	local p = Player(cid)
+	return p and p:getIp() or false
+end
+
+function getPlayerAccountType(cid)
+	local p = Player(cid)
+	return p and p:getAccountType() or false
+end
+
+function getPlayerLastLoginSaved(cid)
+	local p = Player(cid)
+	return p and p:getLastLoginSaved() or false
+end
+
 getPlayerLastLogin = getPlayerLastLoginSaved
-function getPlayerName(cid) local p = Player(cid) return p and p:getName() or false end
+function getPlayerName(cid)
+	local p = Player(cid)
+	return p and p:getName() or false
+end
+
 getPlayerNameDescription = getPlayerName
-function getPlayerFreeCap(cid) local p = Player(cid) return p and (p:getFreeCapacity() / 100) or false end
-function getPlayerPosition(cid) local p = Player(cid) return p and p:getPosition() or false end
-function getPlayerMagLevel(cid) local p = Player(cid) return p and p:getMagicLevel() or false end
-function getPlayerSpentMana(cid) local p = Player(cid) return p and p:getManaSpent() or false end
-function getPlayerRequiredMana(cid, magicLevel) local p = Player(cid) return p and p:getVocation():getRequiredManaSpent(magicLevel) or false end
-function getPlayerRequiredSkillTries(cid, skillId) local p = Player(cid) return p and p:getVocation():getRequiredSkillTries(skillId) or false end
+function getPlayerFreeCap(cid)
+	local p = Player(cid)
+	return p and (p:getFreeCapacity() / 100) or false
+end
+
+function getPlayerPosition(cid)
+	local p = Player(cid)
+	return p and p:getPosition() or false
+end
+
+function getPlayerMagLevel(cid)
+	local p = Player(cid)
+	return p and p:getMagicLevel() or false
+end
+
+function getPlayerSpentMana(cid)
+	local p = Player(cid)
+	return p and p:getManaSpent() or false
+end
+
+function getPlayerRequiredMana(cid, magicLevel)
+	local p = Player(cid)
+	return p and p:getVocation():getRequiredManaSpent(magicLevel) or false
+end
+
+function getPlayerRequiredSkillTries(cid, skillId)
+	local p = Player(cid)
+	return p and p:getVocation():getRequiredSkillTries(skillId) or false
+end
+
 function getPlayerAccess(cid)
 	local player = Player(cid)
 	if not player then
@@ -409,32 +611,132 @@ function getPlayerAccess(cid)
 	end
 	return player:getGroup():getAccess() and 1 or 0
 end
-function getPlayerSkill(cid, skillId) local p = Player(cid) return p and p:getSkillLevel(skillId) or false end
+
+function getPlayerSkill(cid, skillId)
+	local p = Player(cid)
+	return p and p:getSkillLevel(skillId) or false
+end
+
 getPlayerSkillLevel = getPlayerSkill
-function getPlayerSkillTries(cid, skillId) local p = Player(cid) return p and p:getSkillTries(skillId) or false end
-function getPlayerMana(cid) local p = Player(cid) return p and p:getMana() or false end
-function getPlayerMaxMana(cid) local p = Player(cid) return p and p:getMaxMana() or false end
-function getPlayerLevel(cid) local p = Player(cid) return p and p:getLevel() or false end
-function getPlayerExperience(cid) local p = Player(cid) return p and p:getExperience() or false end
-function getPlayerTown(cid) local p = Player(cid) return p and p:getTown():getId() or false end
-function getPlayerVocation(cid) local p = Player(cid) return p and p:getVocation():getId() or false end
-function getPlayerSoul(cid) local p = Player(cid) return p and p:getSoul() or false end
-function getPlayerSex(cid) local p = Player(cid) return p and p:getSex() or false end
-function getPlayerStorageValue(cid, key) local p = Player(cid) return p and p:getStorageValue(key) or false end
-function getPlayerBalance(cid) local p = Player(cid) return p and p:getBankBalance() or false end
-function getPlayerMoney(cid) local p = Player(cid) return p and p:getMoney() or false end
-function getPlayerGroupId(cid) local p = Player(cid) return p and p:getGroup():getId() or false end
-function getPlayerLookDir(cid) local p = Player(cid) return p and p:getDirection() or false end
-function getPlayerLight(cid) local p = Player(cid) return p and p:getLight() or false end
-function getPlayerDepotItems(cid, depotId) local p = Player(cid) return p and p:getDepotItems(depotId) or false end
-function getPlayerStamina(cid) local p = Player(cid) return p and p:getStamina() or false end
-function getPlayerSkullType(cid) local p = Player(cid) return p and p:getSkull() or false end
-function getPlayerLossPercent(cid) local p = Player(cid) return p and p:getDeathPenalty() or false end
-function getPlayerMount(cid, mountId) local p = Player(cid) return p and p:hasMount(mountId) or false end
-function getPlayerPremiumDays(cid) local p = Player(cid) return p and p:getPremiumDays() or false end
-function getPlayerBlessing(cid, blessing) local p = Player(cid) return p and p:hasBlessing(blessing) or false end
-function getPlayerFlagValue(cid, flag) local p = Player(cid) return p and p:hasFlag(flag) or false end
-function getPlayerCustomFlagValue() debugPrint("Deprecated function, use player:hasFlag(flag) instead.") return true end
+function getPlayerSkillTries(cid, skillId)
+	local p = Player(cid)
+	return p and p:getSkillTries(skillId) or false
+end
+
+function getPlayerMana(cid)
+	local p = Player(cid)
+	return p and p:getMana() or false
+end
+
+function getPlayerMaxMana(cid)
+	local p = Player(cid)
+	return p and p:getMaxMana() or false
+end
+
+function getPlayerLevel(cid)
+	local p = Player(cid)
+	return p and p:getLevel() or false
+end
+
+function getPlayerExperience(cid)
+	local p = Player(cid)
+	return p and p:getExperience() or false
+end
+
+function getPlayerTown(cid)
+	local p = Player(cid)
+	return p and p:getTown():getId() or false
+end
+
+function getPlayerVocation(cid)
+	local p = Player(cid)
+	return p and p:getVocation():getId() or false
+end
+
+function getPlayerSoul(cid)
+	local p = Player(cid)
+	return p and p:getSoul() or false
+end
+
+function getPlayerSex(cid)
+	local p = Player(cid)
+	return p and p:getSex() or false
+end
+
+function getPlayerStorageValue(cid, key)
+	local p = Player(cid)
+	return p and p:getStorageValue(key) or false
+end
+
+function getPlayerBalance(cid)
+	local p = Player(cid)
+	return p and p:getBankBalance() or false
+end
+
+function getPlayerMoney(cid)
+	local p = Player(cid)
+	return p and p:getMoney() or false
+end
+
+function getPlayerGroupId(cid)
+	local p = Player(cid)
+	return p and p:getGroup():getId() or false
+end
+
+function getPlayerLookDir(cid)
+	local p = Player(cid)
+	return p and p:getDirection() or false
+end
+
+function getPlayerLight(cid)
+	local p = Player(cid)
+	return p and p:getLight() or false
+end
+
+function getPlayerDepotItems(cid, depotId)
+	local p = Player(cid)
+	return p and p:getDepotItems(depotId) or false
+end
+
+function getPlayerStamina(cid)
+	local p = Player(cid)
+	return p and p:getStamina() or false
+end
+
+function getPlayerSkullType(cid)
+	local p = Player(cid)
+	return p and p:getSkull() or false
+end
+
+function getPlayerLossPercent(cid)
+	local p = Player(cid)
+	return p and p:getDeathPenalty() or false
+end
+
+function getPlayerMount(cid, mountId)
+	local p = Player(cid)
+	return p and p:hasMount(mountId) or false
+end
+
+function getPlayerPremiumDays(cid)
+	local p = Player(cid)
+	return p and p:getPremiumDays() or false
+end
+
+function getPlayerBlessing(cid, blessing)
+	local p = Player(cid)
+	return p and p:hasBlessing(blessing) or false
+end
+
+function getPlayerFlagValue(cid, flag)
+	local p = Player(cid)
+	return p and p:hasFlag(flag) or false
+end
+
+function getPlayerCustomFlagValue()
+	debugPrint("Deprecated function, use player:hasFlag(flag) instead.")
+	return true
+end
 
 function getPlayerParty(cid)
 	local player = Player(cid)
@@ -448,6 +750,7 @@ function getPlayerParty(cid)
 	end
 	return party:getLeader():getId()
 end
+
 function getPlayerGuildId(cid)
 	local player = Player(cid)
 	if not player then
@@ -460,7 +763,12 @@ function getPlayerGuildId(cid)
 	end
 	return guild:getId()
 end
-function getPlayerGuildLevel(cid) local p = Player(cid) return p and p:getGuildLevel() or false end
+
+function getPlayerGuildLevel(cid)
+	local p = Player(cid)
+	return p and p:getGuildLevel() or false
+end
+
 function getPlayerGuildName(cid)
 	local player = Player(cid)
 	if not player then
@@ -473,6 +781,7 @@ function getPlayerGuildName(cid)
 	end
 	return guild:getName()
 end
+
 function getPlayerGuildRank(cid)
 	local player = Player(cid)
 	if not player then
@@ -487,11 +796,32 @@ function getPlayerGuildRank(cid)
 	local rank = guild:getRankByLevel(player:getGuildLevel())
 	return rank and rank.name or false
 end
-function getPlayerGuildRankId(cid) local p = Player(cid) return p and p:getGuildLevel() or false end
-function getPlayerGuildNick(cid) local p = Player(cid) return p and p:getGuildNick() or false end
-function getPlayerMasterPos(cid) local p = Player(cid) return p and p:getTown():getTemplePosition() or false end
-function getPlayerItemCount(cid, itemId, ...) local p = Player(cid) return p and p:getItemCount(itemId, ...) or false end
-function getPlayerWeapon(cid) local p = Player(cid) return p and p:getWeaponType() or false end
+
+function getPlayerGuildRankId(cid)
+	local p = Player(cid)
+	return p and p:getGuildLevel() or false
+end
+
+function getPlayerGuildNick(cid)
+	local p = Player(cid)
+	return p and p:getGuildNick() or false
+end
+
+function getPlayerMasterPos(cid)
+	local p = Player(cid)
+	return p and p:getTown():getTemplePosition() or false
+end
+
+function getPlayerItemCount(cid, itemId, ...)
+	local p = Player(cid)
+	return p and p:getItemCount(itemId, ...) or false
+end
+
+function getPlayerWeapon(cid)
+	local p = Player(cid)
+	return p and p:getWeaponType() or false
+end
+
 function getPlayerSlotItem(cid, slot)
 	local player = Player(cid)
 	if not player then
@@ -499,6 +829,7 @@ function getPlayerSlotItem(cid, slot)
 	end
 	return pushThing(player:getSlotItem(slot))
 end
+
 function getPlayerItemById(cid, deepSearch, itemId, ...)
 	local player = Player(cid)
 	if not player then
@@ -506,18 +837,40 @@ function getPlayerItemById(cid, deepSearch, itemId, ...)
 	end
 	return pushThing(player:getItemById(itemId, deepSearch, ...))
 end
+
 function getPlayerFood(cid)
 	local player = Player(cid)
 	if not player then
 		return false
 	end
-	local c = player:getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT) return c and math.floor(c:getTicks() / 1000) or 0
+	local c = player:getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT)
+	return c and math.floor(c:getTicks() / 1000) or 0
 end
-function canPlayerLearnInstantSpell(cid, name) local p = Player(cid) return p and p:canLearnSpell(name) or false end
-function getPlayerLearnedInstantSpell(cid, name) local p = Player(cid) return p and p:hasLearnedSpell(name) or false end
-function isPlayerGhost(cid) local p = Player(cid) return p and p:isInGhostMode() or false end
-function isPlayerPzLocked(cid) local p = Player(cid) return p and p:isPzLocked() or false end
-function isPremium(cid) local p = Player(cid) return p and p:isPremium() or false end
+
+function canPlayerLearnInstantSpell(cid, name)
+	local p = Player(cid)
+	return p and p:canLearnSpell(name) or false
+end
+
+function getPlayerLearnedInstantSpell(cid, name)
+	local p = Player(cid)
+	return p and p:hasLearnedSpell(name) or false
+end
+
+function isPlayerGhost(cid)
+	local p = Player(cid)
+	return p and p:isInGhostMode() or false
+end
+
+function isPlayerPzLocked(cid)
+	local p = Player(cid)
+	return p and p:isPzLocked() or false
+end
+
+function isPremium(cid)
+	local p = Player(cid)
+	return p and p:isPremium() or false
+end
 
 STORAGEVALUE_EMPTY = -1
 function Player:getStorageValue(key)
@@ -546,7 +899,9 @@ function getPlayersByIPAddress(ip, mask)
 		return result
 	end
 
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking getPlayersByIPAddress with a numeric IP is deprecated and will be removed in the future. Please use the string representation of the IP.")
+	print("[Warning - " ..
+	debug.getinfo(2).source:match("@?(.*)") ..
+	"] Invoking getPlayersByIPAddress with a numeric IP is deprecated and will be removed in the future. Please use the string representation of the IP.")
 
 	if not mask then mask = 0xFFFFFFFF end
 	local masked = ip & mask
@@ -560,6 +915,7 @@ function getPlayersByIPAddress(ip, mask)
 
 	return result
 end
+
 getPlayersByIp = getPlayersByIPAddress
 function getOnlinePlayers()
 	local result = {}
@@ -568,6 +924,7 @@ function getOnlinePlayers()
 	end
 	return result
 end
+
 getPlayersOnline = getOnlinePlayers
 function getPlayersByAccountNumber(accountNumber)
 	local result = {}
@@ -578,6 +935,7 @@ function getPlayersByAccountNumber(accountNumber)
 	end
 	return result
 end
+
 function getPlayerGUIDByName(name)
 	local player = Player(name)
 	if player then
@@ -600,16 +958,56 @@ end
 getPlayerAccountBalance = getPlayerBalance
 getIpByName = getIPByPlayerName
 
-function setPlayerStorageValue(cid, key, value) local p = Player(cid) return p and p:setStorageValue(key, value) or false end
-function doPlayerSetNameDescription() debugPrint("Deprecated function, use Player:onLook event instead.") return true end
-function doPlayerSendChannelMessage(cid, author, message, SpeakClasses, channel) local p = Player(cid) return p and p:sendChannelMessage(author, message, SpeakClasses, channel) or false end
-function doPlayerSetMaxCapacity(cid, cap) local p = Player(cid) return p and p:setCapacity(cap) or false end
-function doPlayerSetSpecialDescription() debugPrint("Deprecated function, use Player:onLook event instead.") return true end
-function doPlayerSetBalance(cid, balance) local p = Player(cid) return p and p:setBankBalance(balance) or false end
-function doPlayerSetPromotionLevel(cid, level) local p = Player(cid) return p and p:setVocation(p:getVocation():getPromotion()) or false end
-function doPlayerAddMoney(cid, money) local p = Player(cid) return p and p:addMoney(money) or false end
-function doPlayerRemoveMoney(cid, money) local p = Player(cid) return p and p:removeMoney(money) or false end
-function doPlayerTakeItem(cid, itemid, count) local p = Player(cid) return p and p:removeItem(itemid, count) or false end
+function setPlayerStorageValue(cid, key, value)
+	local p = Player(cid)
+	return p and p:setStorageValue(key, value) or false
+end
+
+function doPlayerSetNameDescription()
+	debugPrint("Deprecated function, use Player:onLook event instead.")
+	return true
+end
+
+function doPlayerSendChannelMessage(cid, author, message, SpeakClasses, channel)
+	local p = Player(cid)
+	return p and p:sendChannelMessage(author, message, SpeakClasses, channel) or false
+end
+
+function doPlayerSetMaxCapacity(cid, cap)
+	local p = Player(cid)
+	return p and p:setCapacity(cap) or false
+end
+
+function doPlayerSetSpecialDescription()
+	debugPrint("Deprecated function, use Player:onLook event instead.")
+	return true
+end
+
+function doPlayerSetBalance(cid, balance)
+	local p = Player(cid)
+	return p and p:setBankBalance(balance) or false
+end
+
+function doPlayerSetPromotionLevel(cid, level)
+	local p = Player(cid)
+	return p and p:setVocation(p:getVocation():getPromotion()) or false
+end
+
+function doPlayerAddMoney(cid, money)
+	local p = Player(cid)
+	return p and p:addMoney(money) or false
+end
+
+function doPlayerRemoveMoney(cid, money)
+	local p = Player(cid)
+	return p and p:removeMoney(money) or false
+end
+
+function doPlayerTakeItem(cid, itemid, count)
+	local p = Player(cid)
+	return p and p:removeItem(itemid, count) or false
+end
+
 function doPlayerTransferMoneyTo(cid, target, money)
 	if not isValidMoney(money) then
 		return false
@@ -617,24 +1015,93 @@ function doPlayerTransferMoneyTo(cid, target, money)
 	local p = Player(cid)
 	return p and p:transferMoneyTo(target, money) or false
 end
-function doPlayerSave(cid) local p = Player(cid) return p and p:save() or false end
-function doPlayerAddSoul(cid, soul) local p = Player(cid) return p and p:addSoul(soul) or false end
-function doPlayerSetVocation(cid, vocation) local p = Player(cid) return p and p:setVocation(Vocation(vocation)) or false end
-function doPlayerSetTown(cid, town) local p = Player(cid) return p and p:setTown(Town(town)) or false end
-function setPlayerGroupId(cid, groupId) local p = Player(cid) return p and p:setGroup(Group(groupId)) or false end
+
+function doPlayerSave(cid)
+	local p = Player(cid)
+	return p and p:save() or false
+end
+
+function doPlayerAddSoul(cid, soul)
+	local p = Player(cid)
+	return p and p:addSoul(soul) or false
+end
+
+function doPlayerSetVocation(cid, vocation)
+	local p = Player(cid)
+	return p and p:setVocation(Vocation(vocation)) or false
+end
+
+function doPlayerSetTown(cid, town)
+	local p = Player(cid)
+	return p and p:setTown(Town(town)) or false
+end
+
+function setPlayerGroupId(cid, groupId)
+	local p = Player(cid)
+	return p and p:setGroup(Group(groupId)) or false
+end
+
 doPlayerSetGroupId = setPlayerGroupId
-function doPlayerSetSex(cid, sex) local p = Player(cid) return p and p:setSex(sex) or false end
-function doPlayerSetGuildLevel(cid, level) local p = Player(cid) return p and p:setGuildLevel(level) or false end
-function doPlayerSetGuildNick(cid, nick) local p = Player(cid) return p and p:setGuildNick(nick) or false end
-function doPlayerSetOfflineTrainingSkill(cid, skillId) local p = Player(cid) return p and p:setOfflineTrainingSkill(skillId) or false end
-function doShowTextDialog(cid, itemId, text) local p = Player(cid) return p and p:showTextDialog(itemId, text) or false end
-function doPlayerAddItemEx(cid, uid, ...) local p = Player(cid) return p and p:addItemEx(Item(uid), ...) or false end
-function doPlayerRemoveItem(cid, itemid, count, ...) local p = Player(cid) return p and p:removeItem(itemid, count, ...) or false end
-function doPlayerAddPremiumDays(cid, days) local p = Player(cid) return p and p:addPremiumDays(days) or false end
-function doPlayerRemovePremiumDays(cid, days) local p = Player(cid) return p and p:removePremiumDays(days) or false end
-function doPlayerSetStamina(cid, minutes) local p = Player(cid) return p and p:setStamina(minutes) or false end
-function doPlayerAddBlessing(cid, blessing) local p = Player(cid) return p and p:addBlessing(blessing) or false end
-function doPlayerAddOutfit(cid, lookType, addons) local p = Player(cid) return p and p:addOutfitAddon(lookType, addons) or false end
+function doPlayerSetSex(cid, sex)
+	local p = Player(cid)
+	return p and p:setSex(sex) or false
+end
+
+function doPlayerSetGuildLevel(cid, level)
+	local p = Player(cid)
+	return p and p:setGuildLevel(level) or false
+end
+
+function doPlayerSetGuildNick(cid, nick)
+	local p = Player(cid)
+	return p and p:setGuildNick(nick) or false
+end
+
+function doPlayerSetOfflineTrainingSkill(cid, skillId)
+	local p = Player(cid)
+	return p and p:setOfflineTrainingSkill(skillId) or false
+end
+
+function doShowTextDialog(cid, itemId, text)
+	local p = Player(cid)
+	return p and p:showTextDialog(itemId, text) or false
+end
+
+function doPlayerAddItemEx(cid, uid, ...)
+	local p = Player(cid)
+	return p and p:addItemEx(Item(uid), ...) or false
+end
+
+function doPlayerRemoveItem(cid, itemid, count, ...)
+	local p = Player(cid)
+	return p and p:removeItem(itemid, count, ...) or false
+end
+
+function doPlayerAddPremiumDays(cid, days)
+	local p = Player(cid)
+	return p and p:addPremiumDays(days) or false
+end
+
+function doPlayerRemovePremiumDays(cid, days)
+	local p = Player(cid)
+	return p and p:removePremiumDays(days) or false
+end
+
+function doPlayerSetStamina(cid, minutes)
+	local p = Player(cid)
+	return p and p:setStamina(minutes) or false
+end
+
+function doPlayerAddBlessing(cid, blessing)
+	local p = Player(cid)
+	return p and p:addBlessing(blessing) or false
+end
+
+function doPlayerAddOutfit(cid, lookType, addons)
+	local p = Player(cid)
+	return p and p:addOutfitAddon(lookType, addons) or false
+end
+
 function doPlayerRemOutfit(cid, lookType, addons)
 	local player = Player(cid)
 	if not player then
@@ -645,29 +1112,106 @@ function doPlayerRemOutfit(cid, lookType, addons)
 	end
 	return player:removeOutfitAddon(lookType, addons)
 end
+
 doPlayerRemoveOutfit = doPlayerRemOutfit
-function doPlayerAddAddons(cid, addon) local p = Player(cid) return p and p:addAddonToAllOutfits(addon) or false end
-function canPlayerWearOutfit(cid, lookType, addons) local p = Player(cid) return p and p:hasOutfit(lookType, addons) or false end
-function doPlayerAddMount(cid, mountId) local p = Player(cid) return p and p:addMount(mountId) or false end
-function doPlayerRemoveMount(cid, mountId) local p = Player(cid) return p and p:removeMount(mountId) or false end
-function doPlayerSendOutfitWindow(cid) local p = Player(cid) return p and p:sendOutfitWindow() or false end
-function doPlayerSendCancel(cid, text) local p = Player(cid) return p and p:sendCancelMessage(text) or false end
-function doPlayerFeed(cid, food) local p = Player(cid) return p and p:feed(food) or false end
-function playerLearnInstantSpell(cid, name) local p = Player(cid) return p and p:learnSpell(name) or false end
+function doPlayerAddAddons(cid, addon)
+	local p = Player(cid)
+	return p and p:addAddonToAllOutfits(addon) or false
+end
+
+function canPlayerWearOutfit(cid, lookType, addons)
+	local p = Player(cid)
+	return p and p:hasOutfit(lookType, addons) or false
+end
+
+function doPlayerAddMount(cid, mountId)
+	local p = Player(cid)
+	return p and p:addMount(mountId) or false
+end
+
+function doPlayerRemoveMount(cid, mountId)
+	local p = Player(cid)
+	return p and p:removeMount(mountId) or false
+end
+
+function doPlayerSendOutfitWindow(cid)
+	local p = Player(cid)
+	return p and p:sendOutfitWindow() or false
+end
+
+function doPlayerSendCancel(cid, text)
+	local p = Player(cid)
+	return p and p:sendCancelMessage(text) or false
+end
+
+function doPlayerFeed(cid, food)
+	local p = Player(cid)
+	return p and p:feed(food) or false
+end
+
+function playerLearnInstantSpell(cid, name)
+	local p = Player(cid)
+	return p and p:learnSpell(name) or false
+end
+
 doPlayerLearnInstantSpell = playerLearnInstantSpell
-function doPlayerUnlearnInstantSpell(cid, name) local p = Player(cid) return p and p:forgetSpell(name) or false end
-function doPlayerPopupFYI(cid, message) local p = Player(cid) return p and p:popupFYI(message) or false end
-function doSendTutorial(cid, tutorialId) local p = Player(cid) return p and p:sendTutorial(tutorialId) or false end
+function doPlayerUnlearnInstantSpell(cid, name)
+	local p = Player(cid)
+	return p and p:forgetSpell(name) or false
+end
+
+function doPlayerPopupFYI(cid, message)
+	local p = Player(cid)
+	return p and p:popupFYI(message) or false
+end
+
+function doSendTutorial(cid, tutorialId)
+	local p = Player(cid)
+	return p and p:sendTutorial(tutorialId) or false
+end
+
 doPlayerSendTutorial = doSendTutorial
-function doAddMapMark(cid, pos, type, description) local p = Player(cid) return p and p:addMapMark(pos, type, description or "") or false end
+function doAddMapMark(cid, pos, type, description)
+	local p = Player(cid)
+	return p and p:addMapMark(pos, type, description or "") or false
+end
+
 doPlayerAddMapMark = doAddMapMark
-function doPlayerSendTextMessage(cid, type, text, ...) local p = Player(cid) return p and p:sendTextMessage(type, text, ...) or false end
-function doSendAnimatedText() debugPrint("Deprecated function.") return true end
-function getPlayerAccountManager() debugPrint("Deprecated function.") return true end
-function doPlayerSetExperienceRate() debugPrint("Deprecated function, use Player:onGainExperience event instead.") return true end
-function doPlayerSetSkillLevel(cid, skillId, value, ...) local p = Player(cid) return p and p:addSkill(skillId, value, ...) end
-function doPlayerSetMagicLevel(cid, value) local p = Player(cid) return p and p:addMagicLevel(value) end
-function doPlayerAddLevel(cid, amount, round) local p = Player(cid) return p and p:addLevel(amount, round) end
+function doPlayerSendTextMessage(cid, type, text, ...)
+	local p = Player(cid)
+	return p and p:sendTextMessage(type, text, ...) or false
+end
+
+function doSendAnimatedText()
+	debugPrint("Deprecated function.")
+	return true
+end
+
+function getPlayerAccountManager()
+	debugPrint("Deprecated function.")
+	return true
+end
+
+function doPlayerSetExperienceRate()
+	debugPrint("Deprecated function, use Player:onGainExperience event instead.")
+	return true
+end
+
+function doPlayerSetSkillLevel(cid, skillId, value, ...)
+	local p = Player(cid)
+	return p and p:addSkill(skillId, value, ...)
+end
+
+function doPlayerSetMagicLevel(cid, value)
+	local p = Player(cid)
+	return p and p:addMagicLevel(value)
+end
+
+function doPlayerAddLevel(cid, amount, round)
+	local p = Player(cid)
+	return p and p:addLevel(amount, round)
+end
+
 function doPlayerAddExp(cid, exp, useMult, ...)
 	local player = Player(cid)
 	if not player then
@@ -679,11 +1223,24 @@ function doPlayerAddExp(cid, exp, useMult, ...)
 	end
 	return player:addExperience(exp, ...)
 end
+
 doPlayerAddExperience = doPlayerAddExp
-function doPlayerAddManaSpent(cid, mana) local p = Player(cid) return p and p:addManaSpent(mana) or false end
+function doPlayerAddManaSpent(cid, mana)
+	local p = Player(cid)
+	return p and p:addManaSpent(mana) or false
+end
+
 doPlayerAddSpentMana = doPlayerAddManaSpent
-function doPlayerAddSkillTry(cid, skillid, n) local p = Player(cid) return p and p:addSkillTries(skillid, n) or false end
-function doPlayerAddMana(cid, mana, ...) local p = Player(cid) return p and p:addMana(mana, ...) or false end
+function doPlayerAddSkillTry(cid, skillid, n)
+	local p = Player(cid)
+	return p and p:addSkillTries(skillid, n) or false
+end
+
+function doPlayerAddMana(cid, mana, ...)
+	local p = Player(cid)
+	return p and p:addMana(mana, ...) or false
+end
+
 function doPlayerJoinParty(cid, leaderId)
 	local player = Player(cid)
 	if not player then
@@ -714,6 +1271,7 @@ function doPlayerJoinParty(cid, leaderId)
 	party:addMember(player)
 	return true
 end
+
 function getPartyMembers(cid)
 	local player = Player(cid)
 	if not player then
@@ -725,7 +1283,7 @@ function getPartyMembers(cid)
 		return false
 	end
 
-	local result = {party:getLeader():getId()}
+	local result = { party:getLeader():getId() }
 	for _, member in ipairs(party:getMembers()) do
 		result[#result + 1] = member:getId()
 	end
@@ -748,6 +1306,7 @@ function getMonsterTargetList(cid)
 	end
 	return result
 end
+
 function getMonsterFriendList(cid)
 	local monster = Monster(cid)
 	if not monster then
@@ -764,6 +1323,7 @@ function getMonsterFriendList(cid)
 	end
 	return result
 end
+
 function doSetMonsterTarget(cid, target)
 	local monster = Monster(cid)
 	if not monster then
@@ -782,6 +1342,7 @@ function doSetMonsterTarget(cid, target)
 	monster:selectTarget(target)
 	return true
 end
+
 doMonsterSetTarget = doSetMonsterTarget
 function doMonsterChangeTarget(cid)
 	local monster = Monster(cid)
@@ -796,12 +1357,17 @@ function doMonsterChangeTarget(cid)
 	monster:searchTarget(1)
 	return true
 end
+
 function doCreateNpc(name, pos, ...)
-	local npc = Game.createNpc(name, pos, ...) return npc and npc:setMasterPos(pos) or false
+	local npc = Game.createNpc(name, pos, ...)
+	return npc and npc:setMasterPos(pos) or false
 end
+
 function doSummonCreature(name, pos, ...)
-	local m = Game.createMonster(name, pos, ...) return m and m:getId() or false
+	local m = Game.createMonster(name, pos, ...)
+	return m and m:getId() or false
 end
+
 doCreateMonster = doSummonCreature
 function doConvinceCreature(cid, target)
 	local creature = Creature(cid)
@@ -817,6 +1383,7 @@ function doConvinceCreature(cid, target)
 	creature:addSummon(targetCreature)
 	return true
 end
+
 function doSummonMonster(cid, name)
 	local player = Player(cid)
 	local position = player:getPosition()
@@ -831,17 +1398,51 @@ function doSummonMonster(cid, name)
 	return true
 end
 
-function getTownId(townName) local t = Town(townName) return t and t:getId() or false end
-function getTownName(townId) local t = Town(townId) return t and t:getName() or false end
-function getTownTemplePosition(townId) local t = Town(townId) return t and t:getTemplePosition() or false end
+function getTownId(townName)
+	local t = Town(townName)
+	return t and t:getId() or false
+end
 
-function doSetItemActionId(uid, actionId) local i = Item(uid) return i and i:setActionId(actionId) or false end
-function doTransformItem(uid, newItemId, ...) local i = Item(uid) return i and i:transform(newItemId, ...) or false end
-function doChangeTypeItem(uid, newType) local i = Item(uid) return i and i:transform(i:getId(), newType) or false end
-function doRemoveItem(uid, ...) local i = Item(uid) return i and i:remove(...) or false end
+function getTownName(townId)
+	local t = Town(townId)
+	return t and t:getName() or false
+end
 
-function getContainerSize(uid) local c = Container(uid) return c and c:getSize() or false end
-function getContainerCap(uid) local c = Container(uid) return c and c:getCapacity() or false end
+function getTownTemplePosition(townId)
+	local t = Town(townId)
+	return t and t:getTemplePosition() or false
+end
+
+function doSetItemActionId(uid, actionId)
+	local i = Item(uid)
+	return i and i:setActionId(actionId) or false
+end
+
+function doTransformItem(uid, newItemId, ...)
+	local i = Item(uid)
+	return i and i:transform(newItemId, ...) or false
+end
+
+function doChangeTypeItem(uid, newType)
+	local i = Item(uid)
+	return i and i:transform(i:getId(), newType) or false
+end
+
+function doRemoveItem(uid, ...)
+	local i = Item(uid)
+	return i and i:remove(...) or false
+end
+
+function getContainerSize(uid)
+	local c = Container(uid)
+	return c and c:getSize() or false
+end
+
+function getContainerCap(uid)
+	local c = Container(uid)
+	return c and c:getCapacity() or false
+end
+
 function getContainerItem(uid, slot)
 	local container = Container(uid)
 	if not container then
@@ -873,7 +1474,10 @@ function doAddContainerItem(uid, itemid, count)
 end
 
 function doSendMagicEffect(pos, magicEffect, ...) return Position(pos):sendMagicEffect(magicEffect, ...) end
-function doSendDistanceShoot(fromPos, toPos, distanceEffect, ...) return Position(fromPos):sendDistanceEffect(toPos, distanceEffect, ...) end
+
+function doSendDistanceShoot(fromPos, toPos, distanceEffect, ...) return Position(fromPos):sendDistanceEffect(toPos,
+		distanceEffect, ...) end
+
 function isSightClear(fromPos, toPos, floorCheck) return Position(fromPos):isSightClear(toPos, floorCheck) end
 
 function getPromotedVocation(vocationId)
@@ -888,6 +1492,7 @@ function getPromotedVocation(vocationId)
 	end
 	return promotedVocation:getId()
 end
+
 getPlayerPromotionLevel = getPromotedVocation
 
 function getGuildId(guildName)
@@ -901,26 +1506,58 @@ function getGuildId(guildName)
 	return guildId
 end
 
-function getHouseName(houseId) local h = House(houseId) return h and h:getName() or false end
-function getHouseOwner(houseId) local h = House(houseId) return h and h:getOwnerGuid() or false end
-function getHouseEntry(houseId) local h = House(houseId) return h and h:getExitPosition() or false end
-function getHouseTown(houseId) local h = House(houseId) if not h then return false end local t = h:getTown() return t and t:getId() or false end
-function getHouseTilesSize(houseId) local h = House(houseId) return h and h:getTileCount() or false end
+function getHouseName(houseId)
+	local h = House(houseId)
+	return h and h:getName() or false
+end
+
+function getHouseOwner(houseId)
+	local h = House(houseId)
+	return h and h:getOwnerGuid() or false
+end
+
+function getHouseEntry(houseId)
+	local h = House(houseId)
+	return h and h:getExitPosition() or false
+end
+
+function getHouseTown(houseId)
+	local h = House(houseId)
+	if not h then return false end
+	local t = h:getTown()
+	return t and t:getId() or false
+end
+
+function getHouseTilesSize(houseId)
+	local h = House(houseId)
+	return h and h:getTileCount() or false
+end
 
 function isItemStackable(itemId) return ItemType(itemId):isStackable() end
+
 function isItemRune(itemId) return ItemType(itemId):isRune() end
+
 function isItemDoor(itemId) return ItemType(itemId):isDoor() end
+
 function isItemContainer(itemId) return ItemType(itemId):isContainer() end
+
 function isItemFluidContainer(itemId) return ItemType(itemId):isFluidContainer() end
+
 function isItemMovable(itemId) return ItemType(itemId):isMovable() end
-function isCorpse(uid) local i = Item(uid) return i and ItemType(i:getId()):isCorpse() or false end
+
+function isCorpse(uid)
+	local i = Item(uid)
+	return i and ItemType(i:getId()):isCorpse() or false
+end
 
 isItemMoveable = isItemMovable
 isMoveable = isMovable
 
 function getItemName(itemId) return ItemType(itemId):getName() end
+
 getItemNameById = getItemName
 function getItemWeight(itemId, ...) return ItemType(itemId):getWeight(...) / 100 end
+
 function getItemDescriptions(itemId)
 	local itemType = ItemType(itemId)
 	return {
@@ -930,6 +1567,7 @@ function getItemDescriptions(itemId)
 		description = itemType:getDescription()
 	}
 end
+
 function getItemIdByName(name)
 	local id = ItemType(name):getId()
 	if id == 0 then
@@ -937,6 +1575,7 @@ function getItemIdByName(name)
 	end
 	return id
 end
+
 function getItemWeightByUID(uid, ...)
 	local item = Item(uid)
 	if not item then
@@ -944,8 +1583,10 @@ function getItemWeightByUID(uid, ...)
 	end
 
 	local itemType = ItemType(item:getId())
-	return itemType:isStackable() and (itemType:getWeight(item:getCount(), ...) / 100) or (itemType:getWeight(1, ...) / 100)
+	return itemType:isStackable() and (itemType:getWeight(item:getCount(), ...) / 100) or
+	(itemType:getWeight(1, ...) / 100)
 end
+
 function getItemRWInfo(uid)
 	local item = Item(uid)
 	if not item then
@@ -963,8 +1604,14 @@ function getItemRWInfo(uid)
 	end
 	return rwFlags
 end
+
 function getContainerCapById(itemId) return ItemType(itemId):getCapacity() end
-function getFluidSourceType(itemId) local it = ItemType(itemId) return it.id ~= 0 and it:getFluidSource() or false end
+
+function getFluidSourceType(itemId)
+	local it = ItemType(itemId)
+	return it.id ~= 0 and it:getFluidSource() or false
+end
+
 function hasProperty(uid, prop)
 	local item = Item(uid)
 	if not item then
@@ -1004,6 +1651,7 @@ function doSetItemText(uid, text, writer, date)
 
 	return true
 end
+
 function doSetItemSpecialDescription(uid, desc)
 	local item = Item(uid)
 	if not item then
@@ -1017,12 +1665,31 @@ function doSetItemSpecialDescription(uid, desc)
 	end
 	return true
 end
-function doDecayItem(uid) local i = Item(uid) return i and i:decay() or false end
 
-function setHouseOwner(id, guid) local h = House(id) return h and h:setOwnerGuid(guid) or false end
-function getHouseRent(id) local h = House(id) return h and h:getRent() or nil end
-function getHouseAccessList(id, listId) local h = House(id) return h and h:getAccessList(listId) or nil end
-function setHouseAccessList(id, listId, listText) local h = House(id) return h and h:setAccessList(listId, listText) or false end
+function doDecayItem(uid)
+	local i = Item(uid)
+	return i and i:decay() or false
+end
+
+function setHouseOwner(id, guid)
+	local h = House(id)
+	return h and h:setOwnerGuid(guid) or false
+end
+
+function getHouseRent(id)
+	local h = House(id)
+	return h and h:getRent() or nil
+end
+
+function getHouseAccessList(id, listId)
+	local h = House(id)
+	return h and h:getAccessList(listId) or nil
+end
+
+function setHouseAccessList(id, listId, listText)
+	local h = House(id)
+	return h and h:setAccessList(listId, listText) or false
+end
 
 function getHouseByPlayerGUID(playerGUID)
 	for _, house in ipairs(Game.getHouses()) do
@@ -1119,7 +1786,10 @@ function getTopCreature(position)
 	return pushThing(t:getTopCreature())
 end
 
-function queryTileAddThing(thing, position, ...) local t = Tile(position) return t and t:queryAdd(thing, ...) or false end
+function queryTileAddThing(thing, position, ...)
+	local t = Tile(position)
+	return t and t:queryAdd(thing, ...) or false
+end
 
 function doTeleportThing(uid, dest, pushMovement)
 	if type(uid) == "userdata" then
@@ -1163,6 +1833,7 @@ function getThingPos(uid)
 	position.stackpos = stackpos
 	return position
 end
+
 getThingPosition = getThingPos
 
 function getThingfromPos(pos)
@@ -1248,11 +1919,13 @@ saveData = saveServer
 function getGlobalStorageValue(key)
 	return Game.getStorageValue(key) or -1
 end
+
 getStorage = getGlobalStorageValue
 function setGlobalStorageValue(key, value)
 	Game.setStorageValue(key, value)
 	return true
 end
+
 doSetStorage = setGlobalStorageValue
 getWorldType = Game.getWorldType
 
@@ -1272,10 +1945,13 @@ function doExecuteRaid(raidName)
 	debugPrint("Deprecated function, use Game.startEvent('" .. raidName .. "') instead.")
 	return Game.startEvent(raidName)
 end
+
 Game.startRaid = doExecuteRaid
 
 function Game.convertIpToString(ip)
-	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Game.convertIpToString is deprecated and will be removed in the future. Use the return value of player:getIp() instead.")
+	print("[Warning - " ..
+	debug.getinfo(2).source:match("@?(.*)") ..
+	"] Function Game.convertIpToString is deprecated and will be removed in the future. Use the return value of player:getIp() instead.")
 
 	if type(ip) == "string" then
 		return ip
@@ -1329,16 +2005,22 @@ function broadcastMessage(message, messageType)
 	Game.broadcastMessage(message, messageType)
 	print("> Broadcasted message: \"" .. message .. "\".")
 end
+
 doBroadcastMessage = broadcastMessage
 
 function Guild.addMember(self, player)
 	return player:setGuild(self)
 end
+
 function Guild.removeMember(self, player)
 	return player:getGuild() == self and player:setGuild(nil)
 end
 
-function getPlayerInstantSpellCount(cid) local p = Player(cid) return p and #p:getInstantSpells() end
+function getPlayerInstantSpellCount(cid)
+	local p = Player(cid)
+	return p and #p:getInstantSpells()
+end
+
 function getPlayerInstantSpellInfo(cid, spellId)
 	local player = Player(cid)
 	if not player then
@@ -1353,8 +2035,16 @@ function getPlayerInstantSpellInfo(cid, spellId)
 	return spell
 end
 
-function doSetItemOutfit(cid, item, time) local c = Creature(cid) return c and c:setItemOutfit(item, time) end
-function doSetMonsterOutfit(cid, name, time) local c = Creature(cid) return c and c:setMonsterOutfit(name, time) end
+function doSetItemOutfit(cid, item, time)
+	local c = Creature(cid)
+	return c and c:setItemOutfit(item, time)
+end
+
+function doSetMonsterOutfit(cid, name, time)
+	local c = Creature(cid)
+	return c and c:setMonsterOutfit(name, time)
+end
+
 function doSetCreatureOutfit(cid, outfit, time)
 	local creature = Creature(cid)
 	if not creature then
@@ -1406,10 +2096,13 @@ function doCreateItemEx(itemid, count)
 	return false
 end
 
-function doMoveCreature(cid, direction) local c = Creature(cid) return c and c:move(direction) end
+function doMoveCreature(cid, direction)
+	local c = Creature(cid)
+	return c and c:move(direction)
+end
 
 function createFunctions(class)
-	local exclude = {[2] = {"is"}, [3] = {"get", "set", "add", "can"}, [4] = {"need"}}
+	local exclude = { [2] = { "is" }, [3] = { "get", "set", "add", "can" }, [4] = { "need" } }
 	local temp = {}
 	for name, func in pairs(class) do
 		local add = true
@@ -1425,7 +2118,7 @@ function createFunctions(class)
 			local get = "get" .. str
 			local set = "set" .. str
 			if not (rawget(class, get) and rawget(class, set)) then
-				table.insert(temp, {set, setFunc, get, getFunc})
+				table.insert(temp, { set, setFunc, get, getFunc })
 			end
 		end
 	end
@@ -1548,10 +2241,15 @@ if not loadstring then loadstring = load end
 
 bit = bit or {}
 function bit.bnot(a) return ~a end
+
 function bit.band(a, b) return a & b end
+
 function bit.bor(a, b) return a | b end
+
 function bit.bxor(a, b) return a ~ b end
+
 function bit.lshift(a, b) return a << b end
+
 function bit.rshift(a, b) return a >> b end
 
 function table.maxn(t)

--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -241,7 +241,7 @@ do
 end
 
 function pushThing(thing)
-	local t = { uid = 0, itemid = 0, type = 0, actionid = 0 }
+	local t = {uid = 0, itemid = 0, type = 0, actionid = 0}
 	if thing then
 		if thing:isItem() then
 			t.uid = thing:getUniqueId()
@@ -273,35 +273,25 @@ setCombatFormula = Combat.setFormula
 setCombatParam = Combat.setParameter
 
 Combat.delete = function(...)
-	print("[Warning - " ..
-	debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.delete is deprecated and will be removed in the future")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.delete is deprecated and will be removed in the future")
 end
 
 Combat.setCondition = function(...)
-	print("[Warning - " ..
-	debug.getinfo(2).source:match("@?(.*)") ..
-	"] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Combat.setCondition was renamed to Combat.addCondition and will be removed in the future")
 	Combat.addCondition(...)
 end
 
 setCombatCondition = function(...)
-	print("[Warning - " ..
-	debug.getinfo(2).source:match("@?(.*)") ..
-	"] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function setCombatCondition was renamed to addCombatCondition and will be removed in the future")
 	Combat.addCondition(...)
 end
 
 function doTargetCombatHealth(...) return doTargetCombat(...) end
-
 function doAreaCombatHealth(...) return doAreaCombat(...) end
-
 doCombatAreaHealth = doAreaCombatHealth
-function doTargetCombatMana(cid, target, min, max, effect) return doTargetCombat(cid, target, COMBAT_MANADRAIN, min, max,
-		effect) end
-
+function doTargetCombatMana(cid, target, min, max, effect) return doTargetCombat(cid, target, COMBAT_MANADRAIN, min, max, effect) end
 doCombatAreaMana = doTargetCombatMana
-function doAreaCombatMana(cid, pos, area, min, max, effect) return doAreaCombat(cid, COMBAT_MANADRAIN, pos, area, min,
-		max, effect) end
+function doAreaCombatMana(cid, pos, area, min, max, effect) return doAreaCombat(cid, COMBAT_MANADRAIN, pos, area, min, max, effect) end
 
 createConditionObject = Condition
 setConditionParam = Condition.setParameter
@@ -312,91 +302,27 @@ addOutfitCondition = Condition.setOutfit
 function doCombat(cid, combat, var) return combat:execute(cid, var) end
 
 function isCreature(cid) return Creature(cid) end
-
 function isPlayer(cid) return Player(cid) end
-
 function isMonster(cid) return Monster(cid) end
-
-function isSummon(cid)
-	local c = Creature(cid)
-	return c and c:getMaster()
-end
-
+function isSummon(cid) local c = Creature(cid) return c and c:getMaster() end
 function isNpc(cid) return Npc(cid) end
-
 function isItem(uid) return Item(uid) end
-
 function isContainer(uid) return Container(uid) end
 
-function getCreatureName(cid)
-	local c = Creature(cid)
-	return c and c:getName() or false
-end
-
-function getCreatureStorage(uid, key)
-	local c = Creature(uid)
-	return c and c:getStorageValue(key) or false
-end
-
-function getCreatureHealth(cid)
-	local c = Creature(cid)
-	return c and c:getHealth() or false
-end
-
-function getCreatureMaxHealth(cid)
-	local c = Creature(cid)
-	return c and c:getMaxHealth() or false
-end
-
-function getCreatureMana(cid)
-	local c = Creature(cid)
-	return c and c:getMana() or false
-end
-
-function getCreatureMaxMana(cid)
-	local c = Creature(cid)
-	return c and c:getMaxMana() or false
-end
-
-function getCreaturePosition(cid)
-	local c = Creature(cid)
-	return c and c:getPosition() or false
-end
-
-function getCreatureOutfit(cid)
-	local c = Creature(cid)
-	return c and c:getOutfit() or false
-end
-
-function getCreatureSpeed(cid)
-	local c = Creature(cid)
-	return c and c:getSpeed() or false
-end
-
-function getCreatureBaseSpeed(cid)
-	local c = Creature(cid)
-	return c and c:getBaseSpeed() or false
-end
-
-function getCreatureLookDirection(cid)
-	local c = Creature(cid)
-	return c and c:getDirection() or false
-end
-
-function getCreatureHideHealth(cid)
-	local c = Creature(cid)
-	return c and c:isHealthHidden() or false
-end
-
-function getCreatureSkullType(cid)
-	local c = Creature(cid)
-	return c and c:getSkull() or false
-end
-
-function getCreatureNoMove(cid)
-	local c = Creature(cid)
-	return c and c:isMovementBlocked() or false
-end
+function getCreatureName(cid) local c = Creature(cid) return c and c:getName() or false end
+function getCreatureStorage(uid, key) local c = Creature(uid) return c and c:getStorageValue(key) or false end
+function getCreatureHealth(cid) local c = Creature(cid) return c and c:getHealth() or false end
+function getCreatureMaxHealth(cid) local c = Creature(cid) return c and c:getMaxHealth() or false end
+function getCreatureMana(cid) local c = Creature(cid) return c and c:getMana() or false end
+function getCreatureMaxMana(cid) local c = Creature(cid) return c and c:getMaxMana() or false end
+function getCreaturePosition(cid) local c = Creature(cid) return c and c:getPosition() or false end
+function getCreatureOutfit(cid) local c = Creature(cid) return c and c:getOutfit() or false end
+function getCreatureSpeed(cid) local c = Creature(cid) return c and c:getSpeed() or false end
+function getCreatureBaseSpeed(cid) local c = Creature(cid) return c and c:getBaseSpeed() or false end
+function getCreatureLookDirection(cid) local c = Creature(cid) return c and c:getDirection() or false end
+function getCreatureHideHealth(cid) local c = Creature(cid) return c and c:isHealthHidden() or false end
+function getCreatureSkullType(cid) local c = Creature(cid) return c and c:getSkull() or false end
+function getCreatureNoMove(cid) local c = Creature(cid) return c and c:isMovementBlocked() or false end
 
 function getCreatureTarget(cid)
 	local c = Creature(cid)
@@ -431,179 +357,47 @@ end
 
 getCreaturePos = getCreaturePosition
 
-function doCreatureAddHealth(cid, health)
-	local c = Creature(cid)
-	return c and c:addHealth(health) or false
-end
-
-function doCreatureAddMana(cid, mana)
-	local c = Creature(cid)
-	return c and c:addMana(mana) or false
-end
-
-function doRemoveCreature(cid)
-	local c = Creature(cid)
-	return c and c:remove() or false
-end
-
-function doCreatureSetStorage(uid, key, value)
-	local c = Creature(uid)
-	return c and c:setStorageValue(key, value) or false
-end
-
-function doCreatureSetLookDir(cid, direction)
-	local c = Creature(cid)
-	return c and c:setDirection(direction) or false
-end
-
-function doCreatureSetSkullType(cid, skull)
-	local c = Creature(cid)
-	return c and c:setSkull(skull) or false
-end
-
-function setCreatureMaxHealth(cid, health)
-	local c = Creature(cid)
-	return c and c:setMaxHealth(health) or false
-end
-
-function setCreatureMaxMana(cid, mana)
-	local c = Creature(cid)
-	return c and c:setMaxMana(mana) or false
-end
-
-function doCreatureSetHideHealth(cid, hide)
-	local c = Creature(cid)
-	return c and c:setHiddenHealth(hide) or false
-end
-
-function doCreatureSetNoMove(cid, block)
-	local c = Creature(cid)
-	return c and c:setMovementBlocked(block) or false
-end
-
-function doCreatureSay(cid, text, type, ...)
-	local c = Creature(cid)
-	return c and c:say(text, type, ...) or false
-end
-
-function doCreatureChangeOutfit(cid, outfit)
-	local c = Creature(cid)
-	return c and c:setOutfit(outfit) or false
-end
-
-function doSetCreatureDropLoot(cid, doDrop)
-	local c = Creature(cid)
-	return c and c:setDropLoot(doDrop) or false
-end
-
+function doCreatureAddHealth(cid, health) local c = Creature(cid) return c and c:addHealth(health) or false end
+function doCreatureAddMana(cid, mana) local c = Creature(cid) return c and c:addMana(mana) or false end
+function doRemoveCreature(cid) local c = Creature(cid) return c and c:remove() or false end
+function doCreatureSetStorage(uid, key, value) local c = Creature(uid) return c and c:setStorageValue(key, value) or false end
+function doCreatureSetLookDir(cid, direction) local c = Creature(cid) return c and c:setDirection(direction) or false end
+function doCreatureSetSkullType(cid, skull) local c = Creature(cid) return c and c:setSkull(skull) or false end
+function setCreatureMaxHealth(cid, health) local c = Creature(cid) return c and c:setMaxHealth(health) or false end
+function setCreatureMaxMana(cid, mana) local c = Creature(cid) return c and c:setMaxMana(mana) or false end
+function doCreatureSetHideHealth(cid, hide) local c = Creature(cid) return c and c:setHiddenHealth(hide) or false end
+function doCreatureSetNoMove(cid, block) local c = Creature(cid) return c and c:setMovementBlocked(block) or false end
+function doCreatureSay(cid, text, type, ...) local c = Creature(cid) return c and c:say(text, type, ...) or false end
+function doCreatureChangeOutfit(cid, outfit) local c = Creature(cid) return c and c:setOutfit(outfit) or false end
+function doSetCreatureDropLoot(cid, doDrop) local c = Creature(cid) return c and c:setDropLoot(doDrop) or false end
 doCreatureSetDropLoot = doSetCreatureDropLoot
-function doChangeSpeed(cid, delta)
-	local c = Creature(cid)
-	return c and c:changeSpeed(delta) or false
-end
-
-function doAddCondition(cid, conditionId)
-	local c = Creature(cid)
-	return c and c:addCondition(conditionId) or false
-end
-
-function doRemoveCondition(cid, conditionType, subId)
-	local c = Creature(cid)
-	return c and
-	(c:removeCondition(conditionType, CONDITIONID_COMBAT, subId) or c:removeCondition(conditionType, CONDITIONID_DEFAULT, subId) or true)
-end
-
-function getCreatureCondition(cid, type, subId)
-	local c = Creature(cid)
-	return c and c:hasCondition(type, subId) or false
-end
+function doChangeSpeed(cid, delta) local c = Creature(cid) return c and c:changeSpeed(delta) or false end
+function doAddCondition(cid, conditionId) local c = Creature(cid) return c and c:addCondition(conditionId) or false end
+function doRemoveCondition(cid, conditionType, subId) local c = Creature(cid) return c and (c:removeCondition(conditionType, CONDITIONID_COMBAT, subId) or c:removeCondition(conditionType, CONDITIONID_DEFAULT, subId) or true) end
+function getCreatureCondition(cid, type, subId) local c = Creature(cid) return c and c:hasCondition(type, subId) or false end
 
 doCreatureSetLookDirection = doCreatureSetLookDir
 doSetCreatureDirection = doCreatureSetLookDir
 
-function getPlayerByName(name)
-	local p = Player(name)
-	return p and p:getId() or false
-end
-
-function getIPByPlayerName(name)
-	local p = Player(name)
-	return p and p:getIp() or false
-end
-
-function getPlayerGUID(cid)
-	local p = Player(cid)
-	return p and p:getGuid() or false
-end
-
-function getPlayerNameDescription(cid, distance)
-	local p = Player(cid)
-	return p and p:getDescription(distance) or false
-end
-
-function getPlayerSpecialDescription()
-	debugPrint("Deprecated function, use Player:onLook event instead.")
-	return true
-end
-
-function getPlayerAccountId(cid)
-	local p = Player(cid)
-	return p and p:getAccountId() or false
-end
-
+function getPlayerByName(name) local p = Player(name) return p and p:getId() or false end
+function getIPByPlayerName(name) local p = Player(name) return p and p:getIp() or false end
+function getPlayerGUID(cid) local p = Player(cid) return p and p:getGuid() or false end
+function getPlayerNameDescription(cid, distance) local p = Player(cid) return p and p:getDescription(distance) or false end
+function getPlayerSpecialDescription() debugPrint("Deprecated function, use Player:onLook event instead.") return true end
+function getPlayerAccountId(cid) local p = Player(cid) return p and p:getAccountId() or false end
 getPlayerAccount = getPlayerAccountId
-function getPlayerIp(cid)
-	local p = Player(cid)
-	return p and p:getIp() or false
-end
-
-function getPlayerAccountType(cid)
-	local p = Player(cid)
-	return p and p:getAccountType() or false
-end
-
-function getPlayerLastLoginSaved(cid)
-	local p = Player(cid)
-	return p and p:getLastLoginSaved() or false
-end
-
+function getPlayerIp(cid) local p = Player(cid) return p and p:getIp() or false end
+function getPlayerAccountType(cid) local p = Player(cid) return p and p:getAccountType() or false end
+function getPlayerLastLoginSaved(cid) local p = Player(cid) return p and p:getLastLoginSaved() or false end
 getPlayerLastLogin = getPlayerLastLoginSaved
-function getPlayerName(cid)
-	local p = Player(cid)
-	return p and p:getName() or false
-end
-
+function getPlayerName(cid) local p = Player(cid) return p and p:getName() or false end
 getPlayerNameDescription = getPlayerName
-function getPlayerFreeCap(cid)
-	local p = Player(cid)
-	return p and (p:getFreeCapacity() / 100) or false
-end
-
-function getPlayerPosition(cid)
-	local p = Player(cid)
-	return p and p:getPosition() or false
-end
-
-function getPlayerMagLevel(cid)
-	local p = Player(cid)
-	return p and p:getMagicLevel() or false
-end
-
-function getPlayerSpentMana(cid)
-	local p = Player(cid)
-	return p and p:getManaSpent() or false
-end
-
-function getPlayerRequiredMana(cid, magicLevel)
-	local p = Player(cid)
-	return p and p:getVocation():getRequiredManaSpent(magicLevel) or false
-end
-
-function getPlayerRequiredSkillTries(cid, skillId)
-	local p = Player(cid)
-	return p and p:getVocation():getRequiredSkillTries(skillId) or false
-end
-
+function getPlayerFreeCap(cid) local p = Player(cid) return p and (p:getFreeCapacity() / 100) or false end
+function getPlayerPosition(cid) local p = Player(cid) return p and p:getPosition() or false end
+function getPlayerMagLevel(cid) local p = Player(cid) return p and p:getMagicLevel() or false end
+function getPlayerSpentMana(cid) local p = Player(cid) return p and p:getManaSpent() or false end
+function getPlayerRequiredMana(cid, magicLevel) local p = Player(cid) return p and p:getVocation():getRequiredManaSpent(magicLevel) or false end
+function getPlayerRequiredSkillTries(cid, skillId) local p = Player(cid) return p and p:getVocation():getRequiredSkillTries(skillId) or false end
 function getPlayerAccess(cid)
 	local player = Player(cid)
 	if not player then
@@ -611,132 +405,32 @@ function getPlayerAccess(cid)
 	end
 	return player:getGroup():getAccess() and 1 or 0
 end
-
-function getPlayerSkill(cid, skillId)
-	local p = Player(cid)
-	return p and p:getSkillLevel(skillId) or false
-end
-
+function getPlayerSkill(cid, skillId) local p = Player(cid) return p and p:getSkillLevel(skillId) or false end
 getPlayerSkillLevel = getPlayerSkill
-function getPlayerSkillTries(cid, skillId)
-	local p = Player(cid)
-	return p and p:getSkillTries(skillId) or false
-end
-
-function getPlayerMana(cid)
-	local p = Player(cid)
-	return p and p:getMana() or false
-end
-
-function getPlayerMaxMana(cid)
-	local p = Player(cid)
-	return p and p:getMaxMana() or false
-end
-
-function getPlayerLevel(cid)
-	local p = Player(cid)
-	return p and p:getLevel() or false
-end
-
-function getPlayerExperience(cid)
-	local p = Player(cid)
-	return p and p:getExperience() or false
-end
-
-function getPlayerTown(cid)
-	local p = Player(cid)
-	return p and p:getTown():getId() or false
-end
-
-function getPlayerVocation(cid)
-	local p = Player(cid)
-	return p and p:getVocation():getId() or false
-end
-
-function getPlayerSoul(cid)
-	local p = Player(cid)
-	return p and p:getSoul() or false
-end
-
-function getPlayerSex(cid)
-	local p = Player(cid)
-	return p and p:getSex() or false
-end
-
-function getPlayerStorageValue(cid, key)
-	local p = Player(cid)
-	return p and p:getStorageValue(key) or false
-end
-
-function getPlayerBalance(cid)
-	local p = Player(cid)
-	return p and p:getBankBalance() or false
-end
-
-function getPlayerMoney(cid)
-	local p = Player(cid)
-	return p and p:getMoney() or false
-end
-
-function getPlayerGroupId(cid)
-	local p = Player(cid)
-	return p and p:getGroup():getId() or false
-end
-
-function getPlayerLookDir(cid)
-	local p = Player(cid)
-	return p and p:getDirection() or false
-end
-
-function getPlayerLight(cid)
-	local p = Player(cid)
-	return p and p:getLight() or false
-end
-
-function getPlayerDepotItems(cid, depotId)
-	local p = Player(cid)
-	return p and p:getDepotItems(depotId) or false
-end
-
-function getPlayerStamina(cid)
-	local p = Player(cid)
-	return p and p:getStamina() or false
-end
-
-function getPlayerSkullType(cid)
-	local p = Player(cid)
-	return p and p:getSkull() or false
-end
-
-function getPlayerLossPercent(cid)
-	local p = Player(cid)
-	return p and p:getDeathPenalty() or false
-end
-
-function getPlayerMount(cid, mountId)
-	local p = Player(cid)
-	return p and p:hasMount(mountId) or false
-end
-
-function getPlayerPremiumDays(cid)
-	local p = Player(cid)
-	return p and p:getPremiumDays() or false
-end
-
-function getPlayerBlessing(cid, blessing)
-	local p = Player(cid)
-	return p and p:hasBlessing(blessing) or false
-end
-
-function getPlayerFlagValue(cid, flag)
-	local p = Player(cid)
-	return p and p:hasFlag(flag) or false
-end
-
-function getPlayerCustomFlagValue()
-	debugPrint("Deprecated function, use player:hasFlag(flag) instead.")
-	return true
-end
+function getPlayerSkillTries(cid, skillId) local p = Player(cid) return p and p:getSkillTries(skillId) or false end
+function getPlayerMana(cid) local p = Player(cid) return p and p:getMana() or false end
+function getPlayerMaxMana(cid) local p = Player(cid) return p and p:getMaxMana() or false end
+function getPlayerLevel(cid) local p = Player(cid) return p and p:getLevel() or false end
+function getPlayerExperience(cid) local p = Player(cid) return p and p:getExperience() or false end
+function getPlayerTown(cid) local p = Player(cid) return p and p:getTown():getId() or false end
+function getPlayerVocation(cid) local p = Player(cid) return p and p:getVocation():getId() or false end
+function getPlayerSoul(cid) local p = Player(cid) return p and p:getSoul() or false end
+function getPlayerSex(cid) local p = Player(cid) return p and p:getSex() or false end
+function getPlayerStorageValue(cid, key) local p = Player(cid) return p and p:getStorageValue(key) or false end
+function getPlayerBalance(cid) local p = Player(cid) return p and p:getBankBalance() or false end
+function getPlayerMoney(cid) local p = Player(cid) return p and p:getMoney() or false end
+function getPlayerGroupId(cid) local p = Player(cid) return p and p:getGroup():getId() or false end
+function getPlayerLookDir(cid) local p = Player(cid) return p and p:getDirection() or false end
+function getPlayerLight(cid) local p = Player(cid) return p and p:getLight() or false end
+function getPlayerDepotItems(cid, depotId) local p = Player(cid) return p and p:getDepotItems(depotId) or false end
+function getPlayerStamina(cid) local p = Player(cid) return p and p:getStamina() or false end
+function getPlayerSkullType(cid) local p = Player(cid) return p and p:getSkull() or false end
+function getPlayerLossPercent(cid) local p = Player(cid) return p and p:getDeathPenalty() or false end
+function getPlayerMount(cid, mountId) local p = Player(cid) return p and p:hasMount(mountId) or false end
+function getPlayerPremiumDays(cid) local p = Player(cid) return p and p:getPremiumDays() or false end
+function getPlayerBlessing(cid, blessing) local p = Player(cid) return p and p:hasBlessing(blessing) or false end
+function getPlayerFlagValue(cid, flag) local p = Player(cid) return p and p:hasFlag(flag) or false end
+function getPlayerCustomFlagValue() debugPrint("Deprecated function, use player:hasFlag(flag) instead.") return true end
 
 function getPlayerParty(cid)
 	local player = Player(cid)
@@ -750,7 +444,6 @@ function getPlayerParty(cid)
 	end
 	return party:getLeader():getId()
 end
-
 function getPlayerGuildId(cid)
 	local player = Player(cid)
 	if not player then
@@ -763,12 +456,7 @@ function getPlayerGuildId(cid)
 	end
 	return guild:getId()
 end
-
-function getPlayerGuildLevel(cid)
-	local p = Player(cid)
-	return p and p:getGuildLevel() or false
-end
-
+function getPlayerGuildLevel(cid) local p = Player(cid) return p and p:getGuildLevel() or false end
 function getPlayerGuildName(cid)
 	local player = Player(cid)
 	if not player then
@@ -781,7 +469,6 @@ function getPlayerGuildName(cid)
 	end
 	return guild:getName()
 end
-
 function getPlayerGuildRank(cid)
 	local player = Player(cid)
 	if not player then
@@ -796,32 +483,11 @@ function getPlayerGuildRank(cid)
 	local rank = guild:getRankByLevel(player:getGuildLevel())
 	return rank and rank.name or false
 end
-
-function getPlayerGuildRankId(cid)
-	local p = Player(cid)
-	return p and p:getGuildLevel() or false
-end
-
-function getPlayerGuildNick(cid)
-	local p = Player(cid)
-	return p and p:getGuildNick() or false
-end
-
-function getPlayerMasterPos(cid)
-	local p = Player(cid)
-	return p and p:getTown():getTemplePosition() or false
-end
-
-function getPlayerItemCount(cid, itemId, ...)
-	local p = Player(cid)
-	return p and p:getItemCount(itemId, ...) or false
-end
-
-function getPlayerWeapon(cid)
-	local p = Player(cid)
-	return p and p:getWeaponType() or false
-end
-
+function getPlayerGuildRankId(cid) local p = Player(cid) return p and p:getGuildLevel() or false end
+function getPlayerGuildNick(cid) local p = Player(cid) return p and p:getGuildNick() or false end
+function getPlayerMasterPos(cid) local p = Player(cid) return p and p:getTown():getTemplePosition() or false end
+function getPlayerItemCount(cid, itemId, ...) local p = Player(cid) return p and p:getItemCount(itemId, ...) or false end
+function getPlayerWeapon(cid) local p = Player(cid) return p and p:getWeaponType() or false end
 function getPlayerSlotItem(cid, slot)
 	local player = Player(cid)
 	if not player then
@@ -829,7 +495,6 @@ function getPlayerSlotItem(cid, slot)
 	end
 	return pushThing(player:getSlotItem(slot))
 end
-
 function getPlayerItemById(cid, deepSearch, itemId, ...)
 	local player = Player(cid)
 	if not player then
@@ -837,40 +502,18 @@ function getPlayerItemById(cid, deepSearch, itemId, ...)
 	end
 	return pushThing(player:getItemById(itemId, deepSearch, ...))
 end
-
 function getPlayerFood(cid)
 	local player = Player(cid)
 	if not player then
 		return false
 	end
-	local c = player:getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT)
-	return c and math.floor(c:getTicks() / 1000) or 0
+	local c = player:getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT) return c and math.floor(c:getTicks() / 1000) or 0
 end
-
-function canPlayerLearnInstantSpell(cid, name)
-	local p = Player(cid)
-	return p and p:canLearnSpell(name) or false
-end
-
-function getPlayerLearnedInstantSpell(cid, name)
-	local p = Player(cid)
-	return p and p:hasLearnedSpell(name) or false
-end
-
-function isPlayerGhost(cid)
-	local p = Player(cid)
-	return p and p:isInGhostMode() or false
-end
-
-function isPlayerPzLocked(cid)
-	local p = Player(cid)
-	return p and p:isPzLocked() or false
-end
-
-function isPremium(cid)
-	local p = Player(cid)
-	return p and p:isPremium() or false
-end
+function canPlayerLearnInstantSpell(cid, name) local p = Player(cid) return p and p:canLearnSpell(name) or false end
+function getPlayerLearnedInstantSpell(cid, name) local p = Player(cid) return p and p:hasLearnedSpell(name) or false end
+function isPlayerGhost(cid) local p = Player(cid) return p and p:isInGhostMode() or false end
+function isPlayerPzLocked(cid) local p = Player(cid) return p and p:isPzLocked() or false end
+function isPremium(cid) local p = Player(cid) return p and p:isPremium() or false end
 
 STORAGEVALUE_EMPTY = -1
 function Player:getStorageValue(key)
@@ -899,9 +542,7 @@ function getPlayersByIPAddress(ip, mask)
 		return result
 	end
 
-	print("[Warning - " ..
-	debug.getinfo(2).source:match("@?(.*)") ..
-	"] Invoking getPlayersByIPAddress with a numeric IP is deprecated and will be removed in the future. Please use the string representation of the IP.")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Invoking getPlayersByIPAddress with a numeric IP is deprecated and will be removed in the future. Please use the string representation of the IP.")
 
 	if not mask then mask = 0xFFFFFFFF end
 	local masked = ip & mask
@@ -915,7 +556,6 @@ function getPlayersByIPAddress(ip, mask)
 
 	return result
 end
-
 getPlayersByIp = getPlayersByIPAddress
 function getOnlinePlayers()
 	local result = {}
@@ -924,7 +564,6 @@ function getOnlinePlayers()
 	end
 	return result
 end
-
 getPlayersOnline = getOnlinePlayers
 function getPlayersByAccountNumber(accountNumber)
 	local result = {}
@@ -935,7 +574,6 @@ function getPlayersByAccountNumber(accountNumber)
 	end
 	return result
 end
-
 function getPlayerGUIDByName(name)
 	local player = Player(name)
 	if player then
@@ -958,56 +596,16 @@ end
 getPlayerAccountBalance = getPlayerBalance
 getIpByName = getIPByPlayerName
 
-function setPlayerStorageValue(cid, key, value)
-	local p = Player(cid)
-	return p and p:setStorageValue(key, value) or false
-end
-
-function doPlayerSetNameDescription()
-	debugPrint("Deprecated function, use Player:onLook event instead.")
-	return true
-end
-
-function doPlayerSendChannelMessage(cid, author, message, SpeakClasses, channel)
-	local p = Player(cid)
-	return p and p:sendChannelMessage(author, message, SpeakClasses, channel) or false
-end
-
-function doPlayerSetMaxCapacity(cid, cap)
-	local p = Player(cid)
-	return p and p:setCapacity(cap) or false
-end
-
-function doPlayerSetSpecialDescription()
-	debugPrint("Deprecated function, use Player:onLook event instead.")
-	return true
-end
-
-function doPlayerSetBalance(cid, balance)
-	local p = Player(cid)
-	return p and p:setBankBalance(balance) or false
-end
-
-function doPlayerSetPromotionLevel(cid, level)
-	local p = Player(cid)
-	return p and p:setVocation(p:getVocation():getPromotion()) or false
-end
-
-function doPlayerAddMoney(cid, money)
-	local p = Player(cid)
-	return p and p:addMoney(money) or false
-end
-
-function doPlayerRemoveMoney(cid, money)
-	local p = Player(cid)
-	return p and p:removeMoney(money) or false
-end
-
-function doPlayerTakeItem(cid, itemid, count)
-	local p = Player(cid)
-	return p and p:removeItem(itemid, count) or false
-end
-
+function setPlayerStorageValue(cid, key, value) local p = Player(cid) return p and p:setStorageValue(key, value) or false end
+function doPlayerSetNameDescription() debugPrint("Deprecated function, use Player:onLook event instead.") return true end
+function doPlayerSendChannelMessage(cid, author, message, SpeakClasses, channel) local p = Player(cid) return p and p:sendChannelMessage(author, message, SpeakClasses, channel) or false end
+function doPlayerSetMaxCapacity(cid, cap) local p = Player(cid) return p and p:setCapacity(cap) or false end
+function doPlayerSetSpecialDescription() debugPrint("Deprecated function, use Player:onLook event instead.") return true end
+function doPlayerSetBalance(cid, balance) local p = Player(cid) return p and p:setBankBalance(balance) or false end
+function doPlayerSetPromotionLevel(cid, level) local p = Player(cid) return p and p:setVocation(p:getVocation():getPromotion()) or false end
+function doPlayerAddMoney(cid, money) local p = Player(cid) return p and p:addMoney(money) or false end
+function doPlayerRemoveMoney(cid, money) local p = Player(cid) return p and p:removeMoney(money) or false end
+function doPlayerTakeItem(cid, itemid, count) local p = Player(cid) return p and p:removeItem(itemid, count) or false end
 function doPlayerTransferMoneyTo(cid, target, money)
 	if not isValidMoney(money) then
 		return false
@@ -1015,93 +613,24 @@ function doPlayerTransferMoneyTo(cid, target, money)
 	local p = Player(cid)
 	return p and p:transferMoneyTo(target, money) or false
 end
-
-function doPlayerSave(cid)
-	local p = Player(cid)
-	return p and p:save() or false
-end
-
-function doPlayerAddSoul(cid, soul)
-	local p = Player(cid)
-	return p and p:addSoul(soul) or false
-end
-
-function doPlayerSetVocation(cid, vocation)
-	local p = Player(cid)
-	return p and p:setVocation(Vocation(vocation)) or false
-end
-
-function doPlayerSetTown(cid, town)
-	local p = Player(cid)
-	return p and p:setTown(Town(town)) or false
-end
-
-function setPlayerGroupId(cid, groupId)
-	local p = Player(cid)
-	return p and p:setGroup(Group(groupId)) or false
-end
-
+function doPlayerSave(cid) local p = Player(cid) return p and p:save() or false end
+function doPlayerAddSoul(cid, soul) local p = Player(cid) return p and p:addSoul(soul) or false end
+function doPlayerSetVocation(cid, vocation) local p = Player(cid) return p and p:setVocation(Vocation(vocation)) or false end
+function doPlayerSetTown(cid, town) local p = Player(cid) return p and p:setTown(Town(town)) or false end
+function setPlayerGroupId(cid, groupId) local p = Player(cid) return p and p:setGroup(Group(groupId)) or false end
 doPlayerSetGroupId = setPlayerGroupId
-function doPlayerSetSex(cid, sex)
-	local p = Player(cid)
-	return p and p:setSex(sex) or false
-end
-
-function doPlayerSetGuildLevel(cid, level)
-	local p = Player(cid)
-	return p and p:setGuildLevel(level) or false
-end
-
-function doPlayerSetGuildNick(cid, nick)
-	local p = Player(cid)
-	return p and p:setGuildNick(nick) or false
-end
-
-function doPlayerSetOfflineTrainingSkill(cid, skillId)
-	local p = Player(cid)
-	return p and p:setOfflineTrainingSkill(skillId) or false
-end
-
-function doShowTextDialog(cid, itemId, text)
-	local p = Player(cid)
-	return p and p:showTextDialog(itemId, text) or false
-end
-
-function doPlayerAddItemEx(cid, uid, ...)
-	local p = Player(cid)
-	return p and p:addItemEx(Item(uid), ...) or false
-end
-
-function doPlayerRemoveItem(cid, itemid, count, ...)
-	local p = Player(cid)
-	return p and p:removeItem(itemid, count, ...) or false
-end
-
-function doPlayerAddPremiumDays(cid, days)
-	local p = Player(cid)
-	return p and p:addPremiumDays(days) or false
-end
-
-function doPlayerRemovePremiumDays(cid, days)
-	local p = Player(cid)
-	return p and p:removePremiumDays(days) or false
-end
-
-function doPlayerSetStamina(cid, minutes)
-	local p = Player(cid)
-	return p and p:setStamina(minutes) or false
-end
-
-function doPlayerAddBlessing(cid, blessing)
-	local p = Player(cid)
-	return p and p:addBlessing(blessing) or false
-end
-
-function doPlayerAddOutfit(cid, lookType, addons)
-	local p = Player(cid)
-	return p and p:addOutfitAddon(lookType, addons) or false
-end
-
+function doPlayerSetSex(cid, sex) local p = Player(cid) return p and p:setSex(sex) or false end
+function doPlayerSetGuildLevel(cid, level) local p = Player(cid) return p and p:setGuildLevel(level) or false end
+function doPlayerSetGuildNick(cid, nick) local p = Player(cid) return p and p:setGuildNick(nick) or false end
+function doPlayerSetOfflineTrainingSkill(cid, skillId) local p = Player(cid) return p and p:setOfflineTrainingSkill(skillId) or false end
+function doShowTextDialog(cid, itemId, text) local p = Player(cid) return p and p:showTextDialog(itemId, text) or false end
+function doPlayerAddItemEx(cid, uid, ...) local p = Player(cid) return p and p:addItemEx(Item(uid), ...) or false end
+function doPlayerRemoveItem(cid, itemid, count, ...) local p = Player(cid) return p and p:removeItem(itemid, count, ...) or false end
+function doPlayerAddPremiumDays(cid, days) local p = Player(cid) return p and p:addPremiumDays(days) or false end
+function doPlayerRemovePremiumDays(cid, days) local p = Player(cid) return p and p:removePremiumDays(days) or false end
+function doPlayerSetStamina(cid, minutes) local p = Player(cid) return p and p:setStamina(minutes) or false end
+function doPlayerAddBlessing(cid, blessing) local p = Player(cid) return p and p:addBlessing(blessing) or false end
+function doPlayerAddOutfit(cid, lookType, addons) local p = Player(cid) return p and p:addOutfitAddon(lookType, addons) or false end
 function doPlayerRemOutfit(cid, lookType, addons)
 	local player = Player(cid)
 	if not player then
@@ -1112,106 +641,29 @@ function doPlayerRemOutfit(cid, lookType, addons)
 	end
 	return player:removeOutfitAddon(lookType, addons)
 end
-
 doPlayerRemoveOutfit = doPlayerRemOutfit
-function doPlayerAddAddons(cid, addon)
-	local p = Player(cid)
-	return p and p:addAddonToAllOutfits(addon) or false
-end
-
-function canPlayerWearOutfit(cid, lookType, addons)
-	local p = Player(cid)
-	return p and p:hasOutfit(lookType, addons) or false
-end
-
-function doPlayerAddMount(cid, mountId)
-	local p = Player(cid)
-	return p and p:addMount(mountId) or false
-end
-
-function doPlayerRemoveMount(cid, mountId)
-	local p = Player(cid)
-	return p and p:removeMount(mountId) or false
-end
-
-function doPlayerSendOutfitWindow(cid)
-	local p = Player(cid)
-	return p and p:sendOutfitWindow() or false
-end
-
-function doPlayerSendCancel(cid, text)
-	local p = Player(cid)
-	return p and p:sendCancelMessage(text) or false
-end
-
-function doPlayerFeed(cid, food)
-	local p = Player(cid)
-	return p and p:feed(food) or false
-end
-
-function playerLearnInstantSpell(cid, name)
-	local p = Player(cid)
-	return p and p:learnSpell(name) or false
-end
-
+function doPlayerAddAddons(cid, addon) local p = Player(cid) return p and p:addAddonToAllOutfits(addon) or false end
+function canPlayerWearOutfit(cid, lookType, addons) local p = Player(cid) return p and p:hasOutfit(lookType, addons) or false end
+function doPlayerAddMount(cid, mountId) local p = Player(cid) return p and p:addMount(mountId) or false end
+function doPlayerRemoveMount(cid, mountId) local p = Player(cid) return p and p:removeMount(mountId) or false end
+function doPlayerSendOutfitWindow(cid) local p = Player(cid) return p and p:sendOutfitWindow() or false end
+function doPlayerSendCancel(cid, text) local p = Player(cid) return p and p:sendCancelMessage(text) or false end
+function doPlayerFeed(cid, food) local p = Player(cid) return p and p:feed(food) or false end
+function playerLearnInstantSpell(cid, name) local p = Player(cid) return p and p:learnSpell(name) or false end
 doPlayerLearnInstantSpell = playerLearnInstantSpell
-function doPlayerUnlearnInstantSpell(cid, name)
-	local p = Player(cid)
-	return p and p:forgetSpell(name) or false
-end
-
-function doPlayerPopupFYI(cid, message)
-	local p = Player(cid)
-	return p and p:popupFYI(message) or false
-end
-
-function doSendTutorial(cid, tutorialId)
-	local p = Player(cid)
-	return p and p:sendTutorial(tutorialId) or false
-end
-
+function doPlayerUnlearnInstantSpell(cid, name) local p = Player(cid) return p and p:forgetSpell(name) or false end
+function doPlayerPopupFYI(cid, message) local p = Player(cid) return p and p:popupFYI(message) or false end
+function doSendTutorial(cid, tutorialId) local p = Player(cid) return p and p:sendTutorial(tutorialId) or false end
 doPlayerSendTutorial = doSendTutorial
-function doAddMapMark(cid, pos, type, description)
-	local p = Player(cid)
-	return p and p:addMapMark(pos, type, description or "") or false
-end
-
+function doAddMapMark(cid, pos, type, description) local p = Player(cid) return p and p:addMapMark(pos, type, description or "") or false end
 doPlayerAddMapMark = doAddMapMark
-function doPlayerSendTextMessage(cid, type, text, ...)
-	local p = Player(cid)
-	return p and p:sendTextMessage(type, text, ...) or false
-end
-
-function doSendAnimatedText()
-	debugPrint("Deprecated function.")
-	return true
-end
-
-function getPlayerAccountManager()
-	debugPrint("Deprecated function.")
-	return true
-end
-
-function doPlayerSetExperienceRate()
-	debugPrint("Deprecated function, use Player:onGainExperience event instead.")
-	return true
-end
-
-function doPlayerSetSkillLevel(cid, skillId, value, ...)
-	local p = Player(cid)
-	return p and p:addSkill(skillId, value, ...)
-end
-
-function doPlayerSetMagicLevel(cid, value)
-	local p = Player(cid)
-	return p and p:addMagicLevel(value)
-end
-
-function doPlayerAddLevel(cid, amount, round)
-	local p = Player(cid)
-	return p and p:addLevel(amount, round)
-end
-
+function doPlayerSendTextMessage(cid, type, text, ...) local p = Player(cid) return p and p:sendTextMessage(type, text, ...) or false end
+function doSendAnimatedText() debugPrint("Deprecated function.") return true end
+function getPlayerAccountManager() debugPrint("Deprecated function.") return true end
+function doPlayerSetExperienceRate() debugPrint("Deprecated function, use Player:onGainExperience event instead.") return true end
+function doPlayerSetSkillLevel(cid, skillId, value, ...) local p = Player(cid) return p and p:addSkill(skillId, value, ...) end
+function doPlayerSetMagicLevel(cid, value) local p = Player(cid) return p and p:addMagicLevel(value) end
+function doPlayerAddLevel(cid, amount, round) local p = Player(cid) return p and p:addLevel(amount, round) end
 function doPlayerAddExp(cid, exp, useMult, ...)
 	local player = Player(cid)
 	if not player then
@@ -1223,24 +675,11 @@ function doPlayerAddExp(cid, exp, useMult, ...)
 	end
 	return player:addExperience(exp, ...)
 end
-
 doPlayerAddExperience = doPlayerAddExp
-function doPlayerAddManaSpent(cid, mana)
-	local p = Player(cid)
-	return p and p:addManaSpent(mana) or false
-end
-
+function doPlayerAddManaSpent(cid, mana) local p = Player(cid) return p and p:addManaSpent(mana) or false end
 doPlayerAddSpentMana = doPlayerAddManaSpent
-function doPlayerAddSkillTry(cid, skillid, n)
-	local p = Player(cid)
-	return p and p:addSkillTries(skillid, n) or false
-end
-
-function doPlayerAddMana(cid, mana, ...)
-	local p = Player(cid)
-	return p and p:addMana(mana, ...) or false
-end
-
+function doPlayerAddSkillTry(cid, skillid, n) local p = Player(cid) return p and p:addSkillTries(skillid, n) or false end
+function doPlayerAddMana(cid, mana, ...) local p = Player(cid) return p and p:addMana(mana, ...) or false end
 function doPlayerJoinParty(cid, leaderId)
 	local player = Player(cid)
 	if not player then
@@ -1271,7 +710,6 @@ function doPlayerJoinParty(cid, leaderId)
 	party:addMember(player)
 	return true
 end
-
 function getPartyMembers(cid)
 	local player = Player(cid)
 	if not player then
@@ -1283,7 +721,7 @@ function getPartyMembers(cid)
 		return false
 	end
 
-	local result = { party:getLeader():getId() }
+	local result = {party:getLeader():getId()}
 	for _, member in ipairs(party:getMembers()) do
 		result[#result + 1] = member:getId()
 	end
@@ -1306,7 +744,6 @@ function getMonsterTargetList(cid)
 	end
 	return result
 end
-
 function getMonsterFriendList(cid)
 	local monster = Monster(cid)
 	if not monster then
@@ -1323,7 +760,6 @@ function getMonsterFriendList(cid)
 	end
 	return result
 end
-
 function doSetMonsterTarget(cid, target)
 	local monster = Monster(cid)
 	if not monster then
@@ -1342,7 +778,6 @@ function doSetMonsterTarget(cid, target)
 	monster:selectTarget(target)
 	return true
 end
-
 doMonsterSetTarget = doSetMonsterTarget
 function doMonsterChangeTarget(cid)
 	local monster = Monster(cid)
@@ -1357,17 +792,12 @@ function doMonsterChangeTarget(cid)
 	monster:searchTarget(1)
 	return true
 end
-
 function doCreateNpc(name, pos, ...)
-	local npc = Game.createNpc(name, pos, ...)
-	return npc and npc:setMasterPos(pos) or false
+	local npc = Game.createNpc(name, pos, ...) return npc and npc:setMasterPos(pos) or false
 end
-
 function doSummonCreature(name, pos, ...)
-	local m = Game.createMonster(name, pos, ...)
-	return m and m:getId() or false
+	local m = Game.createMonster(name, pos, ...) return m and m:getId() or false
 end
-
 doCreateMonster = doSummonCreature
 function doConvinceCreature(cid, target)
 	local creature = Creature(cid)
@@ -1383,7 +813,6 @@ function doConvinceCreature(cid, target)
 	creature:addSummon(targetCreature)
 	return true
 end
-
 function doSummonMonster(cid, name)
 	local player = Player(cid)
 	local position = player:getPosition()
@@ -1398,51 +827,17 @@ function doSummonMonster(cid, name)
 	return true
 end
 
-function getTownId(townName)
-	local t = Town(townName)
-	return t and t:getId() or false
-end
+function getTownId(townName) local t = Town(townName) return t and t:getId() or false end
+function getTownName(townId) local t = Town(townId) return t and t:getName() or false end
+function getTownTemplePosition(townId) local t = Town(townId) return t and t:getTemplePosition() or false end
 
-function getTownName(townId)
-	local t = Town(townId)
-	return t and t:getName() or false
-end
+function doSetItemActionId(uid, actionId) local i = Item(uid) return i and i:setActionId(actionId) or false end
+function doTransformItem(uid, newItemId, ...) local i = Item(uid) return i and i:transform(newItemId, ...) or false end
+function doChangeTypeItem(uid, newType) local i = Item(uid) return i and i:transform(i:getId(), newType) or false end
+function doRemoveItem(uid, ...) local i = Item(uid) return i and i:remove(...) or false end
 
-function getTownTemplePosition(townId)
-	local t = Town(townId)
-	return t and t:getTemplePosition() or false
-end
-
-function doSetItemActionId(uid, actionId)
-	local i = Item(uid)
-	return i and i:setActionId(actionId) or false
-end
-
-function doTransformItem(uid, newItemId, ...)
-	local i = Item(uid)
-	return i and i:transform(newItemId, ...) or false
-end
-
-function doChangeTypeItem(uid, newType)
-	local i = Item(uid)
-	return i and i:transform(i:getId(), newType) or false
-end
-
-function doRemoveItem(uid, ...)
-	local i = Item(uid)
-	return i and i:remove(...) or false
-end
-
-function getContainerSize(uid)
-	local c = Container(uid)
-	return c and c:getSize() or false
-end
-
-function getContainerCap(uid)
-	local c = Container(uid)
-	return c and c:getCapacity() or false
-end
-
+function getContainerSize(uid) local c = Container(uid) return c and c:getSize() or false end
+function getContainerCap(uid) local c = Container(uid) return c and c:getCapacity() or false end
 function getContainerItem(uid, slot)
 	local container = Container(uid)
 	if not container then
@@ -1474,10 +869,7 @@ function doAddContainerItem(uid, itemid, count)
 end
 
 function doSendMagicEffect(pos, magicEffect, ...) return Position(pos):sendMagicEffect(magicEffect, ...) end
-
-function doSendDistanceShoot(fromPos, toPos, distanceEffect, ...) return Position(fromPos):sendDistanceEffect(toPos,
-		distanceEffect, ...) end
-
+function doSendDistanceShoot(fromPos, toPos, distanceEffect, ...) return Position(fromPos):sendDistanceEffect(toPos, distanceEffect, ...) end
 function isSightClear(fromPos, toPos, floorCheck) return Position(fromPos):isSightClear(toPos, floorCheck) end
 
 function getPromotedVocation(vocationId)
@@ -1492,7 +884,6 @@ function getPromotedVocation(vocationId)
 	end
 	return promotedVocation:getId()
 end
-
 getPlayerPromotionLevel = getPromotedVocation
 
 function getGuildId(guildName)
@@ -1506,58 +897,26 @@ function getGuildId(guildName)
 	return guildId
 end
 
-function getHouseName(houseId)
-	local h = House(houseId)
-	return h and h:getName() or false
-end
-
-function getHouseOwner(houseId)
-	local h = House(houseId)
-	return h and h:getOwnerGuid() or false
-end
-
-function getHouseEntry(houseId)
-	local h = House(houseId)
-	return h and h:getExitPosition() or false
-end
-
-function getHouseTown(houseId)
-	local h = House(houseId)
-	if not h then return false end
-	local t = h:getTown()
-	return t and t:getId() or false
-end
-
-function getHouseTilesSize(houseId)
-	local h = House(houseId)
-	return h and h:getTileCount() or false
-end
+function getHouseName(houseId) local h = House(houseId) return h and h:getName() or false end
+function getHouseOwner(houseId) local h = House(houseId) return h and h:getOwnerGuid() or false end
+function getHouseEntry(houseId) local h = House(houseId) return h and h:getExitPosition() or false end
+function getHouseTown(houseId) local h = House(houseId) if not h then return false end local t = h:getTown() return t and t:getId() or false end
+function getHouseTilesSize(houseId) local h = House(houseId) return h and h:getTileCount() or false end
 
 function isItemStackable(itemId) return ItemType(itemId):isStackable() end
-
 function isItemRune(itemId) return ItemType(itemId):isRune() end
-
 function isItemDoor(itemId) return ItemType(itemId):isDoor() end
-
 function isItemContainer(itemId) return ItemType(itemId):isContainer() end
-
 function isItemFluidContainer(itemId) return ItemType(itemId):isFluidContainer() end
-
 function isItemMovable(itemId) return ItemType(itemId):isMovable() end
-
-function isCorpse(uid)
-	local i = Item(uid)
-	return i and ItemType(i:getId()):isCorpse() or false
-end
+function isCorpse(uid) local i = Item(uid) return i and ItemType(i:getId()):isCorpse() or false end
 
 isItemMoveable = isItemMovable
 isMoveable = isMovable
 
 function getItemName(itemId) return ItemType(itemId):getName() end
-
 getItemNameById = getItemName
 function getItemWeight(itemId, ...) return ItemType(itemId):getWeight(...) / 100 end
-
 function getItemDescriptions(itemId)
 	local itemType = ItemType(itemId)
 	return {
@@ -1567,7 +926,6 @@ function getItemDescriptions(itemId)
 		description = itemType:getDescription()
 	}
 end
-
 function getItemIdByName(name)
 	local id = ItemType(name):getId()
 	if id == 0 then
@@ -1575,7 +933,6 @@ function getItemIdByName(name)
 	end
 	return id
 end
-
 function getItemWeightByUID(uid, ...)
 	local item = Item(uid)
 	if not item then
@@ -1583,10 +940,8 @@ function getItemWeightByUID(uid, ...)
 	end
 
 	local itemType = ItemType(item:getId())
-	return itemType:isStackable() and (itemType:getWeight(item:getCount(), ...) / 100) or
-	(itemType:getWeight(1, ...) / 100)
+	return itemType:isStackable() and (itemType:getWeight(item:getCount(), ...) / 100) or (itemType:getWeight(1, ...) / 100)
 end
-
 function getItemRWInfo(uid)
 	local item = Item(uid)
 	if not item then
@@ -1604,14 +959,8 @@ function getItemRWInfo(uid)
 	end
 	return rwFlags
 end
-
 function getContainerCapById(itemId) return ItemType(itemId):getCapacity() end
-
-function getFluidSourceType(itemId)
-	local it = ItemType(itemId)
-	return it.id ~= 0 and it:getFluidSource() or false
-end
-
+function getFluidSourceType(itemId) local it = ItemType(itemId) return it.id ~= 0 and it:getFluidSource() or false end
 function hasProperty(uid, prop)
 	local item = Item(uid)
 	if not item then
@@ -1651,7 +1000,6 @@ function doSetItemText(uid, text, writer, date)
 
 	return true
 end
-
 function doSetItemSpecialDescription(uid, desc)
 	local item = Item(uid)
 	if not item then
@@ -1665,31 +1013,12 @@ function doSetItemSpecialDescription(uid, desc)
 	end
 	return true
 end
+function doDecayItem(uid) local i = Item(uid) return i and i:decay() or false end
 
-function doDecayItem(uid)
-	local i = Item(uid)
-	return i and i:decay() or false
-end
-
-function setHouseOwner(id, guid)
-	local h = House(id)
-	return h and h:setOwnerGuid(guid) or false
-end
-
-function getHouseRent(id)
-	local h = House(id)
-	return h and h:getRent() or nil
-end
-
-function getHouseAccessList(id, listId)
-	local h = House(id)
-	return h and h:getAccessList(listId) or nil
-end
-
-function setHouseAccessList(id, listId, listText)
-	local h = House(id)
-	return h and h:setAccessList(listId, listText) or false
-end
+function setHouseOwner(id, guid) local h = House(id) return h and h:setOwnerGuid(guid) or false end
+function getHouseRent(id) local h = House(id) return h and h:getRent() or nil end
+function getHouseAccessList(id, listId) local h = House(id) return h and h:getAccessList(listId) or nil end
+function setHouseAccessList(id, listId, listText) local h = House(id) return h and h:setAccessList(listId, listText) or false end
 
 function getHouseByPlayerGUID(playerGUID)
 	for _, house in ipairs(Game.getHouses()) do
@@ -1786,10 +1115,7 @@ function getTopCreature(position)
 	return pushThing(t:getTopCreature())
 end
 
-function queryTileAddThing(thing, position, ...)
-	local t = Tile(position)
-	return t and t:queryAdd(thing, ...) or false
-end
+function queryTileAddThing(thing, position, ...) local t = Tile(position) return t and t:queryAdd(thing, ...) or false end
 
 function doTeleportThing(uid, dest, pushMovement)
 	if type(uid) == "userdata" then
@@ -1833,7 +1159,6 @@ function getThingPos(uid)
 	position.stackpos = stackpos
 	return position
 end
-
 getThingPosition = getThingPos
 
 function getThingfromPos(pos)
@@ -1919,13 +1244,11 @@ saveData = saveServer
 function getGlobalStorageValue(key)
 	return Game.getStorageValue(key) or -1
 end
-
 getStorage = getGlobalStorageValue
 function setGlobalStorageValue(key, value)
 	Game.setStorageValue(key, value)
 	return true
 end
-
 doSetStorage = setGlobalStorageValue
 getWorldType = Game.getWorldType
 
@@ -1945,13 +1268,10 @@ function doExecuteRaid(raidName)
 	debugPrint("Deprecated function, use Game.startEvent('" .. raidName .. "') instead.")
 	return Game.startEvent(raidName)
 end
-
 Game.startRaid = doExecuteRaid
 
 function Game.convertIpToString(ip)
-	print("[Warning - " ..
-	debug.getinfo(2).source:match("@?(.*)") ..
-	"] Function Game.convertIpToString is deprecated and will be removed in the future. Use the return value of player:getIp() instead.")
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function Game.convertIpToString is deprecated and will be removed in the future. Use the return value of player:getIp() instead.")
 
 	if type(ip) == "string" then
 		return ip
@@ -2005,22 +1325,16 @@ function broadcastMessage(message, messageType)
 	Game.broadcastMessage(message, messageType)
 	print("> Broadcasted message: \"" .. message .. "\".")
 end
-
 doBroadcastMessage = broadcastMessage
 
 function Guild.addMember(self, player)
 	return player:setGuild(self)
 end
-
 function Guild.removeMember(self, player)
 	return player:getGuild() == self and player:setGuild(nil)
 end
 
-function getPlayerInstantSpellCount(cid)
-	local p = Player(cid)
-	return p and #p:getInstantSpells()
-end
-
+function getPlayerInstantSpellCount(cid) local p = Player(cid) return p and #p:getInstantSpells() end
 function getPlayerInstantSpellInfo(cid, spellId)
 	local player = Player(cid)
 	if not player then
@@ -2035,16 +1349,8 @@ function getPlayerInstantSpellInfo(cid, spellId)
 	return spell
 end
 
-function doSetItemOutfit(cid, item, time)
-	local c = Creature(cid)
-	return c and c:setItemOutfit(item, time)
-end
-
-function doSetMonsterOutfit(cid, name, time)
-	local c = Creature(cid)
-	return c and c:setMonsterOutfit(name, time)
-end
-
+function doSetItemOutfit(cid, item, time) local c = Creature(cid) return c and c:setItemOutfit(item, time) end
+function doSetMonsterOutfit(cid, name, time) local c = Creature(cid) return c and c:setMonsterOutfit(name, time) end
 function doSetCreatureOutfit(cid, outfit, time)
 	local creature = Creature(cid)
 	if not creature then
@@ -2096,13 +1402,10 @@ function doCreateItemEx(itemid, count)
 	return false
 end
 
-function doMoveCreature(cid, direction)
-	local c = Creature(cid)
-	return c and c:move(direction)
-end
+function doMoveCreature(cid, direction) local c = Creature(cid) return c and c:move(direction) end
 
 function createFunctions(class)
-	local exclude = { [2] = { "is" }, [3] = { "get", "set", "add", "can" }, [4] = { "need" } }
+	local exclude = {[2] = {"is"}, [3] = {"get", "set", "add", "can"}, [4] = {"need"}}
 	local temp = {}
 	for name, func in pairs(class) do
 		local add = true
@@ -2118,7 +1421,7 @@ function createFunctions(class)
 			local get = "get" .. str
 			local set = "set" .. str
 			if not (rawget(class, get) and rawget(class, set)) then
-				table.insert(temp, { set, setFunc, get, getFunc })
+				table.insert(temp, {set, setFunc, get, getFunc})
 			end
 		end
 	end
@@ -2241,15 +1544,10 @@ if not loadstring then loadstring = load end
 
 bit = bit or {}
 function bit.bnot(a) return ~a end
-
 function bit.band(a, b) return a & b end
-
 function bit.bor(a, b) return a | b end
-
 function bit.bxor(a, b) return a ~ b end
-
 function bit.lshift(a, b) return a << b end
-
 function bit.rshift(a, b) return a >> b end
 
 function table.maxn(t)

--- a/data/scripts/globalevents/player_record.lua
+++ b/data/scripts/globalevents/player_record.lua
@@ -1,8 +1,0 @@
-local event = GlobalEvent("PlayerRecord")
-
-function event.onRecord(current, old)
-	addEvent(Game.broadcastMessage, 150, "New record: " .. current .. " players are logged in.", MESSAGE_STATUS_DEFAULT)
-	return true
-end
-
-event:register()

--- a/data/scripts/systems/player-record.lua
+++ b/data/scripts/systems/player-record.lua
@@ -1,0 +1,32 @@
+do
+	local event = Event()
+
+	event.onGameStartup = function()
+		local resultId = db.storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'players_record'")
+		if resultId then
+			Game.setPlayerRecord(result.getNumber(resultId, "value"))
+		else
+			db.query("INSERT INTO `server_config` (`config`, `value`) VALUES ('players_record', '0')")
+		end
+	end
+
+	event:register()
+end
+
+do
+	local event = Event()
+
+	event.onPlayerJoin = function(self)
+		local playerCount = Game.getPlayerCount()
+		if playerCount <= Game.getPlayerRecord() then
+			return
+		end
+
+		Game.setPlayerRecord(playerCount)
+		Game.broadcastMessage("New record: " .. playerCount .. " players are logged in.", MESSAGE_STATUS_DEFAULT)
+
+		db.asyncQuery("UPDATE `server_config` SET `value` = '" .. playerCount .. "' WHERE `config` = 'players_record'")
+	end
+
+	event:register()
+end

--- a/data/scripts/systems/player-record.lua
+++ b/data/scripts/systems/player-record.lua
@@ -5,6 +5,7 @@ do
 		local resultId = db.storeQuery("SELECT `value` FROM `server_config` WHERE `config` = 'players_record'")
 		if resultId then
 			Game.setPlayerRecord(result.getNumber(resultId, "value"))
+			result.free(resultId)
 		else
 			db.query("INSERT INTO `server_config` (`config`, `value`) VALUES ('players_record', '0')")
 		end

--- a/src/game.h
+++ b/src/game.h
@@ -210,7 +210,6 @@ public:
 	size_t getPlayersOnline() const { return players.size(); }
 	size_t getMonstersOnline() const { return monsters.size(); }
 	size_t getNpcsOnline() const { return npcs.size(); }
-	uint32_t getPlayersRecord() const { return playersRecord; }
 
 	ReturnValue internalMoveCreature(const std::shared_ptr<Creature>& creature, Direction direction,
 	                                 uint32_t flags = 0);
@@ -297,9 +296,6 @@ public:
 	bool internalCreatureSay(const std::shared_ptr<Creature>& creature, SpeakClasses type, const std::string& text,
 	                         bool ghostMode, SpectatorVec* spectatorsPtr = nullptr, const Position* pos = nullptr,
 	                         bool echo = false);
-
-	void loadPlayersRecord();
-	void checkPlayersRecord();
 
 	void sendGuildMotd(uint32_t playerId);
 	void kickPlayer(uint32_t playerId, bool displayEffect);
@@ -502,6 +498,9 @@ public:
 	void addParty(const std::shared_ptr<Party>& party) { parties.insert(party); }
 	void removeParty(const std::shared_ptr<Party>& party) { parties.erase(party); }
 
+	auto getPlayerRecord() const { return playerRecord; }
+	void setPlayerRecord(uint32_t record) { playerRecord = record; }
+
 private:
 	bool playerSaySpell(const std::shared_ptr<Player>& player, SpeakClasses type, const std::string& text);
 	void playerWhisper(const std::shared_ptr<Player>& player, const std::string& text);
@@ -545,10 +544,9 @@ private:
 	GameState_t gameState = GAME_STATE_NORMAL;
 	WorldType_t worldType = WORLD_TYPE_PVP;
 
-	ServiceManager* serviceManager = nullptr;
+	uint32_t playerRecord = 0;
 
-	void updatePlayersRecord() const;
-	uint32_t playersRecord = 0;
+	ServiceManager* serviceManager = nullptr;
 };
 
 #endif // FS_GAME_H

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -197,15 +197,6 @@ GlobalEventMap GlobalEvents::getEventMap(GlobalEvent_t type)
 			return thinkMap;
 		case GLOBALEVENT_TIMER:
 			return timerMap;
-		case GLOBALEVENT_RECORD: {
-			GlobalEventMap retMap;
-			for (const auto& [name, globalEvent] : serverMap) {
-				if (globalEvent.getEventType() == type) {
-					retMap.emplace(name, globalEvent);
-				}
-			}
-			return retMap;
-		}
 		default:
 			return GlobalEventMap();
 	}
@@ -270,15 +261,6 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 
 		nextExecution = (current_time + difference) * 1000;
 		eventType = GLOBALEVENT_TIMER;
-	} else if ((attr = node.attribute("type"))) {
-		const char* value = attr.value();
-		if (boost::iequals(value, "record")) {
-			eventType = GLOBALEVENT_RECORD;
-		} else {
-			std::cout << "[Error - GlobalEvent::configureEvent] No valid type \"" << attr.as_string()
-			          << "\" for globalevent with name " << name << std::endl;
-			return false;
-		}
 	} else if ((attr = node.attribute("interval"))) {
 		interval = std::max<int32_t>(SCHEDULER_MINTICKS, pugi::cast<int32_t>(attr.value()));
 		nextExecution = OTSYS_TIME() + interval;
@@ -293,32 +275,11 @@ bool GlobalEvent::configureEvent(const pugi::xml_node& node)
 std::string_view GlobalEvent::getScriptEventName() const
 {
 	switch (eventType) {
-		case GLOBALEVENT_RECORD:
-			return "onRecord";
 		case GLOBALEVENT_TIMER:
 			return "onTime";
 		default:
 			return "onThink";
 	}
-}
-
-bool GlobalEvent::executeRecord(uint32_t current, uint32_t old)
-{
-	// onRecord(current, old)
-	if (!tfs::lua::reserveScriptEnv()) {
-		std::cout << "[Error - GlobalEvent::executeRecord] Call stack overflow" << std::endl;
-		return false;
-	}
-
-	const auto env = tfs::lua::getScriptEnv();
-	env->setScriptId(scriptId, scriptInterface);
-
-	lua_State* L = scriptInterface->getLuaState();
-	scriptInterface->pushFunction(scriptId);
-
-	tfs::lua::pushNumber(L, current);
-	tfs::lua::pushNumber(L, old);
-	return scriptInterface->callFunction(2);
 }
 
 bool GlobalEvent::executeEvent() const

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -36,7 +36,6 @@ void GlobalEvents::clear(bool fromLua)
 	timerEventId = 0;
 
 	clearMap(thinkMap, fromLua);
-	clearMap(serverMap, fromLua);
 	clearMap(timerMap, fromLua);
 
 	reInitState(fromLua);
@@ -59,11 +58,6 @@ bool GlobalEvents::registerEvent(Event_ptr event, const pugi::xml_node&)
 			if (timerEventId == 0) {
 				timerEventId = g_scheduler.addEvent(createSchedulerTask(SCHEDULER_MINTICKS, [this]() { timer(); }));
 			}
-			return true;
-		}
-	} else if (globalEvent->getEventType() != GLOBALEVENT_NONE) {
-		auto result = serverMap.emplace(globalEvent->getName(), std::move(*globalEvent));
-		if (result.second) {
 			return true;
 		}
 	} else { // think event
@@ -90,11 +84,6 @@ bool GlobalEvents::registerLuaEvent(GlobalEvent* event)
 			if (timerEventId == 0) {
 				timerEventId = g_scheduler.addEvent(createSchedulerTask(SCHEDULER_MINTICKS, [this]() { timer(); }));
 			}
-			return true;
-		}
-	} else if (globalEvent->getEventType() != GLOBALEVENT_NONE) {
-		auto result = serverMap.emplace(globalEvent->getName(), std::move(*globalEvent));
-		if (result.second) {
 			return true;
 		}
 	} else { // think event
@@ -177,15 +166,6 @@ void GlobalEvents::think()
 
 	if (nextScheduledTime != std::numeric_limits<int64_t>::max()) {
 		thinkEventId = g_scheduler.addEvent(createSchedulerTask(nextScheduledTime, [this]() { think(); }));
-	}
-}
-
-void GlobalEvents::execute(GlobalEvent_t type) const
-{
-	for (auto&& globalEvent : serverMap | std::views::values | std::views::as_const) {
-		if (globalEvent.getEventType() == type) {
-			globalEvent.executeEvent();
-		}
 	}
 }
 

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -15,8 +15,6 @@ enum GlobalEvent_t
 {
 	GLOBALEVENT_NONE,
 	GLOBALEVENT_TIMER,
-
-	GLOBALEVENT_RECORD,
 };
 
 class GlobalEvents final : public BaseEvents
@@ -59,7 +57,6 @@ public:
 
 	bool configureEvent(const pugi::xml_node& node) override;
 
-	bool executeRecord(uint32_t current, uint32_t old);
 	bool executeEvent() const;
 
 	GlobalEvent_t getEventType() const { return eventType; }

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -29,7 +29,6 @@ public:
 
 	void timer();
 	void think();
-	void execute(GlobalEvent_t type) const;
 
 	GlobalEventMap getEventMap(GlobalEvent_t type);
 	static void clearMap(GlobalEventMap& map, bool fromLua);
@@ -46,7 +45,7 @@ private:
 	LuaScriptInterface& getScriptInterface() override { return scriptInterface; }
 	LuaScriptInterface scriptInterface;
 
-	GlobalEventMap thinkMap, serverMap, timerMap;
+	GlobalEventMap thinkMap, timerMap;
 	int32_t thinkEventId = 0, timerEventId = 0;
 };
 

--- a/src/http/serverinfo.cpp
+++ b/src/http/serverinfo.cpp
@@ -30,7 +30,7 @@ std::pair<beast::http::status, json::value> tfs::http::handle_serverinfo(const j
 	     {"players",
 	      {{"online", g_game.getPlayersOnline()},
 	       {"max", getNumber(ConfigManager::MAX_PLAYERS)},
-	       {"peak", g_game.getPlayersRecord()}}},
+	       {"peak", g_game.getPlayerRecord()}}},
 	     {"monsters", {{"total", g_game.getMonstersOnline()}}},
 	     {"npcs", {{"total", g_game.getNpcsOnline()}}},
 	     {"rates",

--- a/src/lua/modules/game.cpp
+++ b/src/lua/modules/game.cpp
@@ -663,6 +663,21 @@ int luaGameReload(lua_State* L)
 	return 1;
 }
 
+int luaGameGetPlayerRecord(lua_State* L)
+{
+	// Game.getPlayerRecord()
+	tfs::lua::pushNumber(L, g_game.getPlayerRecord());
+	return 1;
+}
+
+int luaGameSetPlayerRecord(lua_State* L)
+{
+	// Game.setPlayerRecord(record)
+	g_game.setPlayerRecord(tfs::lua::getNumber<uint32_t>(L, 1));
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
 } // namespace
 
 void tfs::lua::registerGame(LuaScriptInterface& lsi)
@@ -730,4 +745,7 @@ void tfs::lua::registerGame(LuaScriptInterface& lsi)
 	lsi.registerMethod("Game", "getClientVersion", luaGameGetClientVersion);
 
 	lsi.registerMethod("Game", "reload", luaGameReload);
+
+	lsi.registerMethod("Game", "getPlayerRecord", luaGameGetPlayerRecord);
+	lsi.registerMethod("Game", "setPlayerRecord", luaGameSetPlayerRecord);
 }

--- a/src/lua/modules/globalevent.cpp
+++ b/src/lua/modules/globalevent.cpp
@@ -40,9 +40,7 @@ int luaGlobalEventType(lua_State* L)
 	if (global) {
 		std::string typeName = tfs::lua::getString(L, 2);
 		std::string tmpStr = boost::algorithm::to_lower_copy(typeName);
-		if (tmpStr == "record") {
-			global->setEventType(GLOBALEVENT_RECORD);
-		} else if (tmpStr == "timer") {
+		if (tmpStr == "timer") {
 			global->setEventType(GLOBALEVENT_TIMER);
 		} else {
 			std::cout << "[Error - luaGlobalEventType] Invalid type for global event: " << typeName << '\n';
@@ -81,7 +79,7 @@ int luaGlobalEventRegister(lua_State* L)
 
 int luaGlobalEventOnCallback(lua_State* L)
 {
-	// globalevent:onThink / record / etc. (callback)
+	// globalevent:onThink / onTime
 	GlobalEvent* globalevent = tfs::lua::getUserdata<GlobalEvent>(L, 1);
 	if (globalevent) {
 		if (!globalevent->loadCallback()) {
@@ -180,5 +178,4 @@ void tfs::lua::registerGlobalEvent(LuaScriptInterface& lsi)
 	lsi.registerMethod("GlobalEvent", "interval", luaGlobalEventInterval);
 	lsi.registerMethod("GlobalEvent", "onThink", luaGlobalEventOnCallback);
 	lsi.registerMethod("GlobalEvent", "onTime", luaGlobalEventOnCallback);
-	lsi.registerMethod("GlobalEvent", "onRecord", luaGlobalEventOnCallback);
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1040,8 +1040,6 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 			}
 		}
 
-		g_game.checkPlayersRecord();
-
 		IOLoginData::updateOnlineStatus(guid, true);
 
 		if (const auto& bed = g_game.getBedBySleeper(guid)) {

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -126,7 +126,7 @@ void ProtocolStatus::sendStatusString()
 
 	players.append_attribute("online") = std::to_string(reportableOnlinePlayerCount).c_str();
 	players.append_attribute("max") = std::to_string(getNumber(ConfigManager::MAX_PLAYERS)).c_str();
-	players.append_attribute("peak") = std::to_string(g_game.getPlayersRecord()).c_str();
+	players.append_attribute("peak") = std::to_string(g_game.getPlayerRecord()).c_str();
 
 	pugi::xml_node monsters = tsqp.append_child("monsters");
 	monsters.append_attribute("total") = std::to_string(g_game.getMonstersOnline()).c_str();
@@ -191,7 +191,7 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 		output->addByte(0x20);
 		output->add<uint32_t>(g_game.getPlayersOnline());
 		output->add<uint32_t>(getNumber(ConfigManager::MAX_PLAYERS));
-		output->add<uint32_t>(g_game.getPlayersRecord());
+		output->add<uint32_t>(g_game.getPlayerRecord());
 	}
 
 	if (requestedInfo & REQUEST_MAP_INFO) {


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Move player record from C++ to Lua

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Player-record handling moved to a new event-driven system: peak player count is loaded at startup, updated on player joins, and broadcasts a "New record" message when exceeded.

* **Chores**
  * Status outputs and internal accessor renamed to use the new playerRecord naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->