### PR TITLE
fix(beds): change event initialization to Event.onPlayerLogin

### DIFF
--- a/data/scripts/systems/beds/wake_up.lua
+++ b/data/scripts/systems/beds/wake_up.lua
@@ -1,4 +1,4 @@
-local event = Event("BedLogin")
+local event = Event()
 
 local function findRelevantBed(player)
     local pos = player:getPosition()

--- a/data/scripts/systems/beds/wake_up.lua
+++ b/data/scripts/systems/beds/wake_up.lua
@@ -1,4 +1,4 @@
-local event = CreatureEvent("BedLogin")
+local event = Event("BedLogin")
 
 local function findRelevantBed(player)
     local pos = player:getPosition()
@@ -52,7 +52,7 @@ local function regeneratePlayer(player, sleptSeconds)
     end
 end
 
-function event.onLogin(player)
+function event.onPlayerLogin(player)
     local headboard, footboard = findRelevantBed(player)
     if not headboard or not footboard or headboard:getSleeper() ~= player:getGuid() then
         return true


### PR DESCRIPTION
Changed the event instantiation from `CreatureEvent` to use `Event` class in `wake_up.lua`, since the former was removed by #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the bed wake-up system's internal event handling architecture to improve code consistency and maintainability. Functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->