### PR TITLE
fix(chat): prevent use-after-free by using std::exchange for user map

### DIFF
--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -303,7 +303,7 @@ bool Chat::load()
 				}
 			}
 
-			UsersMap tempUserMap = std::move(channel.users);
+			UsersMap tempUserMap = std::exchange(channel.users, {});
 			for (const auto& player : tempUserMap | std::views::values | tfs::views::lock_weak_ptrs) {
 				channel.addUser(player);
 			}


### PR DESCRIPTION
This pull request updates the way user data is moved out of the `channel.users` container in the `Chat::load()` method, using `std::exchange` instead of `std::move` for improved clarity and safety.

- Code quality improvement:
  * In `src/chat.cpp`, replaced `std::move(channel.users)` with `std::exchange(channel.users, {})` when transferring user data to `tempUserMap` in `Chat::load()`, making the intention to clear `channel.users` explicit and reducing the risk of accidental undefined behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to channel user management with no impact to end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->