### PR TITLE
fix(weapons): add item IDs to revscriptsys weapons

### DIFF
--- a/data/scripts/weapons/ammunition/arrow.lua
+++ b/data/scripts/weapons/ammunition/arrow.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(2544)
 weapon:action("removecount")
 weapon:register()

--- a/data/scripts/weapons/ammunition/bolt.lua
+++ b/data/scripts/weapons/ammunition/bolt.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(2543)
 weapon:action("removecount")
 weapon:register()

--- a/data/scripts/weapons/ammunition/burst_arrow.lua
+++ b/data/scripts/weapons/ammunition/burst_arrow.lua
@@ -22,5 +22,6 @@ function weapon.onUseWeapon(player, variant)
 	return combat:execute(player, variant)
 end
 
+weapon:id(2546)
 weapon:action("removecount")
 weapon:register()

--- a/data/scripts/weapons/ammunition/crystalline_arrow.lua
+++ b/data/scripts/weapons/ammunition/crystalline_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(18304)
 weapon:action("removecount")
 weapon:level(90)
 weapon:register()

--- a/data/scripts/weapons/ammunition/diamond_arrow.lua
+++ b/data/scripts/weapons/ammunition/diamond_arrow.lua
@@ -1,5 +1,3 @@
-local weapon = Weapon(WEAPON_AMMO)
-
 local area = createCombatArea({
 	{0, 1, 1, 1, 0},
 	{1, 1, 1, 1, 1},
@@ -16,10 +14,28 @@ combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
 combat:setArea(area)
 
-function weapon.onUseWeapon(player, variant)
-	return combat:execute(player, variant)
+do
+	local weapon = Weapon(WEAPON_AMMO)
+
+	function weapon.onUseWeapon(player, variant)
+		return combat:execute(player, variant)
+	end
+
+	weapon:id(28413)
+	weapon:action("removecount")
+	weapon:level(150)
+	weapon:register()
 end
 
-weapon:action("removecount")
-weapon:level(150)
-weapon:register()
+do
+	local weapon = Weapon(WEAPON_AMMO)
+
+	function weapon.onUseWeapon(player, variant)
+		return combat:execute(player, variant)
+	end
+
+	weapon:id(38557)
+	weapon:action("removecount")
+	weapon:level(150)
+	weapon:register()
+end

--- a/data/scripts/weapons/ammunition/diamond_arrow.lua
+++ b/data/scripts/weapons/ammunition/diamond_arrow.lua
@@ -14,28 +14,18 @@ combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
 combat:setArea(area)
 
-do
+local function registerDiamondArrow(id)
 	local weapon = Weapon(WEAPON_AMMO)
 
 	function weapon.onUseWeapon(player, variant)
 		return combat:execute(player, variant)
 	end
 
-	weapon:id(28413)
+	weapon:id(id)
 	weapon:action("removecount")
 	weapon:level(150)
 	weapon:register()
 end
 
-do
-	local weapon = Weapon(WEAPON_AMMO)
-
-	function weapon.onUseWeapon(player, variant)
-		return combat:execute(player, variant)
-	end
-
-	weapon:id(38557)
-	weapon:action("removecount")
-	weapon:level(150)
-	weapon:register()
-end
+registerDiamondArrow(28413)
+registerDiamondArrow(38557)

--- a/data/scripts/weapons/ammunition/drill_bolt.lua
+++ b/data/scripts/weapons/ammunition/drill_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(18436)
 weapon:action("removecount")
 weapon:level(70)
 weapon:register()

--- a/data/scripts/weapons/ammunition/earth_arrow.lua
+++ b/data/scripts/weapons/ammunition/earth_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7850)
 weapon:action("removecount")
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/ammunition/envenomed_arrow.lua
+++ b/data/scripts/weapons/ammunition/envenomed_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(18437)
 weapon:action("removecount")
 weapon:level(70)
 weapon:register()

--- a/data/scripts/weapons/ammunition/flaming_arrow.lua
+++ b/data/scripts/weapons/ammunition/flaming_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7840)
 weapon:action("removecount")
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/ammunition/flash_arrow.lua
+++ b/data/scripts/weapons/ammunition/flash_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7838)
 weapon:action("removecount")
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/ammunition/infernal_bolt.lua
+++ b/data/scripts/weapons/ammunition/infernal_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(6529)
 weapon:action("removecount")
 weapon:level(110)
 weapon:register()

--- a/data/scripts/weapons/ammunition/onyx_arrow.lua
+++ b/data/scripts/weapons/ammunition/onyx_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7365)
 weapon:action("removecount")
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/ammunition/piercing_bolt.lua
+++ b/data/scripts/weapons/ammunition/piercing_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7363)
 weapon:action("removecount")
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/ammunition/poison_arrow.lua
+++ b/data/scripts/weapons/ammunition/poison_arrow.lua
@@ -15,5 +15,6 @@ function weapon.onUseWeapon(player, variant)
 	return true
 end
 
+weapon:id(2545)
 weapon:action("removecount")
 weapon:register()

--- a/data/scripts/weapons/ammunition/power_bolt.lua
+++ b/data/scripts/weapons/ammunition/power_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(2547)
 weapon:action("removecount")
 weapon:level(55)
 weapon:register()

--- a/data/scripts/weapons/ammunition/prismatic_bolt.lua
+++ b/data/scripts/weapons/ammunition/prismatic_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(18435)
 weapon:action("removecount")
 weapon:level(90)
 weapon:register()

--- a/data/scripts/weapons/ammunition/shiver_arrow.lua
+++ b/data/scripts/weapons/ammunition/shiver_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7839)
 weapon:action("removecount")
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/ammunition/simple_arrow.lua
+++ b/data/scripts/weapons/ammunition/simple_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(23839)
 weapon:action("removecount")
 weapon:wieldUnproperly(false)
 weapon:level(1)

--- a/data/scripts/weapons/ammunition/sniper_arrow.lua
+++ b/data/scripts/weapons/ammunition/sniper_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(7364)
 weapon:action("removecount")
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/ammunition/spectral_bolt.lua
+++ b/data/scripts/weapons/ammunition/spectral_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(38558)
 weapon:action("removecount")
 weapon:level(150)
 weapon:register()

--- a/data/scripts/weapons/ammunition/tarsal_arrow.lua
+++ b/data/scripts/weapons/ammunition/tarsal_arrow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(15648)
 weapon:action("removecount")
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/ammunition/vortex_bolt.lua
+++ b/data/scripts/weapons/ammunition/vortex_bolt.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AMMO)
+weapon:id(15649)
 weapon:action("removecount")
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/axe/angelic_axe.lua
+++ b/data/scripts/weapons/axe/angelic_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7436)
 weapon:level(45)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/barbarian_axe.lua
+++ b/data/scripts/weapons/axe/barbarian_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2429)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/axe/battle_axe.lua
+++ b/data/scripts/weapons/axe/battle_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2378)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/beastslayer_axe.lua
+++ b/data/scripts/weapons/axe/beastslayer_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(3962)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/axe/butcher's_axe.lua
+++ b/data/scripts/weapons/axe/butcher's_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7412)
 weapon:level(45)
 weapon:register()

--- a/data/scripts/weapons/axe/crude_umbral_axe.lua
+++ b/data/scripts/weapons/axe/crude_umbral_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(22404)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/crude_umbral_chopper.lua
+++ b/data/scripts/weapons/axe/crude_umbral_chopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(22407)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/daramian_waraxe.lua
+++ b/data/scripts/weapons/axe/daramian_waraxe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2440)
 weapon:level(25)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/deepling_axe.lua
+++ b/data/scripts/weapons/axe/deepling_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(15404)
 weapon:level(80)
 weapon:register()

--- a/data/scripts/weapons/axe/demonwing_axe.lua
+++ b/data/scripts/weapons/axe/demonwing_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(8926)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/double_axe.lua
+++ b/data/scripts/weapons/axe/double_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2387)
 weapon:level(25)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/dragon_lance.lua
+++ b/data/scripts/weapons/axe/dragon_lance.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2414)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/axe/drakinata.lua
+++ b/data/scripts/weapons/axe/drakinata.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(11305)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/axe/dreaded_cleaver.lua
+++ b/data/scripts/weapons/axe/dreaded_cleaver.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7419)
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/axe/dwarven_axe.lua
+++ b/data/scripts/weapons/axe/dwarven_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2435)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/axe/earth_barbarian_axe.lua
+++ b/data/scripts/weapons/axe/earth_barbarian_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7859)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/earth_headchopper.lua
+++ b/data/scripts/weapons/axe/earth_headchopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7862)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/earth_heroic_axe.lua
+++ b/data/scripts/weapons/axe/earth_heroic_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7861)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/earth_knight_axe.lua
+++ b/data/scripts/weapons/axe/earth_knight_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7860)
 weapon:level(25)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/earth_war_axe.lua
+++ b/data/scripts/weapons/axe/earth_war_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7863)
 weapon:level(65)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/energy_barbarian_axe.lua
+++ b/data/scripts/weapons/axe/energy_barbarian_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7874)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/energy_headchopper.lua
+++ b/data/scripts/weapons/axe/energy_headchopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7877)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/energy_heroic_axe.lua
+++ b/data/scripts/weapons/axe/energy_heroic_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7876)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/energy_knight_axe.lua
+++ b/data/scripts/weapons/axe/energy_knight_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7875)
 weapon:level(25)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/energy_war_axe.lua
+++ b/data/scripts/weapons/axe/energy_war_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7878)
 weapon:level(65)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/executioner.lua
+++ b/data/scripts/weapons/axe/executioner.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7453)
 weapon:level(85)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/fiery_barbarian_axe.lua
+++ b/data/scripts/weapons/axe/fiery_barbarian_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7749)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/fiery_headchopper.lua
+++ b/data/scripts/weapons/axe/fiery_headchopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7752)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/fiery_heroic_axe.lua
+++ b/data/scripts/weapons/axe/fiery_heroic_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7751)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/fiery_knight_axe.lua
+++ b/data/scripts/weapons/axe/fiery_knight_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7750)
 weapon:level(25)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/fiery_war_axe.lua
+++ b/data/scripts/weapons/axe/fiery_war_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7753)
 weapon:level(65)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/fire_axe.lua
+++ b/data/scripts/weapons/axe/fire_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2432)
 weapon:level(35)
 weapon:register()

--- a/data/scripts/weapons/axe/glorious_axe.lua
+++ b/data/scripts/weapons/axe/glorious_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7454)
 weapon:level(30)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/great_axe.lua
+++ b/data/scripts/weapons/axe/great_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2415)
 weapon:level(95)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/guardian_axe.lua
+++ b/data/scripts/weapons/axe/guardian_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(15454)
 weapon:level(50)
 weapon:register()

--- a/data/scripts/weapons/axe/guardian_halberd.lua
+++ b/data/scripts/weapons/axe/guardian_halberd.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2427)
 weapon:level(55)
 weapon:register()

--- a/data/scripts/weapons/axe/halberd.lua
+++ b/data/scripts/weapons/axe/halberd.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2381)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/axe/headchopper.lua
+++ b/data/scripts/weapons/axe/headchopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7380)
 weapon:level(35)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/hellforged_axe.lua
+++ b/data/scripts/weapons/axe/hellforged_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(8924)
 weapon:level(110)
 weapon:register()

--- a/data/scripts/weapons/axe/heroic_axe.lua
+++ b/data/scripts/weapons/axe/heroic_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7389)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/axe/hive_scythe.lua
+++ b/data/scripts/weapons/axe/hive_scythe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(15492)
 weapon:level(70)
 weapon:register()

--- a/data/scripts/weapons/axe/icy_barbarian_axe.lua
+++ b/data/scripts/weapons/axe/icy_barbarian_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7768)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/icy_headchopper.lua
+++ b/data/scripts/weapons/axe/icy_headchopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7771)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/icy_heroic_axe.lua
+++ b/data/scripts/weapons/axe/icy_heroic_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7770)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/icy_knight_axe.lua
+++ b/data/scripts/weapons/axe/icy_knight_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7769)
 weapon:level(25)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/axe/icy_war_axe.lua
+++ b/data/scripts/weapons/axe/icy_war_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7772)
 weapon:level(65)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/axe/impaler.lua
+++ b/data/scripts/weapons/axe/impaler.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7435)
 weapon:level(85)
 weapon:register()

--- a/data/scripts/weapons/axe/knight_axe.lua
+++ b/data/scripts/weapons/axe/knight_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2430)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/axe/mythril_axe.lua
+++ b/data/scripts/weapons/axe/mythril_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7455)
 weapon:level(80)
 weapon:register()

--- a/data/scripts/weapons/axe/naginata.lua
+++ b/data/scripts/weapons/axe/naginata.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2426)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/axe/noble_axe.lua
+++ b/data/scripts/weapons/axe/noble_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7456)
 weapon:level(35)
 weapon:register()

--- a/data/scripts/weapons/axe/obsidian_lance.lua
+++ b/data/scripts/weapons/axe/obsidian_lance.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2425)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/axe/ogre_choppa.lua
+++ b/data/scripts/weapons/axe/ogre_choppa.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(24828)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/axe/ornamented_axe.lua
+++ b/data/scripts/weapons/axe/ornamented_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7411)
 weapon:level(50)
 weapon:register()

--- a/data/scripts/weapons/axe/plague_bite.lua
+++ b/data/scripts/weapons/axe/plague_bite.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(25415)
 weapon:level(150)
 weapon:register()

--- a/data/scripts/weapons/axe/ravager's_axe.lua
+++ b/data/scripts/weapons/axe/ravager's_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2443)
 weapon:level(70)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/ravenwing.lua
+++ b/data/scripts/weapons/axe/ravenwing.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7433)
 weapon:level(65)
 weapon:register()

--- a/data/scripts/weapons/axe/reaper's_axe.lua
+++ b/data/scripts/weapons/axe/reaper's_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7420)
 weapon:level(70)
 weapon:register()

--- a/data/scripts/weapons/axe/rift_lance.lua
+++ b/data/scripts/weapons/axe/rift_lance.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(25383)
 weapon:level(70)
 weapon:register()

--- a/data/scripts/weapons/axe/royal_axe.lua
+++ b/data/scripts/weapons/axe/royal_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7434)
 weapon:level(75)
 weapon:register()

--- a/data/scripts/weapons/axe/ruthless_axe.lua
+++ b/data/scripts/weapons/axe/ruthless_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(6553)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/solar_axe.lua
+++ b/data/scripts/weapons/axe/solar_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(8925)
 weapon:level(130)
 weapon:register()

--- a/data/scripts/weapons/axe/stonecutter_axe.lua
+++ b/data/scripts/weapons/axe/stonecutter_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2431)
 weapon:level(90)
 weapon:register()

--- a/data/scripts/weapons/axe/titan_axe.lua
+++ b/data/scripts/weapons/axe/titan_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7413)
 weapon:level(40)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/twin_axe.lua
+++ b/data/scripts/weapons/axe/twin_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2447)
 weapon:level(50)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/twin_hooks.lua
+++ b/data/scripts/weapons/axe/twin_hooks.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(11309)
 weapon:level(20)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/umbral_axe.lua
+++ b/data/scripts/weapons/axe/umbral_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(22405)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/umbral_chopper.lua
+++ b/data/scripts/weapons/axe/umbral_chopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(22408)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/umbral_master_axe.lua
+++ b/data/scripts/weapons/axe/umbral_master_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(22406)
 weapon:level(250)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/umbral_master_chopper.lua
+++ b/data/scripts/weapons/axe/umbral_master_chopper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(22409)
 weapon:level(250)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/vile_axe.lua
+++ b/data/scripts/weapons/axe/vile_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(7388)
 weapon:level(55)
 weapon:register()

--- a/data/scripts/weapons/axe/war_axe.lua
+++ b/data/scripts/weapons/axe/war_axe.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(2454)
 weapon:level(65)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/axe/warrior's_axe.lua
+++ b/data/scripts/weapons/axe/warrior's_axe.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(15451)
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/axe/zaoan_halberd.lua
+++ b/data/scripts/weapons/axe/zaoan_halberd.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_AXE)
+weapon:id(11323)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/club/abyss_hammer.lua
+++ b/data/scripts/weapons/club/abyss_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7414)
 weapon:level(60)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/amber_staff.lua
+++ b/data/scripts/weapons/club/amber_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7426)
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/club/arcane_staff.lua
+++ b/data/scripts/weapons/club/arcane_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2453)
 weapon:level(75)
 weapon:register()

--- a/data/scripts/weapons/club/blessed_sceptre.lua
+++ b/data/scripts/weapons/club/blessed_sceptre.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7429)
 weapon:level(75)
 weapon:register()

--- a/data/scripts/weapons/club/bonebreaker.lua
+++ b/data/scripts/weapons/club/bonebreaker.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7428)
 weapon:level(55)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/brutetamer's_staff.lua
+++ b/data/scripts/weapons/club/brutetamer's_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7379)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/club/chaos_mace.lua
+++ b/data/scripts/weapons/club/chaos_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7427)
 weapon:level(45)
 weapon:register()

--- a/data/scripts/weapons/club/clerical_mace.lua
+++ b/data/scripts/weapons/club/clerical_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2423)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/club/cranial_basher.lua
+++ b/data/scripts/weapons/club/cranial_basher.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7415)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/club/crude_umbral_hammer.lua
+++ b/data/scripts/weapons/club/crude_umbral_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(22413)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/crude_umbral_mace.lua
+++ b/data/scripts/weapons/club/crude_umbral_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(22410)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/crystal_mace.lua
+++ b/data/scripts/weapons/club/crystal_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2445)
 weapon:level(35)
 weapon:register()

--- a/data/scripts/weapons/club/dark_trinity_mace.lua
+++ b/data/scripts/weapons/club/dark_trinity_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(8927)
 weapon:level(120)
 weapon:register()

--- a/data/scripts/weapons/club/deepling_squelcher.lua
+++ b/data/scripts/weapons/club/deepling_squelcher.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(15647)
 weapon:level(48)
 weapon:register()

--- a/data/scripts/weapons/club/deepling_staff.lua
+++ b/data/scripts/weapons/club/deepling_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(15400)
 weapon:level(38)
 weapon:register()

--- a/data/scripts/weapons/club/demonbone.lua
+++ b/data/scripts/weapons/club/demonbone.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7431)
 weapon:level(80)
 weapon:register()

--- a/data/scripts/weapons/club/diamond_sceptre.lua
+++ b/data/scripts/weapons/club/diamond_sceptre.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7387)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/club/drachaku.lua
+++ b/data/scripts/weapons/club/drachaku.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(11308)
 weapon:level(55)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/dragon_hammer.lua
+++ b/data/scripts/weapons/club/dragon_hammer.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2434)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/club/dragonbone_staff.lua
+++ b/data/scripts/weapons/club/dragonbone_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7430)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/club/earth_clerical_mace.lua
+++ b/data/scripts/weapons/club/earth_clerical_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7864)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/earth_cranial_basher.lua
+++ b/data/scripts/weapons/club/earth_cranial_basher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7866)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/earth_crystal_mace.lua
+++ b/data/scripts/weapons/club/earth_crystal_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7865)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/earth_orcish_maul.lua
+++ b/data/scripts/weapons/club/earth_orcish_maul.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7867)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/earth_war_hammer.lua
+++ b/data/scripts/weapons/club/earth_war_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7868)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/club/energy_clerical_mace.lua
+++ b/data/scripts/weapons/club/energy_clerical_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7879)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/energy_cranial_basher.lua
+++ b/data/scripts/weapons/club/energy_cranial_basher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7881)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/energy_crystal_mace.lua
+++ b/data/scripts/weapons/club/energy_crystal_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7880)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/energy_orcish_maul.lua
+++ b/data/scripts/weapons/club/energy_orcish_maul.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7882)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/energy_war_hammer.lua
+++ b/data/scripts/weapons/club/energy_war_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7883)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/club/ferumbras'_staff.lua
+++ b/data/scripts/weapons/club/ferumbras'_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(25420)
 weapon:level(100)
 weapon:register()

--- a/data/scripts/weapons/club/fiery_clerical_mace.lua
+++ b/data/scripts/weapons/club/fiery_clerical_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7754)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/fiery_cranial_basher.lua
+++ b/data/scripts/weapons/club/fiery_cranial_basher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7756)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/fiery_crystal_mace.lua
+++ b/data/scripts/weapons/club/fiery_crystal_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7755)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/fiery_orcish_maul.lua
+++ b/data/scripts/weapons/club/fiery_orcish_maul.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7757)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/fiery_war_hammer.lua
+++ b/data/scripts/weapons/club/fiery_war_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7758)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/club/furry_club.lua
+++ b/data/scripts/weapons/club/furry_club.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7432)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/club/hammer_of_prophecy.lua
+++ b/data/scripts/weapons/club/hammer_of_prophecy.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7450)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/hammer_of_wrath.lua
+++ b/data/scripts/weapons/club/hammer_of_wrath.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2444)
 weapon:level(65)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/heavy_mace.lua
+++ b/data/scripts/weapons/club/heavy_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2452)
 weapon:level(70)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/icy_clerical_mace.lua
+++ b/data/scripts/weapons/club/icy_clerical_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7773)
 weapon:level(20)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/icy_cranial_basher.lua
+++ b/data/scripts/weapons/club/icy_cranial_basher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7775)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/icy_crystal_mace.lua
+++ b/data/scripts/weapons/club/icy_crystal_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7774)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/icy_orcish_maul.lua
+++ b/data/scripts/weapons/club/icy_orcish_maul.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7776)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/club/icy_war_hammer.lua
+++ b/data/scripts/weapons/club/icy_war_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7777)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/club/jade_hammer.lua
+++ b/data/scripts/weapons/club/jade_hammer.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7422)
 weapon:level(75)
 weapon:register()

--- a/data/scripts/weapons/club/lich_staff.lua
+++ b/data/scripts/weapons/club/lich_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(3961)
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/club/life_preserver.lua
+++ b/data/scripts/weapons/club/life_preserver.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(20093)
 weapon:level(15)
 weapon:register()

--- a/data/scripts/weapons/club/lunar_staff.lua
+++ b/data/scripts/weapons/club/lunar_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7424)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/club/maimer.lua
+++ b/data/scripts/weapons/club/maimer.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(25418)
 weapon:level(150)
 weapon:register()

--- a/data/scripts/weapons/club/mammoth_whopper.lua
+++ b/data/scripts/weapons/club/mammoth_whopper.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7381)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/club/northern_star.lua
+++ b/data/scripts/weapons/club/northern_star.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7409)
 weapon:level(50)
 weapon:register()

--- a/data/scripts/weapons/club/obsidian_truncheon.lua
+++ b/data/scripts/weapons/club/obsidian_truncheon.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(8928)
 weapon:level(100)
 weapon:register()

--- a/data/scripts/weapons/club/ogre_klubba.lua
+++ b/data/scripts/weapons/club/ogre_klubba.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(24827)
 weapon:level(50)
 weapon:register()

--- a/data/scripts/weapons/club/onyx_flail.lua
+++ b/data/scripts/weapons/club/onyx_flail.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7421)
 weapon:level(65)
 weapon:register()

--- a/data/scripts/weapons/club/orcish_maul.lua
+++ b/data/scripts/weapons/club/orcish_maul.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7392)
 weapon:level(35)
 weapon:register()

--- a/data/scripts/weapons/club/ornate_mace.lua
+++ b/data/scripts/weapons/club/ornate_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(15414)
 weapon:level(90)
 weapon:register()

--- a/data/scripts/weapons/club/pair_of_iron_fists.lua
+++ b/data/scripts/weapons/club/pair_of_iron_fists.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(20108)
 weapon:level(50)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/queen's_sceptre.lua
+++ b/data/scripts/weapons/club/queen's_sceptre.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7410)
 weapon:level(55)
 weapon:register()

--- a/data/scripts/weapons/club/sapphire_hammer.lua
+++ b/data/scripts/weapons/club/sapphire_hammer.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7437)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/club/shadow_sceptre.lua
+++ b/data/scripts/weapons/club/shadow_sceptre.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7451)
 weapon:level(35)
 weapon:register()

--- a/data/scripts/weapons/club/silver_mace.lua
+++ b/data/scripts/weapons/club/silver_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2424)
 weapon:level(45)
 weapon:register()

--- a/data/scripts/weapons/club/skull_staff.lua
+++ b/data/scripts/weapons/club/skull_staff.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2436)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/club/skullcrusher.lua
+++ b/data/scripts/weapons/club/skullcrusher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7423)
 weapon:level(85)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/snake_god's_sceptre.lua
+++ b/data/scripts/weapons/club/snake_god's_sceptre.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(12648)
 weapon:level(82)
 weapon:register()

--- a/data/scripts/weapons/club/spiked_squelcher.lua
+++ b/data/scripts/weapons/club/spiked_squelcher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7452)
 weapon:level(30)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/spiky_club.lua
+++ b/data/scripts/weapons/club/spiky_club.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(20139)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/club/taurus_mace.lua
+++ b/data/scripts/weapons/club/taurus_mace.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(7425)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/club/the_stomper.lua
+++ b/data/scripts/weapons/club/the_stomper.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(8929)
 weapon:level(100)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/thunder_hammer.lua
+++ b/data/scripts/weapons/club/thunder_hammer.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2421)
 weapon:level(85)
 weapon:register()

--- a/data/scripts/weapons/club/umbral_hammer.lua
+++ b/data/scripts/weapons/club/umbral_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(22414)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/umbral_mace.lua
+++ b/data/scripts/weapons/club/umbral_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(22411)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/umbral_master_hammer.lua
+++ b/data/scripts/weapons/club/umbral_master_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(22415)
 weapon:level(250)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/umbral_master_mace.lua
+++ b/data/scripts/weapons/club/umbral_master_mace.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(22412)
 weapon:level(250)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/club/war_hammer.lua
+++ b/data/scripts/weapons/club/war_hammer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_CLUB)
+weapon:id(2391)
 weapon:level(50)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/distance/arbalest.lua
+++ b/data/scripts/weapons/distance/arbalest.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(5803)
 weapon:level(75)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/assassin_star.lua
+++ b/data/scripts/weapons/distance/assassin_star.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(7368)
 weapon:breakChance(33)
 weapon:level(80)
 weapon:register()

--- a/data/scripts/weapons/distance/chain_bolter.lua
+++ b/data/scripts/weapons/distance/chain_bolter.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8850)
 weapon:level(60)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/composite_hornbow.lua
+++ b/data/scripts/weapons/distance/composite_hornbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8855)
 weapon:level(50)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/crude_umbral_bow.lua
+++ b/data/scripts/weapons/distance/crude_umbral_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(22416)
 weapon:level(75)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/crude_umbral_crossbow.lua
+++ b/data/scripts/weapons/distance/crude_umbral_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(22419)
 weapon:level(75)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/crystal_crossbow.lua
+++ b/data/scripts/weapons/distance/crystal_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(18453)
 weapon:level(90)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/elethriel's_elemental_bow.lua
+++ b/data/scripts/weapons/distance/elethriel's_elemental_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8858)
 weapon:level(70)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/enchanted_spear.lua
+++ b/data/scripts/weapons/distance/enchanted_spear.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(7367)
 weapon:breakChance(1)
 weapon:level(42)
 weapon:register()

--- a/data/scripts/weapons/distance/glooth_spear.lua
+++ b/data/scripts/weapons/distance/glooth_spear.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(23529)
 weapon:breakChance(31)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/distance/hive_bow.lua
+++ b/data/scripts/weapons/distance/hive_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(15643)
 weapon:level(85)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/hunting_spear.lua
+++ b/data/scripts/weapons/distance/hunting_spear.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(3965)
 weapon:breakChance(6)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/distance/icicle_bow.lua
+++ b/data/scripts/weapons/distance/icicle_bow.lua
@@ -1,2 +1,3 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(21696)
 weapon:register()

--- a/data/scripts/weapons/distance/leaf_star.lua
+++ b/data/scripts/weapons/distance/leaf_star.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(28391)
 weapon:breakChance(42)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/distance/modified_crossbow.lua
+++ b/data/scripts/weapons/distance/modified_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8849)
 weapon:level(45)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/mycological_bow.lua
+++ b/data/scripts/weapons/distance/mycological_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(18454)
 weapon:level(105)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/ornate_crossbow.lua
+++ b/data/scripts/weapons/distance/ornate_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(15644)
 weapon:level(50)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/rift_bow.lua
+++ b/data/scripts/weapons/distance/rift_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(25522)
 weapon:level(120)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/rift_crossbow.lua
+++ b/data/scripts/weapons/distance/rift_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(25523)
 weapon:level(120)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/royal_crossbow.lua
+++ b/data/scripts/weapons/distance/royal_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8851)
 weapon:level(130)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/royal_spear.lua
+++ b/data/scripts/weapons/distance/royal_spear.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(7378)
 weapon:breakChance(3)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/distance/royal_star.lua
+++ b/data/scripts/weapons/distance/royal_star.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(28415)
 weapon:breakChance(30)
 weapon:level(120)
 weapon:register()

--- a/data/scripts/weapons/distance/shimmer_bow.lua
+++ b/data/scripts/weapons/distance/shimmer_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(13873)
 weapon:level(40)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/silkweaver_bow.lua
+++ b/data/scripts/weapons/distance/silkweaver_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8857)
 weapon:level(40)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/small_stone.lua
+++ b/data/scripts/weapons/distance/small_stone.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(1294)
 weapon:breakChance(3)
 weapon:register()

--- a/data/scripts/weapons/distance/snowball.lua
+++ b/data/scripts/weapons/distance/snowball.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(2111)
 weapon:action("removecount")
 weapon:register()

--- a/data/scripts/weapons/distance/spear.lua
+++ b/data/scripts/weapons/distance/spear.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(2389)
 weapon:breakChance(3)
 weapon:register()

--- a/data/scripts/weapons/distance/the_devileye.lua
+++ b/data/scripts/weapons/distance/the_devileye.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8852)
 weapon:level(100)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/the_ironworker.lua
+++ b/data/scripts/weapons/distance/the_ironworker.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8853)
 weapon:level(80)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/thorn_spitter.lua
+++ b/data/scripts/weapons/distance/thorn_spitter.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(16111)
 weapon:level(150)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/throwing_knife.lua
+++ b/data/scripts/weapons/distance/throwing_knife.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(2410)
 weapon:breakChance(7)
 weapon:register()

--- a/data/scripts/weapons/distance/throwing_star.lua
+++ b/data/scripts/weapons/distance/throwing_star.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(2399)
 weapon:breakChance(10)
 weapon:register()

--- a/data/scripts/weapons/distance/throwing_star_of_sula.lua
+++ b/data/scripts/weapons/distance/throwing_star_of_sula.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(25526)
 weapon:breakChance(10)
 weapon:register()

--- a/data/scripts/weapons/distance/triple_bolt_crossbow.lua
+++ b/data/scripts/weapons/distance/triple_bolt_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(21690)
 weapon:level(70)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/umbral_bow.lua
+++ b/data/scripts/weapons/distance/umbral_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(22417)
 weapon:level(150)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/umbral_crossbow.lua
+++ b/data/scripts/weapons/distance/umbral_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(22420)
 weapon:level(150)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/umbral_master_bow.lua
+++ b/data/scripts/weapons/distance/umbral_master_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(22418)
 weapon:level(250)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/umbral_master_crossbow.lua
+++ b/data/scripts/weapons/distance/umbral_master_crossbow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(22421)
 weapon:level(250)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/viper_star.lua
+++ b/data/scripts/weapons/distance/viper_star.lua
@@ -20,5 +20,6 @@ function weapon.onUseWeapon(player, variant)
 	return true
 end
 
+weapon:id(7366)
 weapon:breakChance(9)
 weapon:register()

--- a/data/scripts/weapons/distance/warsinger_bow.lua
+++ b/data/scripts/weapons/distance/warsinger_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8854)
 weapon:level(80)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/distance/yol's_bow.lua
+++ b/data/scripts/weapons/distance/yol's_bow.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_DISTANCE)
+weapon:id(8856)
 weapon:level(60)
 weapon:vocation("paladin")
 weapon:register()

--- a/data/scripts/weapons/sword/assassin_dagger.lua
+++ b/data/scripts/weapons/sword/assassin_dagger.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7404)
 weapon:level(40)
 weapon:register()

--- a/data/scripts/weapons/sword/berserker.lua
+++ b/data/scripts/weapons/sword/berserker.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7403)
 weapon:level(65)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/blacksteel_sword.lua
+++ b/data/scripts/weapons/sword/blacksteel_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7406)
 weapon:level(35)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/blade_of_corruption.lua
+++ b/data/scripts/weapons/sword/blade_of_corruption.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(12649)
 weapon:level(82)
 weapon:register()

--- a/data/scripts/weapons/sword/bloody_edge.lua
+++ b/data/scripts/weapons/sword/bloody_edge.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7416)
 weapon:level(55)
 weapon:register()

--- a/data/scripts/weapons/sword/bright_sword.lua
+++ b/data/scripts/weapons/sword/bright_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2407)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/sword/broadsword.lua
+++ b/data/scripts/weapons/sword/broadsword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2413)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/crimson_sword.lua
+++ b/data/scripts/weapons/sword/crimson_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7385)
 weapon:level(20)
 weapon:register()

--- a/data/scripts/weapons/sword/crude_umbral_blade.lua
+++ b/data/scripts/weapons/sword/crude_umbral_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(22398)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/crude_umbral_slayer.lua
+++ b/data/scripts/weapons/sword/crude_umbral_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(22401)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/crystal_sword.lua
+++ b/data/scripts/weapons/sword/crystal_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7449)
 weapon:level(25)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/crystalline_sword.lua
+++ b/data/scripts/weapons/sword/crystalline_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(18450)
 weapon:level(62)
 weapon:register()

--- a/data/scripts/weapons/sword/demonrage_sword.lua
+++ b/data/scripts/weapons/sword/demonrage_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7382)
 weapon:level(60)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/djinn_blade.lua
+++ b/data/scripts/weapons/sword/djinn_blade.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2451)
 weapon:level(35)
 weapon:register()

--- a/data/scripts/weapons/sword/dragon_slayer.lua
+++ b/data/scripts/weapons/sword/dragon_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7402)
 weapon:level(45)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/earth_blacksteel_sword.lua
+++ b/data/scripts/weapons/sword/earth_blacksteel_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7857)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/earth_dragon_slayer.lua
+++ b/data/scripts/weapons/sword/earth_dragon_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7858)
 weapon:level(45)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/earth_mystic_blade.lua
+++ b/data/scripts/weapons/sword/earth_mystic_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7856)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/earth_relic_sword.lua
+++ b/data/scripts/weapons/sword/earth_relic_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7855)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/earth_spike_sword.lua
+++ b/data/scripts/weapons/sword/earth_spike_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7854)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/emerald_sword.lua
+++ b/data/scripts/weapons/sword/emerald_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(8930)
 weapon:level(100)
 weapon:register()

--- a/data/scripts/weapons/sword/energy_blacksteel_sword.lua
+++ b/data/scripts/weapons/sword/energy_blacksteel_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7872)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/energy_dragon_slayer.lua
+++ b/data/scripts/weapons/sword/energy_dragon_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7873)
 weapon:level(45)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/energy_mystic_blade.lua
+++ b/data/scripts/weapons/sword/energy_mystic_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7871)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/energy_relic_sword.lua
+++ b/data/scripts/weapons/sword/energy_relic_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7870)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/energy_spike_sword.lua
+++ b/data/scripts/weapons/sword/energy_spike_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7869)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/epee.lua
+++ b/data/scripts/weapons/sword/epee.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2438)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/sword/fiery_blacksteel_sword.lua
+++ b/data/scripts/weapons/sword/fiery_blacksteel_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7747)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/fiery_dragon_slayer.lua
+++ b/data/scripts/weapons/sword/fiery_dragon_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7748)
 weapon:level(45)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/fiery_mystic_blade.lua
+++ b/data/scripts/weapons/sword/fiery_mystic_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7746)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/fiery_relic_sword.lua
+++ b/data/scripts/weapons/sword/fiery_relic_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7745)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/fiery_spike_sword.lua
+++ b/data/scripts/weapons/sword/fiery_spike_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7744)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/fire_sword.lua
+++ b/data/scripts/weapons/sword/fire_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2392)
 weapon:level(30)
 weapon:register()

--- a/data/scripts/weapons/sword/giant_sword.lua
+++ b/data/scripts/weapons/sword/giant_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2393)
 weapon:level(55)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/haunted_blade.lua
+++ b/data/scripts/weapons/sword/haunted_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7407)
 weapon:level(30)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/havoc_blade.lua
+++ b/data/scripts/weapons/sword/havoc_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7405)
 weapon:level(70)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/heavy_trident.lua
+++ b/data/scripts/weapons/sword/heavy_trident.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(13838)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/sword/ice_rapier.lua
+++ b/data/scripts/weapons/sword/ice_rapier.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2396)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/icy_blacksteel_sword.lua
+++ b/data/scripts/weapons/sword/icy_blacksteel_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7766)
 weapon:level(35)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/icy_dragon_slayer.lua
+++ b/data/scripts/weapons/sword/icy_dragon_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7767)
 weapon:level(45)
 weapon:action("removecharge")
 weapon:vocation("knight")

--- a/data/scripts/weapons/sword/icy_mystic_blade.lua
+++ b/data/scripts/weapons/sword/icy_mystic_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7765)
 weapon:level(60)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/icy_relic_sword.lua
+++ b/data/scripts/weapons/sword/icy_relic_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7764)
 weapon:level(50)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/icy_spike_sword.lua
+++ b/data/scripts/weapons/sword/icy_spike_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7763)
 weapon:action("removecharge")
 weapon:register()

--- a/data/scripts/weapons/sword/impaler_of_the_igniter.lua
+++ b/data/scripts/weapons/sword/impaler_of_the_igniter.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(25416)
 weapon:level(150)
 weapon:register()

--- a/data/scripts/weapons/sword/magic_longsword.lua
+++ b/data/scripts/weapons/sword/magic_longsword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2390)
 weapon:level(140)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/magic_sword.lua
+++ b/data/scripts/weapons/sword/magic_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2400)
 weapon:level(80)
 weapon:register()

--- a/data/scripts/weapons/sword/mercenary_sword.lua
+++ b/data/scripts/weapons/sword/mercenary_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7386)
 weapon:level(40)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/mystic_blade.lua
+++ b/data/scripts/weapons/sword/mystic_blade.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7384)
 weapon:level(60)
 weapon:register()

--- a/data/scripts/weapons/sword/nightmare_blade.lua
+++ b/data/scripts/weapons/sword/nightmare_blade.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7418)
 weapon:level(70)
 weapon:register()

--- a/data/scripts/weapons/sword/pharaoh_sword.lua
+++ b/data/scripts/weapons/sword/pharaoh_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2446)
 weapon:level(45)
 weapon:register()

--- a/data/scripts/weapons/sword/ratana.lua
+++ b/data/scripts/weapons/sword/ratana.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(20092)
 weapon:level(15)
 weapon:register()

--- a/data/scripts/weapons/sword/relic_sword.lua
+++ b/data/scripts/weapons/sword/relic_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7383)
 weapon:level(50)
 weapon:register()

--- a/data/scripts/weapons/sword/runed_sword.lua
+++ b/data/scripts/weapons/sword/runed_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7417)
 weapon:level(65)
 weapon:register()

--- a/data/scripts/weapons/sword/sai.lua
+++ b/data/scripts/weapons/sword/sai.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(11306)
 weapon:level(50)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/shimmer_sword.lua
+++ b/data/scripts/weapons/sword/shimmer_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(13871)
 weapon:level(40)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/thaian_sword.lua
+++ b/data/scripts/weapons/sword/thaian_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7391)
 weapon:level(50)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/the_avenger.lua
+++ b/data/scripts/weapons/sword/the_avenger.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(6528)
 weapon:level(75)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/the_calamity.lua
+++ b/data/scripts/weapons/sword/the_calamity.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(8932)
 weapon:level(100)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/the_epiphany.lua
+++ b/data/scripts/weapons/sword/the_epiphany.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(8931)
 weapon:level(120)
 weapon:register()

--- a/data/scripts/weapons/sword/the_justice_seeker.lua
+++ b/data/scripts/weapons/sword/the_justice_seeker.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7390)
 weapon:level(75)
 weapon:register()

--- a/data/scripts/weapons/sword/twiceslicer.lua
+++ b/data/scripts/weapons/sword/twiceslicer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(12613)
 weapon:level(58)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/two_handed_sword.lua
+++ b/data/scripts/weapons/sword/two_handed_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2377)
 weapon:level(20)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/umbral_blade.lua
+++ b/data/scripts/weapons/sword/umbral_blade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(22399)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/umbral_master_slayer.lua
+++ b/data/scripts/weapons/sword/umbral_master_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(22403)
 weapon:level(250)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/umbral_masterblade.lua
+++ b/data/scripts/weapons/sword/umbral_masterblade.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(22400)
 weapon:level(250)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/umbral_slayer.lua
+++ b/data/scripts/weapons/sword/umbral_slayer.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(22402)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/warlord_sword.lua
+++ b/data/scripts/weapons/sword/warlord_sword.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(2408)
 weapon:level(120)
 weapon:vocation("knight")
 weapon:register()

--- a/data/scripts/weapons/sword/wyvern_fang.lua
+++ b/data/scripts/weapons/sword/wyvern_fang.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(7408)
 weapon:level(25)
 weapon:register()

--- a/data/scripts/weapons/sword/zaoan_sword.lua
+++ b/data/scripts/weapons/sword/zaoan_sword.lua
@@ -1,3 +1,4 @@
 local weapon = Weapon(WEAPON_SWORD)
+weapon:id(11307)
 weapon:level(55)
 weapon:register()

--- a/data/scripts/weapons/wand/chiller.lua
+++ b/data/scripts/weapons/wand/chiller.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(23721)
 weapon:level(1)
 weapon:mana(1)
 weapon:damage(3, 7)

--- a/data/scripts/weapons/wand/ferumbras'_staff.lua
+++ b/data/scripts/weapons/wand/ferumbras'_staff.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(25422)
 weapon:level(100)
 weapon:mana(19)
 weapon:damage(80, 110)

--- a/data/scripts/weapons/wand/glacial_rod.lua
+++ b/data/scripts/weapons/wand/glacial_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(18412)
 weapon:level(65)
 weapon:mana(17)
 weapon:damage(70, 100)

--- a/data/scripts/weapons/wand/hailstorm_rod.lua
+++ b/data/scripts/weapons/wand/hailstorm_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2183)
 weapon:level(33)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/moonlight_rod.lua
+++ b/data/scripts/weapons/wand/moonlight_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2186)
 weapon:level(13)
 weapon:mana(3)
 weapon:damage(13, 25)

--- a/data/scripts/weapons/wand/muck_rod.lua
+++ b/data/scripts/weapons/wand/muck_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(18411)
 weapon:level(65)
 weapon:mana(17)
 weapon:damage(70, 100)

--- a/data/scripts/weapons/wand/necrotic_rod.lua
+++ b/data/scripts/weapons/wand/necrotic_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2185)
 weapon:level(19)
 weapon:mana(5)
 weapon:damage(27, 33)

--- a/data/scripts/weapons/wand/northwind_rod.lua
+++ b/data/scripts/weapons/wand/northwind_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(8911)
 weapon:level(22)
 weapon:mana(5)
 weapon:damage(27, 33)

--- a/data/scripts/weapons/wand/ogre_scepta.lua
+++ b/data/scripts/weapons/wand/ogre_scepta.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(24839)
 weapon:level(37)
 weapon:mana(13)
 weapon:damage(56, 74)

--- a/data/scripts/weapons/wand/rod_of_destruction.lua
+++ b/data/scripts/weapons/wand/rod_of_destruction.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(30114)
 weapon:level(200)
 weapon:mana(18)
 weapon:damage(80, 110)

--- a/data/scripts/weapons/wand/scorcher.lua
+++ b/data/scripts/weapons/wand/scorcher.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(23719)
 weapon:level(1)
 weapon:mana(1)
 weapon:damage(3, 7)

--- a/data/scripts/weapons/wand/shimmer_rod.lua
+++ b/data/scripts/weapons/wand/shimmer_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(13872)
 weapon:level(40)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/shimmer_wand.lua
+++ b/data/scripts/weapons/wand/shimmer_wand.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(13880)
 weapon:level(40)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/snakebite_rod.lua
+++ b/data/scripts/weapons/wand/snakebite_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2182)
 weapon:level(7)
 weapon:mana(2)
 weapon:damage(8, 18)

--- a/data/scripts/weapons/wand/sorcerer_and_druid_staff.lua
+++ b/data/scripts/weapons/wand/sorcerer_and_druid_staff.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(19391)
 weapon:level(1)
 weapon:mana(2)
 weapon:damage(8, 18)

--- a/data/scripts/weapons/wand/springsprout_rod.lua
+++ b/data/scripts/weapons/wand/springsprout_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(8912)
 weapon:level(37)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/terra_rod.lua
+++ b/data/scripts/weapons/wand/terra_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2181)
 weapon:level(26)
 weapon:mana(8)
 weapon:damage(42, 48)

--- a/data/scripts/weapons/wand/underworld_rod.lua
+++ b/data/scripts/weapons/wand/underworld_rod.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(8910)
 weapon:level(42)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/wand_of_cosmic_energy.lua
+++ b/data/scripts/weapons/wand/wand_of_cosmic_energy.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2189)
 weapon:level(26)
 weapon:mana(8)
 weapon:damage(42, 48)

--- a/data/scripts/weapons/wand/wand_of_darkness.lua
+++ b/data/scripts/weapons/wand/wand_of_darkness.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(28416)
 weapon:level(41)
 weapon:mana(15)
 weapon:damage(75, 95)

--- a/data/scripts/weapons/wand/wand_of_decay.lua
+++ b/data/scripts/weapons/wand/wand_of_decay.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2188)
 weapon:level(19)
 weapon:mana(5)
 weapon:damage(27, 33)

--- a/data/scripts/weapons/wand/wand_of_defiance.lua
+++ b/data/scripts/weapons/wand/wand_of_defiance.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(18390)
 weapon:level(65)
 weapon:mana(17)
 weapon:damage(70, 100)

--- a/data/scripts/weapons/wand/wand_of_destruction.lua
+++ b/data/scripts/weapons/wand/wand_of_destruction.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(30113)
 weapon:level(200)
 weapon:mana(18)
 weapon:damage(80, 110)

--- a/data/scripts/weapons/wand/wand_of_dimensions.lua
+++ b/data/scripts/weapons/wand/wand_of_dimensions.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(13760)
 weapon:level(37)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/wand_of_draconia.lua
+++ b/data/scripts/weapons/wand/wand_of_draconia.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(8921)
 weapon:level(22)
 weapon:mana(5)
 weapon:damage(27, 33)

--- a/data/scripts/weapons/wand/wand_of_dragonbreath.lua
+++ b/data/scripts/weapons/wand/wand_of_dragonbreath.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2191)
 weapon:level(13)
 weapon:mana(3)
 weapon:damage(13, 25)

--- a/data/scripts/weapons/wand/wand_of_everblazing.lua
+++ b/data/scripts/weapons/wand/wand_of_everblazing.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(18409)
 weapon:level(65)
 weapon:mana(17)
 weapon:damage(70, 100)

--- a/data/scripts/weapons/wand/wand_of_inferno.lua
+++ b/data/scripts/weapons/wand/wand_of_inferno.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2187)
 weapon:level(33)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/wand_of_starstorm.lua
+++ b/data/scripts/weapons/wand/wand_of_starstorm.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(8920)
 weapon:level(37)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/wand_of_voodoo.lua
+++ b/data/scripts/weapons/wand/wand_of_voodoo.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(8922)
 weapon:level(42)
 weapon:mana(13)
 weapon:damage(55, 75)

--- a/data/scripts/weapons/wand/wand_of_vortex.lua
+++ b/data/scripts/weapons/wand/wand_of_vortex.lua
@@ -1,4 +1,5 @@
 local weapon = Weapon(WEAPON_WAND)
+weapon:id(2190)
 weapon:level(7)
 weapon:mana(2)
 weapon:damage(8, 18)


### PR DESCRIPTION
This pull request fixes the definition of weapons by assigning item IDs to each weapon, which were accidentally removed by commit d6f93b4f0eedc36f4cae71413ead6527ee6f94d2

* Refactored `diamond_arrow.lua` to define two separate diamond arrow weapons, each with its own unique ID (`28413` and `38557`), by encapsulating them in separate blocks.

Fixes #135 