### PR TITLE
fix(container): fix queryMaxCount to handle null items

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -310,19 +310,17 @@ ReturnValue Container::queryMaxCount(int32_t index, const std::shared_ptr<const 
 			// Iterate through every item and check how much free stackable slots there is.
 			uint32_t slotIndex = 0;
 			for (const auto& containerItem : itemList) {
-				if (containerItem != item && *containerItem == *item &&
+				if (containerItem && containerItem != item && *containerItem == *item &&
 				    containerItem->getItemCount() < ITEM_STACK_SIZE) {
 					if (queryAdd(slotIndex++, item, count, flags) == RETURNVALUE_NOERROR) {
 						n += ITEM_STACK_SIZE - containerItem->getItemCount();
 					}
 				}
 			}
-		} else {
-			if (const auto& destItem = getItemByIndex(index);
-			    *item == *destItem && destItem->getItemCount() < ITEM_STACK_SIZE) {
-				if (queryAdd(index, item, count, flags) == RETURNVALUE_NOERROR) {
-					n = ITEM_STACK_SIZE - destItem->getItemCount();
-				}
+		} else if (const auto& destItem = getItemByIndex(index);
+		           destItem && *destItem == *item && destItem->getItemCount() < ITEM_STACK_SIZE) {
+			if (queryAdd(index, item, count, flags) == RETURNVALUE_NOERROR) {
+				n = ITEM_STACK_SIZE - destItem->getItemCount();
 			}
 		}
 


### PR DESCRIPTION
A check was missing where it previously only entered the code path if the pointer was not null

Fixes #132 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added null safety validation in container item stacking logic to prevent potential crashes from invalid pointer access.
  * Enhanced guard conditions for item handling to ensure proper null checks before operations, improving overall stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->