### PR TITLE
refactor(general): rename optional get* accessors to as*

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -193,7 +193,7 @@ ReturnValue Actions::internalUseItem(const std::shared_ptr<Player>& player, cons
 		}
 
 		// depot container
-		if (const auto& depot = container->getDepotLocker()) {
+		if (const auto& depot = container->asDepotLocker()) {
 			container = player->getDepotLocker();
 			container->setParent(depot->getParent()->getTile());
 		}

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -259,7 +259,7 @@ bool Actions::useItem(const std::shared_ptr<Player>& player, const Position& pos
 
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto& tile = item->getTile()) {
-			if (const auto& houseTile = tile->getHouseTile()) {
+			if (const auto& houseTile = tile->asHouseTile()) {
 				if (!item->getTopParent()->asCreature() && !houseTile->getHouse()->isInvited(player)) {
 					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 					return false;
@@ -310,7 +310,7 @@ bool Actions::useItemEx(const std::shared_ptr<Player>& player, const Position& f
 
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto& tile = item->getTile()) {
-			if (const auto& houseTile = tile->getHouseTile()) {
+			if (const auto& houseTile = tile->asHouseTile()) {
 				if (!item->getTopParent()->asCreature() && !houseTile->getHouse()->isInvited(player)) {
 					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 					return false;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -165,7 +165,7 @@ Action* Actions::getAction(const std::shared_ptr<const Item>& item)
 ReturnValue Actions::internalUseItem(const std::shared_ptr<Player>& player, const Position& pos, uint8_t index,
                                      const std::shared_ptr<Item>& item, bool isHotkey)
 {
-	if (const auto& door = item->getDoor()) {
+	if (const auto& door = item->asDoor()) {
 		if (!door->canUse(player)) {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -186,7 +186,7 @@ ReturnValue Actions::internalUseItem(const std::shared_ptr<Player>& player, cons
 		}
 	}
 
-	if (auto container = item->getContainer()) {
+	if (auto container = item->asContainer()) {
 		uint32_t corpseOwner = container->getCorpseOwner();
 		if (corpseOwner != 0 && !player->canOpenCorpse(corpseOwner)) {
 			return RETURNVALUE_YOUARENOTTHEOWNER;

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1309,7 +1309,7 @@ void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 	// remove magic walls/wild growth
 	if (id == ITEM_MAGICWALL_SAFE || id == ITEM_WILDGROWTH_SAFE || isBlocking()) {
 		if (!creature->isInGhostMode()) {
-			g_game.internalRemoveItem(getMagicField(), 1);
+			g_game.internalRemoveItem(asMagicField(), 1);
 		}
 
 		return;
@@ -1318,7 +1318,7 @@ void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 	// remove magic walls/wild growth (only nopvp tiles/world)
 	if (id == ITEM_MAGICWALL_NOPVP || id == ITEM_WILDGROWTH_NOPVP) {
 		if (g_game.getWorldType() == WORLD_TYPE_NO_PVP || getTile()->hasFlag(TILESTATE_NOPVPZONE)) {
-			g_game.internalRemoveItem(getMagicField(), 1);
+			g_game.internalRemoveItem(asMagicField(), 1);
 		}
 		return;
 	}

--- a/src/combat.h
+++ b/src/combat.h
@@ -150,11 +150,11 @@ class MagicField final : public Item
 public:
 	explicit MagicField(uint16_t type) : Item{type}, createTime(OTSYS_TIME()) {}
 
-	std::shared_ptr<MagicField> getMagicField() override
+	std::shared_ptr<MagicField> asMagicField() override
 	{
 		return std::static_pointer_cast<MagicField>(shared_from_this());
 	}
-	std::shared_ptr<const MagicField> getMagicField() const override
+	std::shared_ptr<const MagicField> asMagicField() const override
 	{
 		return std::static_pointer_cast<const MagicField>(shared_from_this());
 	}

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<Item> Container::clone() const
 std::string Container::getName(bool addArticle /* = false*/) const
 {
 	const ItemType& it = items[id];
-	return getNameDescription(it, getContainer(), -1, addArticle);
+	return getNameDescription(it, asContainer(), -1, addArticle);
 }
 
 bool Container::hasContainerParent() const
@@ -64,7 +64,7 @@ bool Container::hasContainerParent() const
 
 void Container::addItem(std::shared_ptr<Item> item)
 {
-	item->setParent(getContainer());
+	item->setParent(asContainer());
 	itemList.push_back(std::move(item));
 }
 
@@ -148,7 +148,7 @@ void Container::onAddContainerItem(const std::shared_ptr<Item>& item)
 	// send to client
 	for (const auto& spectator : spectators) {
 		assert(spectator->asPlayer() != nullptr);
-		std::static_pointer_cast<Player>(spectator)->sendAddContainerItem(getContainer(), item);
+		std::static_pointer_cast<Player>(spectator)->sendAddContainerItem(asContainer(), item);
 	}
 
 	// event methods
@@ -167,13 +167,13 @@ void Container::onUpdateContainerItem(uint32_t index, const std::shared_ptr<Item
 	// send to client
 	for (const auto& spectator : spectators) {
 		assert(spectator->asPlayer() != nullptr);
-		std::static_pointer_cast<Player>(spectator)->sendUpdateContainerItem(getContainer(), index, newItem);
+		std::static_pointer_cast<Player>(spectator)->sendUpdateContainerItem(asContainer(), index, newItem);
 	}
 
 	// event methods
 	for (const auto& spectator : spectators) {
 		assert(spectator->asPlayer() != nullptr);
-		std::static_pointer_cast<Player>(spectator)->onUpdateContainerItem(getContainer(), oldItem, newItem);
+		std::static_pointer_cast<Player>(spectator)->onUpdateContainerItem(asContainer(), oldItem, newItem);
 	}
 }
 
@@ -185,13 +185,13 @@ void Container::onRemoveContainerItem(uint32_t index, const std::shared_ptr<Item
 	// send change to client
 	for (const auto& spectator : spectators) {
 		assert(spectator->asPlayer() != nullptr);
-		std::static_pointer_cast<Player>(spectator)->sendRemoveContainerItem(getContainer(), index);
+		std::static_pointer_cast<Player>(spectator)->sendRemoveContainerItem(asContainer(), index);
 	}
 
 	// event methods
 	for (const auto& spectator : spectators) {
 		assert(spectator->asPlayer() != nullptr);
-		std::static_pointer_cast<Player>(spectator)->onRemoveContainerItem(getContainer(), item);
+		std::static_pointer_cast<Player>(spectator)->onRemoveContainerItem(asContainer(), item);
 	}
 }
 
@@ -453,7 +453,7 @@ void Container::addThing(int32_t index, const std::shared_ptr<Thing>& thing)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	item->setParent(getContainer());
+	item->setParent(asContainer());
 	itemList.push_front(item);
 	updateItemWeight(item->getWeight());
 	ammoCount += item->getItemCount();
@@ -521,7 +521,7 @@ void Container::replaceThing(uint32_t index, const std::shared_ptr<Thing>& thing
 	ammoCount -= replacedItem->getItemCount();
 
 	itemList[index] = item;
-	item->setParent(getContainer());
+	item->setParent(asContainer());
 	updateItemWeight(-static_cast<int32_t>(replacedItem->getWeight()) + item->getWeight());
 
 	ammoCount += item->getItemCount();
@@ -680,7 +680,7 @@ void Container::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 		return;
 	}
 
-	item->setParent(getContainer());
+	item->setParent(asContainer());
 	itemList.push_front(item);
 	updateItemWeight(item->getWeight());
 	ammoCount += item->getItemCount();
@@ -699,7 +699,7 @@ ContainerIterator Container::iterator() const
 {
 	ContainerIterator cit;
 	if (!itemList.empty()) {
-		cit.over.push_back(getContainer());
+		cit.over.push_back(asContainer());
 		cit.cur = itemList.begin();
 	}
 	return cit;
@@ -708,7 +708,7 @@ ContainerIterator Container::iterator() const
 void ContainerIterator::advance()
 {
 	if (const auto currentItem = cur->get()) {
-		if (const auto& c = currentItem->getContainer()) {
+		if (const auto& c = currentItem->asContainer()) {
 			if (!c->empty()) {
 				over.push_back(c);
 			}

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -412,7 +412,7 @@ std::shared_ptr<Thing> Container::queryDestination(int32_t& index, const std::sh
 
 	if (index != INDEX_WHEREEVER) {
 		if (const auto& itemFromIndex = getItemByIndex(index)) {
-			if (const auto& receiver = itemFromIndex->getReceiver()) {
+			if (const auto& receiver = itemFromIndex->asReceiver()) {
 				index = INDEX_WHEREEVER;
 				destItem = nullptr;
 				return receiver;

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -272,7 +272,7 @@ ReturnValue Container::queryAdd(int32_t index, const std::shared_ptr<const Thing
 	const auto& topParent = getTopParent();
 	if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto& tile = topParent->getTile()) {
-			if (const auto& houseTile = tile->getHouseTile()) {
+			if (const auto& houseTile = tile->asHouseTile()) {
 				if (!topParent->asCreature() && !houseTile->getHouse()->isInvited(actor->asPlayer())) {
 					return RETURNVALUE_PLAYERISNOTINVITED;
 				}
@@ -361,7 +361,7 @@ ReturnValue Container::queryRemove(const std::shared_ptr<const Thing>& thing, ui
 	if (actor && getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		const auto& topParent = getTopParent();
 		if (const auto& tile = topParent->getTile()) {
-			if (const auto& houseTile = tile->getHouseTile()) {
+			if (const auto& houseTile = tile->asHouseTile()) {
 				if (!topParent->asCreature() && !houseTile->getHouse()->isInvited(actor->asPlayer())) {
 					return RETURNVALUE_PLAYERISNOTINVITED;
 				}

--- a/src/container.h
+++ b/src/container.h
@@ -57,8 +57,8 @@ public:
 	virtual std::shared_ptr<DepotLocker> asDepotLocker() { return nullptr; }
 	virtual std::shared_ptr<const DepotLocker> asDepotLocker() const { return nullptr; }
 
-	virtual std::shared_ptr<StoreInbox> getStoreInbox() { return nullptr; }
-	virtual std::shared_ptr<const StoreInbox> getStoreInbox() const { return nullptr; }
+	virtual std::shared_ptr<StoreInbox> asStoreInbox() { return nullptr; }
+	virtual std::shared_ptr<const StoreInbox> asStoreInbox() const { return nullptr; }
 
 	bool hasContainerParent() const;
 

--- a/src/container.h
+++ b/src/container.h
@@ -42,8 +42,8 @@ public:
 
 	std::shared_ptr<Item> clone() const override final;
 
-	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
-	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
+	std::shared_ptr<Thing> asReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> asReceiver() const override final { return shared_from_this(); }
 
 	std::shared_ptr<Container> asContainer() override final
 	{

--- a/src/container.h
+++ b/src/container.h
@@ -54,8 +54,8 @@ public:
 		return std::static_pointer_cast<const Container>(shared_from_this());
 	}
 
-	virtual std::shared_ptr<DepotLocker> getDepotLocker() { return nullptr; }
-	virtual std::shared_ptr<const DepotLocker> getDepotLocker() const { return nullptr; }
+	virtual std::shared_ptr<DepotLocker> asDepotLocker() { return nullptr; }
+	virtual std::shared_ptr<const DepotLocker> asDepotLocker() const { return nullptr; }
 
 	virtual std::shared_ptr<StoreInbox> getStoreInbox() { return nullptr; }
 	virtual std::shared_ptr<const StoreInbox> getStoreInbox() const { return nullptr; }

--- a/src/container.h
+++ b/src/container.h
@@ -45,11 +45,11 @@ public:
 	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
 	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	std::shared_ptr<Container> getContainer() override final
+	std::shared_ptr<Container> asContainer() override final
 	{
 		return std::static_pointer_cast<Container>(shared_from_this());
 	}
-	std::shared_ptr<const Container> getContainer() const override final
+	std::shared_ptr<const Container> asContainer() const override final
 	{
 		return std::static_pointer_cast<const Container>(shared_from_this());
 	}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -528,7 +528,7 @@ bool Creature::dropCorpse(const std::shared_ptr<Creature>& lastHitCreature,
 		                               mostDamageUnjustified);
 
 		if (corpse) {
-			dropLoot(corpse->getContainer(), lastHitCreature);
+			dropLoot(corpse->asContainer(), lastHitCreature);
 		}
 	}
 

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -24,7 +24,7 @@ ReturnValue DepotChest::queryAdd(int32_t index, const std::shared_ptr<const Thin
 		}
 
 		if (item->getTopParent().get() != this) {
-			if (const auto& container = item->getContainer()) {
+			if (const auto& container = item->asContainer()) {
 				addCount = container->getItemHoldingCount() + 1;
 			} else {
 				addCount = 1;

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -20,11 +20,11 @@ public:
 	// Serialization
 	void readAttr(AttrTypes_t attr, OTB::iterator& first, const OTB::iterator& last) override;
 
-	std::shared_ptr<DepotLocker> getDepotLocker() override
+	std::shared_ptr<DepotLocker> asDepotLocker() override
 	{
 		return std::static_pointer_cast<DepotLocker>(shared_from_this());
 	}
-	std::shared_ptr<const DepotLocker> getDepotLocker() const override
+	std::shared_ptr<const DepotLocker> asDepotLocker() const override
 	{
 		return std::static_pointer_cast<const DepotLocker>(shared_from_this());
 	}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2619,7 +2619,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 
 	if (getBoolean(ConfigManager::ONLY_INVITED_CAN_MOVE_HOUSE_ITEMS)) {
 		if (const auto& tile = tradeItem->getTile()) {
-			if (const auto& houseTile = tile->getHouseTile()) {
+			if (const auto& houseTile = tile->asHouseTile()) {
 				if (!tradeItem->getTopParent()->asCreature() && !houseTile->getHouse()->isInvited(player)) {
 					player->sendCancelMessage(RETURNVALUE_PLAYERISNOTINVITED);
 					return;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1467,7 +1467,7 @@ std::shared_ptr<Item> Game::findItemOfType(const std::shared_ptr<Thing>& fromThi
 		}
 
 		if (depthSearch) {
-			if (const auto& container = item->getContainer()) {
+			if (const auto& container = item->asContainer()) {
 				containers.push_back(container);
 			}
 		}
@@ -1481,7 +1481,7 @@ std::shared_ptr<Item> Game::findItemOfType(const std::shared_ptr<Thing>& fromThi
 				return item;
 			}
 
-			if (const auto& subContainer = item->getContainer()) {
+			if (const auto& subContainer = item->asContainer()) {
 				containers.push_back(subContainer);
 			}
 		}
@@ -1515,7 +1515,7 @@ bool Game::removeMoney(const std::shared_ptr<Thing>& fromThing, uint64_t money, 
 			continue;
 		}
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			containers.push_back(container);
 		} else {
 			const uint32_t worth = item->getWorth();
@@ -1530,7 +1530,7 @@ bool Game::removeMoney(const std::shared_ptr<Thing>& fromThing, uint64_t money, 
 	while (i < containers.size()) {
 		const auto container = containers[i++];
 		for (const auto& item : container->getItemList()) {
-			if (const auto& tmpContainer = item->getContainer()) {
+			if (const auto& tmpContainer = item->asContainer()) {
 				containers.push_back(tmpContainer);
 			} else {
 				const uint32_t worth = item->getWorth();
@@ -1815,7 +1815,7 @@ void Game::playerEquipItem(uint32_t playerId, uint16_t spriteId)
 		return;
 	}
 
-	const auto& backpack = item->getContainer();
+	const auto& backpack = item->asContainer();
 	if (!backpack) {
 		return;
 	}
@@ -2291,7 +2291,7 @@ static auto createBrowseField(const std::shared_ptr<Tile>& tile)
 
 	if (TileItemVector* itemVector = tile->getItemList()) {
 		for (const auto& item : *itemVector) {
-			if ((item->getContainer() || item->hasProperty(CONST_PROP_MOVEABLE)) &&
+			if ((item->asContainer() || item->hasProperty(CONST_PROP_MOVEABLE)) &&
 			    !item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 				browseField->addItem(item);
 			}
@@ -2652,7 +2652,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 		return;
 	}
 
-	if (const auto& tradeItemContainer = tradeItem->getContainer()) {
+	if (const auto& tradeItemContainer = tradeItem->asContainer()) {
 		for (auto&& item : tradeItems | std::views::keys | std::views::as_const) {
 			if (tradeItem == item) {
 				player->sendCancelMessage("This item is already being traded.");
@@ -2664,7 +2664,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 				return;
 			}
 
-			const auto& container = item->getContainer();
+			const auto& container = item->asContainer();
 			if (container && container->isHoldingItem(tradeItem)) {
 				player->sendCancelMessage("This item is already being traded.");
 				return;
@@ -2677,7 +2677,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 				return;
 			}
 
-			const auto& container = item->getContainer();
+			const auto& container = item->asContainer();
 			if (container && container->isHoldingItem(tradeItem)) {
 				player->sendCancelMessage("This item is already being traded.");
 				return;
@@ -2685,7 +2685,7 @@ void Game::playerRequestTrade(uint32_t playerId, const Position& pos, uint8_t st
 		}
 	}
 
-	if (const auto& tradeContainer = tradeItem->getContainer()) {
+	if (const auto& tradeContainer = tradeItem->asContainer()) {
 		if (tradeContainer->getItemHoldingCount() + 1 > ITEM_STACK_SIZE) {
 			player->sendCancelMessage(std::format("You can only trade up to {} objects at once.", ITEM_STACK_SIZE));
 			return;
@@ -2898,7 +2898,7 @@ void Game::playerLookInTrade(uint32_t playerId, bool lookAtCounterOffer, uint8_t
 		return;
 	}
 
-	const auto& tradeContainer = tradeItem->getContainer();
+	const auto& tradeContainer = tradeItem->asContainer();
 	if (!tradeContainer) {
 		return;
 	}
@@ -2908,7 +2908,7 @@ void Game::playerLookInTrade(uint32_t playerId, bool lookAtCounterOffer, uint8_t
 	while (i < containers.size()) {
 		const auto container = containers[i++];
 		for (const auto& item : container->getItemList()) {
-			if (const auto& childContainer = item->getContainer()) {
+			if (const auto& childContainer = item->asContainer()) {
 				containers.push_back(childContainer);
 			}
 
@@ -5353,7 +5353,7 @@ std::vector<std::shared_ptr<Item>> Game::getMarketItemList(uint16_t wareId, uint
 		containers.pop_front();
 
 		for (const auto& item : container->getItemList()) {
-			const auto& containerItem = item->getContainer();
+			const auto& containerItem = item->asContainer();
 			if (containerItem && !containerItem->empty()) {
 				containers.push_back(containerItem);
 				continue;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2382,7 +2382,7 @@ void Game::playerRotateItem(uint32_t playerId, const Position& pos, uint8_t stac
 		return;
 	}
 
-	if (const auto& podium = item->getPodium()) {
+	if (const auto& podium = item->asPodium()) {
 		podium->setDirection(static_cast<Direction>((podium->getDirection() + 1) % 4));
 		updatePodium(podium);
 	} else {

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -216,7 +216,7 @@ bool House::transferToDepot(const std::shared_ptr<Player>& player) const
 			for (const auto& item : *items) {
 				if (item->isPickupable()) {
 					moveItemList.push_back(item);
-				} else if (const auto& container = item->getContainer()) {
+				} else if (const auto& container = item->asContainer()) {
 					for (const auto& containerItem : container->getItemList()) {
 						moveItemList.push_back(containerItem);
 					}

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -524,6 +524,6 @@ void Door::onRemoved()
 	Item::onRemoved();
 
 	if (const auto& house = getHouse()) {
-		house->removeDoor(getDoor());
+		house->removeDoor(asDoor());
 	}
 }

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -134,7 +134,7 @@ bool House::kickPlayer(const std::shared_ptr<Player>& player, const std::shared_
 		return false;
 	}
 
-	const auto& houseTile = tile->getHouseTile();
+	const auto& houseTile = tile->asHouseTile();
 	if (!houseTile) {
 		return false;
 	}

--- a/src/house.h
+++ b/src/house.h
@@ -41,8 +41,8 @@ public:
 	Door(const Door&) = delete;
 	Door& operator=(const Door&) = delete;
 
-	std::shared_ptr<Door> getDoor() override { return std::static_pointer_cast<Door>(shared_from_this()); }
-	std::shared_ptr<const Door> getDoor() const override
+	std::shared_ptr<Door> asDoor() override { return std::static_pointer_cast<Door>(shared_from_this()); }
+	std::shared_ptr<const Door> asDoor() const override
 	{
 		return std::static_pointer_cast<const Door>(shared_from_this());
 	}

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -43,7 +43,7 @@ void HouseTile::updateHouse(const std::shared_ptr<Item>& item)
 		return;
 	}
 
-	if (const auto& door = item->getDoor()) {
+	if (const auto& door = item->asDoor()) {
 		if (door->getDoorId() != 0) {
 			if (const auto& house = getHouse()) {
 				house->addDoor(door);

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -15,11 +15,11 @@ public:
 	    DynamicTile{x, y, z}, house{house}
 	{}
 
-	std::shared_ptr<HouseTile> getHouseTile() override
+	std::shared_ptr<HouseTile> asHouseTile() override
 	{
 		return std::static_pointer_cast<HouseTile>(shared_from_this());
 	}
-	std::shared_ptr<const HouseTile> getHouseTile() const override
+	std::shared_ptr<const HouseTile> asHouseTile() const override
 	{
 		return std::static_pointer_cast<const HouseTile>(shared_from_this());
 	}

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -359,7 +359,7 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 		loadItems(itemMap, playerItemsRes);
 
 		for (auto&& [item, pid] : itemMap | std::views::reverse | std::views::values) {
-			if (const auto& itemContainer = item->getContainer()) {
+			if (const auto& itemContainer = item->asContainer()) {
 				uint8_t cid = item->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
 				if (cid > 0) {
 					openContainersList.emplace(cid, itemContainer);
@@ -374,7 +374,7 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 					continue;
 				}
 
-				if (const auto& container = it2->second.first->getContainer()) {
+				if (const auto& container = it2->second.first->asContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -405,7 +405,7 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 					continue;
 				}
 
-				if (const auto& container = it2->second.first->getContainer()) {
+				if (const auto& container = it2->second.first->asContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -429,7 +429,7 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 					continue;
 				}
 
-				if (const auto& container = it2->second.first->getContainer()) {
+				if (const auto& container = it2->second.first->asContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -453,7 +453,7 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 					continue;
 				}
 
-				if (const auto& container = it2->second.first->getContainer()) {
+				if (const auto& container = it2->second.first->asContainer()) {
 					container->internalAddThing(item);
 				}
 			}
@@ -513,7 +513,7 @@ bool IOLoginData::saveItems(const std::shared_ptr<const Player>& player, const I
 	for (auto&& [pid, item] : itemList | std::views::as_const) {
 		++runningId;
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			if (container->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER)) {
 				container->setIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER, 0);
 			}
@@ -548,7 +548,7 @@ bool IOLoginData::saveItems(const std::shared_ptr<const Player>& player, const I
 		for (const auto& item : container->getItemList()) {
 			++runningId;
 
-			if (const auto& subContainer = item->getContainer()) {
+			if (const auto& subContainer = item->asContainer()) {
 				containers.emplace_back(subContainer, runningId);
 
 				if (subContainer->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER)) {

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -30,7 +30,7 @@ void loadItem(OTB::iterator& first, const OTB::iterator& last, const std::shared
 		// create a new item
 		if (const auto& item = Item::CreateItem(id)) {
 			item->unserializeAttr(first, last);
-			if (const auto& container = item->getContainer()) {
+			if (const auto& container = item->asContainer()) {
 				loadContainer(first, last, container);
 			}
 
@@ -55,7 +55,7 @@ void loadItem(OTB::iterator& first, const OTB::iterator& last, const std::shared
 		if (item) {
 			item->unserializeAttr(first, last);
 
-			if (const auto& container = item->getContainer()) {
+			if (const auto& container = item->asContainer()) {
 				loadContainer(first, last, container);
 			}
 
@@ -64,7 +64,7 @@ void loadItem(OTB::iterator& first, const OTB::iterator& last, const std::shared
 			// The map changed since the last save, just read the attributes
 			if (const auto& dummy = Item::CreateItem(id)) {
 				dummy->unserializeAttr(first, last);
-				if (const auto& container = dummy->getContainer()) {
+				if (const auto& container = dummy->asContainer()) {
 					loadContainer(first, last, container);
 				}
 			}
@@ -168,7 +168,7 @@ bool IOMapSerialize::saveHouseItems()
 
 void IOMapSerialize::saveItem(PropWriteStream& stream, const std::shared_ptr<const Item>& item)
 {
-	const auto& container = item->getContainer();
+	const auto& container = item->asContainer();
 
 	// Write ID & props
 	stream.write<uint16_t>(item->getID());
@@ -200,7 +200,7 @@ void IOMapSerialize::saveTile(PropWriteStream& stream, const std::shared_ptr<con
 
 		// Note that these are NEGATED, ie. these are the items that will be saved.
 		if (!(it.moveable || it.forceSerialize || item->asDoor() ||
-		      (item->getContainer() && !item->getContainer()->empty()) || it.canWriteText)) {
+		      (item->asContainer() && !item->asContainer()->empty()) || it.canWriteText)) {
 			continue;
 		}
 

--- a/src/iomapserialize.cpp
+++ b/src/iomapserialize.cpp
@@ -45,7 +45,7 @@ void loadItem(OTB::iterator& first, const OTB::iterator& last, const std::shared
 				if (findItem->getID() == id) {
 					item = findItem;
 					break;
-				} else if (iType.isDoor() && findItem->getDoor()) {
+				} else if (iType.isDoor() && findItem->asDoor()) {
 					item = findItem;
 					break;
 				}
@@ -199,7 +199,7 @@ void IOMapSerialize::saveTile(PropWriteStream& stream, const std::shared_ptr<con
 		const ItemType& it = Item::items[item->getID()];
 
 		// Note that these are NEGATED, ie. these are the items that will be saved.
-		if (!(it.moveable || it.forceSerialize || item->getDoor() ||
+		if (!(it.moveable || it.forceSerialize || item->asDoor() ||
 		      (item->getContainer() && !item->getContainer()->empty()) || it.canWriteText)) {
 			continue;
 		}

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -240,7 +240,7 @@ void Item::setID(uint16_t newid)
 std::shared_ptr<Thing> Item::getTopParent()
 {
 	auto parent = getParent();
-	auto receiver = getReceiver();
+	auto receiver = asReceiver();
 	if (!parent) {
 		return receiver;
 	}
@@ -259,7 +259,7 @@ std::shared_ptr<Thing> Item::getTopParent()
 std::shared_ptr<const Thing> Item::getTopParent() const
 {
 	auto parent = getParent();
-	auto receiver = getReceiver();
+	auto receiver = asReceiver();
 	if (!parent) {
 		return receiver;
 	}

--- a/src/item.h
+++ b/src/item.h
@@ -475,8 +475,8 @@ public:
 	virtual std::shared_ptr<const Mailbox> getMailbox() const { return nullptr; }
 	virtual std::shared_ptr<Door> getDoor() { return nullptr; }
 	virtual std::shared_ptr<const Door> getDoor() const { return nullptr; }
-	virtual std::shared_ptr<MagicField> getMagicField() { return nullptr; }
-	virtual std::shared_ptr<const MagicField> getMagicField() const { return nullptr; }
+	virtual std::shared_ptr<MagicField> asMagicField() { return nullptr; }
+	virtual std::shared_ptr<const MagicField> asMagicField() const { return nullptr; }
 	virtual std::shared_ptr<Podium> asPodium() { return nullptr; }
 	virtual std::shared_ptr<const Podium> asPodium() const { return nullptr; }
 

--- a/src/item.h
+++ b/src/item.h
@@ -467,8 +467,8 @@ public:
 
 	virtual std::shared_ptr<Container> getContainer() { return nullptr; }
 	virtual std::shared_ptr<const Container> getContainer() const { return nullptr; }
-	virtual std::shared_ptr<Teleport> getTeleport() { return nullptr; }
-	virtual std::shared_ptr<const Teleport> getTeleport() const { return nullptr; }
+	virtual std::shared_ptr<Teleport> asTeleport() { return nullptr; }
+	virtual std::shared_ptr<const Teleport> asTeleport() const { return nullptr; }
 	virtual std::shared_ptr<TrashHolder> asTrashHolder() { return nullptr; }
 	virtual std::shared_ptr<const TrashHolder> asTrashHolder() const { return nullptr; }
 	virtual std::shared_ptr<Mailbox> asMailbox() { return nullptr; }

--- a/src/item.h
+++ b/src/item.h
@@ -469,8 +469,8 @@ public:
 	virtual std::shared_ptr<const Container> getContainer() const { return nullptr; }
 	virtual std::shared_ptr<Teleport> getTeleport() { return nullptr; }
 	virtual std::shared_ptr<const Teleport> getTeleport() const { return nullptr; }
-	virtual std::shared_ptr<TrashHolder> getTrashHolder() { return nullptr; }
-	virtual std::shared_ptr<const TrashHolder> getTrashHolder() const { return nullptr; }
+	virtual std::shared_ptr<TrashHolder> asTrashHolder() { return nullptr; }
+	virtual std::shared_ptr<const TrashHolder> asTrashHolder() const { return nullptr; }
 	virtual std::shared_ptr<Mailbox> asMailbox() { return nullptr; }
 	virtual std::shared_ptr<const Mailbox> asMailbox() const { return nullptr; }
 	virtual std::shared_ptr<Door> asDoor() { return nullptr; }

--- a/src/item.h
+++ b/src/item.h
@@ -473,8 +473,8 @@ public:
 	virtual std::shared_ptr<const TrashHolder> getTrashHolder() const { return nullptr; }
 	virtual std::shared_ptr<Mailbox> getMailbox() { return nullptr; }
 	virtual std::shared_ptr<const Mailbox> getMailbox() const { return nullptr; }
-	virtual std::shared_ptr<Door> getDoor() { return nullptr; }
-	virtual std::shared_ptr<const Door> getDoor() const { return nullptr; }
+	virtual std::shared_ptr<Door> asDoor() { return nullptr; }
+	virtual std::shared_ptr<const Door> asDoor() const { return nullptr; }
 	virtual std::shared_ptr<MagicField> asMagicField() { return nullptr; }
 	virtual std::shared_ptr<const MagicField> asMagicField() const { return nullptr; }
 	virtual std::shared_ptr<Podium> asPodium() { return nullptr; }

--- a/src/item.h
+++ b/src/item.h
@@ -477,8 +477,8 @@ public:
 	virtual std::shared_ptr<const Door> getDoor() const { return nullptr; }
 	virtual std::shared_ptr<MagicField> getMagicField() { return nullptr; }
 	virtual std::shared_ptr<const MagicField> getMagicField() const { return nullptr; }
-	virtual std::shared_ptr<Podium> getPodium() { return nullptr; }
-	virtual std::shared_ptr<const Podium> getPodium() const { return nullptr; }
+	virtual std::shared_ptr<Podium> asPodium() { return nullptr; }
+	virtual std::shared_ptr<const Podium> asPodium() const { return nullptr; }
 
 	const std::string& getStrAttr(itemAttrTypes type) const
 	{

--- a/src/item.h
+++ b/src/item.h
@@ -465,8 +465,8 @@ public:
 		return std::static_pointer_cast<const Item>(shared_from_this());
 	}
 
-	virtual std::shared_ptr<Container> getContainer() { return nullptr; }
-	virtual std::shared_ptr<const Container> getContainer() const { return nullptr; }
+	virtual std::shared_ptr<Container> asContainer() { return nullptr; }
+	virtual std::shared_ptr<const Container> asContainer() const { return nullptr; }
 	virtual std::shared_ptr<Teleport> asTeleport() { return nullptr; }
 	virtual std::shared_ptr<const Teleport> asTeleport() const { return nullptr; }
 	virtual std::shared_ptr<TrashHolder> asTrashHolder() { return nullptr; }

--- a/src/item.h
+++ b/src/item.h
@@ -471,8 +471,8 @@ public:
 	virtual std::shared_ptr<const Teleport> getTeleport() const { return nullptr; }
 	virtual std::shared_ptr<TrashHolder> getTrashHolder() { return nullptr; }
 	virtual std::shared_ptr<const TrashHolder> getTrashHolder() const { return nullptr; }
-	virtual std::shared_ptr<Mailbox> getMailbox() { return nullptr; }
-	virtual std::shared_ptr<const Mailbox> getMailbox() const { return nullptr; }
+	virtual std::shared_ptr<Mailbox> asMailbox() { return nullptr; }
+	virtual std::shared_ptr<const Mailbox> asMailbox() const { return nullptr; }
 	virtual std::shared_ptr<Door> asDoor() { return nullptr; }
 	virtual std::shared_ptr<const Door> asDoor() const { return nullptr; }
 	virtual std::shared_ptr<MagicField> asMagicField() { return nullptr; }

--- a/src/lua/env.cpp
+++ b/src/lua/env.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<Container> ScriptEnvironment::getContainerByUID(uint32_t uid)
 	if (!item) {
 		return nullptr;
 	}
-	return item->getContainer();
+	return item->asContainer();
 }
 
 void ScriptEnvironment::removeItemByUID(uint32_t uid)

--- a/src/lua/meta.cpp
+++ b/src/lua/meta.cpp
@@ -52,7 +52,7 @@ void setItemMetatable(lua_State* L, int32_t index, const std::shared_ptr<const I
 {
 	if (item->getContainer()) {
 		luaL_getmetatable(L, "Container");
-	} else if (item->getTeleport()) {
+	} else if (item->asTeleport()) {
 		luaL_getmetatable(L, "Teleport");
 	} else if (item->asPodium()) {
 		luaL_getmetatable(L, "Podium");

--- a/src/lua/meta.cpp
+++ b/src/lua/meta.cpp
@@ -50,7 +50,7 @@ void setWeakMetatable(lua_State* L, int32_t index, const std::string& name)
 
 void setItemMetatable(lua_State* L, int32_t index, const std::shared_ptr<const Item>& item)
 {
-	if (item->getContainer()) {
+	if (item->asContainer()) {
 		luaL_getmetatable(L, "Container");
 	} else if (item->asTeleport()) {
 		luaL_getmetatable(L, "Teleport");

--- a/src/lua/meta.cpp
+++ b/src/lua/meta.cpp
@@ -54,7 +54,7 @@ void setItemMetatable(lua_State* L, int32_t index, const std::shared_ptr<const I
 		luaL_getmetatable(L, "Container");
 	} else if (item->getTeleport()) {
 		luaL_getmetatable(L, "Teleport");
-	} else if (item->getPodium()) {
+	} else if (item->asPodium()) {
 		luaL_getmetatable(L, "Podium");
 	} else {
 		luaL_getmetatable(L, "Item");

--- a/src/lua/modules/container.cpp
+++ b/src/lua/modules/container.cpp
@@ -93,7 +93,7 @@ int luaContainerGetEmptySlots(lua_State* L)
 	bool recursive = tfs::lua::getBoolean(L, 2, false);
 	if (recursive) {
 		for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-			if (const auto& tmpContainer = (*it)->getContainer()) {
+			if (const auto& tmpContainer = (*it)->asContainer()) {
 				slots += tmpContainer->capacity() - tmpContainer->size();
 			}
 		}

--- a/src/lua/modules/container.cpp
+++ b/src/lua/modules/container.cpp
@@ -25,7 +25,7 @@ int luaGetDepotId(lua_State* L)
 		return 1;
 	}
 
-	const auto& depotLocker = container->getDepotLocker();
+	const auto& depotLocker = container->asDepotLocker();
 	if (!depotLocker) {
 		tfs::lua::reportError(L, "Depot not found");
 		tfs::lua::pushBoolean(L, false);
@@ -40,7 +40,7 @@ int luaIsDepot(lua_State* L)
 {
 	// isDepot(uid)
 	const auto& container = tfs::lua::getScriptEnv()->getContainerByUID(tfs::lua::getNumber<uint32_t>(L, -1));
-	tfs::lua::pushBoolean(L, container && container->getDepotLocker());
+	tfs::lua::pushBoolean(L, container && container->asDepotLocker());
 	return 1;
 }
 

--- a/src/lua/modules/podium.cpp
+++ b/src/lua/modules/podium.cpp
@@ -19,7 +19,7 @@ int luaPodiumCreate(lua_State* L)
 	uint32_t id = tfs::lua::getNumber<uint32_t>(L, 2);
 
 	const auto& item = tfs::lua::getScriptEnv()->getItemByUID(id);
-	if (item && item->getPodium()) {
+	if (item && item->asPodium()) {
 		tfs::lua::pushSharedPtr(L, item);
 		tfs::lua::setMetatable(L, -1, "Podium");
 	} else {

--- a/src/lua/modules/teleport.cpp
+++ b/src/lua/modules/teleport.cpp
@@ -16,7 +16,7 @@ int luaTeleportCreate(lua_State* L)
 	uint32_t id = tfs::lua::getNumber<uint32_t>(L, 2);
 
 	const auto& item = tfs::lua::getScriptEnv()->getItemByUID(id);
-	if (item && item->getTeleport()) {
+	if (item && item->asTeleport()) {
 		tfs::lua::pushSharedPtr(L, item);
 		tfs::lua::setMetatable(L, -1, "Teleport");
 	} else {

--- a/src/lua/modules/tile.cpp
+++ b/src/lua/modules/tile.cpp
@@ -718,7 +718,7 @@ int luaTileGetHouse(lua_State* L)
 		return 1;
 	}
 
-	if (const auto& houseTile = tile->getHouseTile()) {
+	if (const auto& houseTile = tile->asHouseTile()) {
 		tfs::lua::pushSharedPtr(L, houseTile->getHouse());
 		tfs::lua::setMetatable(L, -1, "House");
 	} else {

--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -19,7 +19,7 @@ bool canSend(const std::shared_ptr<const Item>& item)
 
 std::string getReceiverName(const std::shared_ptr<Item>& item)
 {
-	if (const auto& container = item->getContainer()) {
+	if (const auto& container = item->asContainer()) {
 		for (const auto& containerItem : container->getItemList()) {
 			if (containerItem->getID() == ITEM_LABEL) {
 				return getReceiverName(containerItem);

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -14,8 +14,8 @@ public:
 	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
 	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	std::shared_ptr<Mailbox> getMailbox() override { return std::static_pointer_cast<Mailbox>(shared_from_this()); }
-	std::shared_ptr<const Mailbox> getMailbox() const override
+	std::shared_ptr<Mailbox> asMailbox() override { return std::static_pointer_cast<Mailbox>(shared_from_this()); }
+	std::shared_ptr<const Mailbox> asMailbox() const override
 	{
 		return std::static_pointer_cast<const Mailbox>(shared_from_this());
 	}

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -11,8 +11,8 @@ class Mailbox final : public Item
 public:
 	explicit Mailbox(uint16_t itemId) : Item{itemId} {}
 
-	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
-	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
+	std::shared_ptr<Thing> asReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> asReceiver() const override final { return shared_from_this(); }
 
 	std::shared_ptr<Mailbox> asMailbox() override { return std::static_pointer_cast<Mailbox>(shared_from_this()); }
 	std::shared_ptr<const Mailbox> asMailbox() const override

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -641,7 +641,7 @@ bool MoveEvent::configureEvent(const pugi::xml_node& node)
 uint32_t MoveEvent::StepInField(const std::shared_ptr<Creature>& creature, const std::shared_ptr<Item>& item,
                                 const Position&)
 {
-	if (const auto& field = item->getMagicField()) {
+	if (const auto& field = item->asMagicField()) {
 		field->onStepInField(creature);
 		return 1;
 	}
@@ -656,7 +656,7 @@ uint32_t MoveEvent::StepOutField(const std::shared_ptr<Creature>&, const std::sh
 
 uint32_t MoveEvent::AddItemField(const std::shared_ptr<Item>& item, const std::shared_ptr<Item>&, const Position&)
 {
-	if (const auto& field = item->getMagicField()) {
+	if (const auto& field = item->asMagicField()) {
 		const auto& tile = item->getTile();
 		if (CreatureVector* creatures = tile->getCreatures()) {
 			for (const auto& creature : *creatures) {

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -166,7 +166,7 @@ void NetworkMessage::addItem(const std::shared_ptr<const Item>& item)
 
 	// display outfit on the podium
 	if (it.isPodium()) {
-		const auto& podium = item->getPodium();
+		const auto& podium = item->asPodium();
 		const Outfit_t& outfit = podium->getOutfit();
 
 		// add outfit

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -155,7 +155,7 @@ void NetworkMessage::addItem(const std::shared_ptr<const Item>& item)
 	if (it.isContainer()) {
 		addByte(0x00); // assigned loot container icon
 		// quiver ammo count
-		const auto& container = item->getContainer();
+		const auto& container = item->asContainer();
 		if (container && it.weaponType == WEAPON_QUIVER) {
 			addByte(0x01);
 			add<uint32_t>(container->getAmmoCount());

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -200,7 +200,7 @@ std::shared_ptr<Item> Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 	}
 
 	// no ammo item was found, search for quiver instead
-	const auto& quiver = inventory[CONST_SLOT_RIGHT] ? inventory[CONST_SLOT_RIGHT]->getContainer() : nullptr;
+	const auto& quiver = inventory[CONST_SLOT_RIGHT] ? inventory[CONST_SLOT_RIGHT]->asContainer() : nullptr;
 	if (!quiver || quiver->getWeaponType() != WEAPON_QUIVER) {
 		// no quiver equipped
 		return nullptr;
@@ -932,13 +932,13 @@ void Player::openSavedContainers()
 			continue;
 		}
 
-		if (const auto& itemContainer = item->getContainer()) {
+		if (const auto& itemContainer = item->asContainer()) {
 			uint8_t cid = item->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
 			if (cid > 0) {
 				openContainersList.emplace(cid, itemContainer);
 			}
 			for (auto it = itemContainer->iterator(); it.hasNext(); it.advance()) {
-				if (const auto& subContainer = (*it)->getContainer()) {
+				if (const auto& subContainer = (*it)->asContainer()) {
 					uint8_t subcid = subContainer->getIntAttr(ITEM_ATTRIBUTE_OPENCONTAINER);
 					if (subcid > 0) {
 						openContainersList.emplace(subcid, subContainer);
@@ -987,7 +987,7 @@ void Player::onRemoveTileItem(const std::shared_ptr<const Tile>& tile, const Pos
 		checkTradeState(item);
 
 		if (const auto& tradeItem = getTradeItem()) {
-			if (const auto& container = item->getContainer()) {
+			if (const auto& container = item->asContainer()) {
 				if (container->isHoldingItem(tradeItem)) {
 					g_game.internalCloseTrade(asPlayer());
 				}
@@ -1394,7 +1394,7 @@ void Player::onRemoveInventoryItem(const std::shared_ptr<Item>& item)
 		checkTradeState(item);
 
 		if (const auto& tradeItem = getTradeItem()) {
-			if (const auto& container = item->getContainer()) {
+			if (const auto& container = item->asContainer()) {
 				if (container->isHoldingItem(tradeItem)) {
 					g_game.internalCloseTrade(asPlayer());
 				}
@@ -2163,7 +2163,7 @@ std::shared_ptr<Item> Player::getCorpse(const std::shared_ptr<Creature>& lastHit
                                         const std::shared_ptr<Creature>& mostDamageCreature)
 {
 	const auto& corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
-	if (corpse && corpse->getContainer()) {
+	if (corpse && corpse->asContainer()) {
 		auto killers = std::ranges::count_if(
 		    getDamageMap(),
 		    [this, now = OTSYS_TIME(), inFightTicks = getNumber(ConfigManager::PZ_LOCKED)](const auto& pair) {
@@ -2336,7 +2336,7 @@ bool Player::hasCapacity(const std::shared_ptr<const Item>& item, uint32_t count
 		return true;
 	}
 
-	uint32_t itemWeight = item->getContainer() ? item->getWeight() : item->getBaseWeight();
+	uint32_t itemWeight = item->asContainer() ? item->getWeight() : item->getBaseWeight();
 	if (item->isStackable()) {
 		itemWeight *= count;
 	}
@@ -2610,14 +2610,14 @@ ReturnValue Player::queryMaxCount(int32_t index, const std::shared_ptr<const Thi
 		uint32_t n = 0;
 		for (int32_t slotIndex = CONST_SLOT_FIRST; slotIndex <= CONST_SLOT_LAST; ++slotIndex) {
 			if (const auto& inventoryItem = inventory[slotIndex]) {
-				if (const auto& subContainer = inventoryItem->getContainer()) {
+				if (const auto& subContainer = inventoryItem->asContainer()) {
 					uint32_t queryCount = 0;
 					subContainer->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), queryCount, flags);
 					n += queryCount;
 
 					// iterate through all items, including sub-containers (deep search)
 					for (ContainerIterator it = subContainer->iterator(); it.hasNext(); it.advance()) {
-						if (const auto& tmpContainer = (*it)->getContainer()) {
+						if (const auto& tmpContainer = (*it)->asContainer()) {
 							queryCount = 0;
 							tmpContainer->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), queryCount, flags);
 							n += queryCount;
@@ -2731,10 +2731,10 @@ std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::share
 						}
 					}
 
-					if (const auto& subContainer = inventoryItem->getContainer()) {
+					if (const auto& subContainer = inventoryItem->asContainer()) {
 						containers.push_back(subContainer);
 					}
-				} else if (const auto& subContainer = inventoryItem->getContainer()) {
+				} else if (const auto& subContainer = inventoryItem->asContainer()) {
 					containers.push_back(subContainer);
 				}
 			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { // empty slot
@@ -2763,7 +2763,7 @@ std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::share
 				}
 
 				for (const auto& tmpContainerItem : tmpContainer->getItemList()) {
-					if (const auto& subContainer = tmpContainerItem->getContainer()) {
+					if (const auto& subContainer = tmpContainerItem->asContainer()) {
 						containers.push_back(subContainer);
 					}
 				}
@@ -2789,7 +2789,7 @@ std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::share
 					return tmpContainer;
 				}
 
-				if (const auto& subContainer = tmpItem->getContainer()) {
+				if (const auto& subContainer = tmpItem->asContainer()) {
 					containers.push_back(subContainer);
 				}
 
@@ -2961,7 +2961,7 @@ uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) con
 			count += Item::countByType(item, subType);
 		}
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				if ((*it)->getID() == itemId) {
 					count += Item::countByType(*it, subType);
@@ -3000,7 +3000,7 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 				g_game.internalRemoveItems(itemList, amount, Item::items[itemId].stackable);
 				return true;
 			}
-		} else if (const auto& container = item->getContainer()) {
+		} else if (const auto& container = item->asContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				if (const auto& containerItem = *it; containerItem->getID() == itemId) {
 					uint32_t itemCount = Item::countByType(containerItem, subType);
@@ -3032,7 +3032,7 @@ std::map<uint32_t, uint32_t>& Player::getAllItemTypeCount(std::map<uint32_t, uin
 
 		countMap[item->getID()] += Item::countByType(item, -1);
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				countMap[(*it)->getID()] += Item::countByType(*it, -1);
 			}
@@ -3065,7 +3065,7 @@ void Player::postAddNotification(const std::shared_ptr<Thing>& thing, const std:
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
-		assert(i ? i->getContainer() != nullptr : true);
+		assert(i ? i->asContainer() != nullptr : true);
 
 		if (i) {
 			requireListUpdate = std::static_pointer_cast<const Container>(i)->getHoldingPlayer().get() != this;
@@ -3080,7 +3080,7 @@ void Player::postAddNotification(const std::shared_ptr<Thing>& thing, const std:
 	}
 
 	if (const auto& item = thing->asItem()) {
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			onSendContainer(container);
 		}
 
@@ -3121,7 +3121,7 @@ void Player::postRemoveNotification(const std::shared_ptr<Thing>& thing, const s
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
-		assert(i ? i->getContainer() != nullptr : true);
+		assert(i ? i->asContainer() != nullptr : true);
 
 		if (i) {
 			requireListUpdate = std::static_pointer_cast<const Container>(i)->getHoldingPlayer().get() != this;
@@ -3142,7 +3142,7 @@ void Player::postRemoveNotification(const std::shared_ptr<Thing>& thing, const s
 			}
 		}
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			if (container->isRemoved() || !getPosition().isInRange(container->getPosition(), 1, 1, 0)) {
 				autoCloseContainers(container);
 			} else if (container->getTopParent().get() == this) {
@@ -3197,7 +3197,7 @@ bool Player::updateSaleShopList(const std::shared_ptr<const Item>& item)
 			return shopInfo.itemId == itemId && shopInfo.sellPrice != 0;
 		});
 		if (it == shopItemList.end()) {
-			const auto& container = item->getContainer();
+			const auto& container = item->asContainer();
 			if (!container) {
 				return false;
 			}
@@ -4541,7 +4541,7 @@ uint64_t Player::getMoney() const
 			continue;
 		}
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			containers.push_back(container);
 		} else {
 			moneyCount += item->getWorth();
@@ -4552,7 +4552,7 @@ uint64_t Player::getMoney() const
 	while (i < containers.size()) {
 		const auto& container = containers[i++];
 		for (const auto& item : container->getItemList()) {
-			if (const auto& childContainer = item->getContainer()) {
+			if (const auto& childContainer = item->asContainer()) {
 				containers.push_back(childContainer);
 			} else {
 				moneyCount += item->getWorth();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2817,7 +2817,7 @@ std::shared_ptr<Thing> Player::queryDestination(int32_t& index, const std::share
 		return asPlayer();
 	}
 
-	const auto& receiver = item->getReceiver();
+	const auto& receiver = item->asReceiver();
 	if (!receiver) {
 		destItem = item;
 		return asPlayer();

--- a/src/player.h
+++ b/src/player.h
@@ -102,8 +102,8 @@ public:
 	Player(const Player&) = delete;
 	Player& operator=(const Player&) = delete;
 
-	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
-	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
+	std::shared_ptr<Thing> asReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> asReceiver() const override final { return shared_from_this(); }
 
 	std::shared_ptr<Player> asPlayer() override { return std::static_pointer_cast<Player>(shared_from_this()); }
 	std::shared_ptr<const Player> asPlayer() const override

--- a/src/podium.cpp
+++ b/src/podium.cpp
@@ -34,7 +34,7 @@ void Podium::readAttr(AttrTypes_t attr, OTB::iterator& first, const OTB::iterato
 		           .lookMountLegs = OTB::read<uint8_t>(first, last),
 		           .lookMountFeet = OTB::read<uint8_t>(first, last)});
 
-		g_game.updatePodium(getPodium());
+		g_game.updatePodium(asPodium());
 		return;
 	}
 

--- a/src/podium.h
+++ b/src/podium.h
@@ -11,8 +11,8 @@ class Podium final : public Item
 public:
 	explicit Podium(uint16_t type) : Item(type) {};
 
-	std::shared_ptr<Podium> getPodium() override { return std::static_pointer_cast<Podium>(shared_from_this()); }
-	std::shared_ptr<const Podium> getPodium() const override
+	std::shared_ptr<Podium> asPodium() override { return std::static_pointer_cast<Podium>(shared_from_this()); }
+	std::shared_ptr<const Podium> asPodium() const override
 	{
 		return std::static_pointer_cast<const Podium>(shared_from_this());
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3096,7 +3096,7 @@ void ProtocolGame::sendPodiumWindow(const std::shared_ptr<const Item>& item)
 		return;
 	}
 
-	const auto& podium = item->getPodium();
+	const auto& podium = item->asPodium();
 	if (!podium) {
 		return;
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2094,7 +2094,7 @@ void ProtocolGame::sendMarketEnter()
 		containerList.pop_back();
 
 		for (const auto& item : container->getItemList()) {
-			const auto& c = item->getContainer();
+			const auto& c = item->asContainer();
 			if (c && !c->empty()) {
 				containerList.push_back(c);
 				continue;
@@ -2334,7 +2334,7 @@ void ProtocolGame::sendTradeItemRequest(const std::string& traderName, const std
 
 	msg.addString(traderName);
 
-	if (const auto& tradeContainer = item->getContainer()) {
+	if (const auto& tradeContainer = item->asContainer()) {
 		auto containerList = std::deque{tradeContainer};
 		auto itemList = std::deque{std::static_pointer_cast<const Item>(tradeContainer)};
 		while (!containerList.empty()) {
@@ -2342,7 +2342,7 @@ void ProtocolGame::sendTradeItemRequest(const std::string& traderName, const std
 			containerList.pop_front();
 
 			for (const auto& containerItem : container->getItemList()) {
-				if (const auto& childContainer = containerItem->getContainer()) {
+				if (const auto& childContainer = containerItem->asContainer()) {
 					containerList.push_back(childContainer);
 				}
 				itemList.push_back(containerItem);

--- a/src/storeinbox.cpp
+++ b/src/storeinbox.cpp
@@ -28,7 +28,7 @@ ReturnValue StoreInbox::queryAdd(int32_t, const std::shared_ptr<const Thing>& th
 			return RETURNVALUE_CANNOTMOVEITEMISNOTSTOREITEM;
 		}
 
-		if (const auto& container = item->getContainer()) {
+		if (const auto& container = item->asContainer()) {
 			if (!container->empty()) {
 				return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
 			}

--- a/src/storeinbox.h
+++ b/src/storeinbox.h
@@ -11,11 +11,11 @@ class StoreInbox final : public Container
 public:
 	explicit StoreInbox(uint16_t type) : Container{type, 20, true, true} {}
 
-	std::shared_ptr<StoreInbox> getStoreInbox() override
+	std::shared_ptr<StoreInbox> asStoreInbox() override
 	{
 		return std::static_pointer_cast<StoreInbox>(shared_from_this());
 	}
-	std::shared_ptr<const StoreInbox> getStoreInbox() const override
+	std::shared_ptr<const StoreInbox> asStoreInbox() const override
 	{
 		return std::static_pointer_cast<const StoreInbox>(shared_from_this());
 	}

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -11,8 +11,8 @@ class Teleport final : public Item
 public:
 	explicit Teleport(uint16_t type) : Item{type} {};
 
-	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
-	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
+	std::shared_ptr<Thing> asReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> asReceiver() const override final { return shared_from_this(); }
 
 	std::shared_ptr<Teleport> asTeleport() override { return std::static_pointer_cast<Teleport>(shared_from_this()); }
 	std::shared_ptr<const Teleport> asTeleport() const override

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -14,8 +14,8 @@ public:
 	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
 	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	std::shared_ptr<Teleport> getTeleport() override { return std::static_pointer_cast<Teleport>(shared_from_this()); }
-	std::shared_ptr<const Teleport> getTeleport() const override
+	std::shared_ptr<Teleport> asTeleport() override { return std::static_pointer_cast<Teleport>(shared_from_this()); }
+	std::shared_ptr<const Teleport> asTeleport() const override
 	{
 		return std::static_pointer_cast<const Teleport>(shared_from_this());
 	}

--- a/src/thing.h
+++ b/src/thing.h
@@ -61,8 +61,8 @@ public:
 
 	virtual bool isRemoved() const { return true; }
 
-	virtual std::shared_ptr<Thing> getReceiver() { return nullptr; }
-	virtual std::shared_ptr<const Thing> getReceiver() const { return nullptr; }
+	virtual std::shared_ptr<Thing> asReceiver() { return nullptr; }
+	virtual std::shared_ptr<const Thing> asReceiver() const { return nullptr; }
 
 	/**
 	 * Query if the thing can add an object

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -122,8 +122,8 @@ std::shared_ptr<Teleport> Tile::getTeleportItem() const
 
 	if (const TileItemVector* items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-			if ((*it)->getTeleport()) {
-				return (*it)->getTeleport();
+			if ((*it)->asTeleport()) {
+				return (*it)->asTeleport();
 			}
 		}
 	}
@@ -1394,7 +1394,7 @@ void Tile::setTileFlags(const std::shared_ptr<const Item>& item)
 		setFlag(TILESTATE_IMMOVABLENOFIELDBLOCKPATH);
 	}
 
-	if (item->getTeleport()) {
+	if (item->asTeleport()) {
 		setFlag(TILESTATE_TELEPORT);
 	}
 
@@ -1457,7 +1457,7 @@ void Tile::resetTileFlags(const std::shared_ptr<const Item>& item)
 		resetFlag(TILESTATE_IMMOVABLENOFIELDBLOCKPATH);
 	}
 
-	if (item->getTeleport()) {
+	if (item->asTeleport()) {
 		resetFlag(TILESTATE_TELEPORT);
 	}
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -345,7 +345,7 @@ void Tile::onAddTileItem(const std::shared_ptr<Item>& item)
 
 	if ((!hasFlag(TILESTATE_PROTECTIONZONE) || getBoolean(ConfigManager::CLEAN_PROTECTION_ZONES)) &&
 	    item->isCleanable()) {
-		if (!getHouseTile()) {
+		if (!asHouseTile()) {
 			g_game.addTileToClean(asTile());
 		}
 	}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -323,7 +323,7 @@ std::shared_ptr<Thing> Tile::getTopVisibleThing(const std::shared_ptr<const Crea
 
 void Tile::onAddTileItem(const std::shared_ptr<Item>& item)
 {
-	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
+	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->asContainer()) {
 		auto it = g_game.browseFields.find(asTile().get());
 		if (it != g_game.browseFields.end()) {
 			it->second->addItemBack(item);
@@ -354,7 +354,7 @@ void Tile::onAddTileItem(const std::shared_ptr<Item>& item)
 void Tile::onUpdateTileItem(const std::shared_ptr<Item>& oldItem, const ItemType& oldType,
                             const std::shared_ptr<Item>& newItem, const ItemType& newType)
 {
-	if (newItem->hasProperty(CONST_PROP_MOVEABLE) || newItem->getContainer()) {
+	if (newItem->hasProperty(CONST_PROP_MOVEABLE) || newItem->asContainer()) {
 		auto it = g_game.browseFields.find(asTile().get());
 		if (it != g_game.browseFields.end()) {
 			int32_t index = it->second->getThingIndex(oldItem);
@@ -363,7 +363,7 @@ void Tile::onUpdateTileItem(const std::shared_ptr<Item>& oldItem, const ItemType
 				newItem->setParent(it->second);
 			}
 		}
-	} else if (oldItem->hasProperty(CONST_PROP_MOVEABLE) || oldItem->getContainer()) {
+	} else if (oldItem->hasProperty(CONST_PROP_MOVEABLE) || oldItem->asContainer()) {
 		auto it = g_game.browseFields.find(asTile().get());
 		if (it != g_game.browseFields.end()) {
 			const auto& oldParent = oldItem->getParent();
@@ -391,7 +391,7 @@ void Tile::onUpdateTileItem(const std::shared_ptr<Item>& oldItem, const ItemType
 void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<int32_t>& oldStackPosVector,
                             const std::shared_ptr<Item>& item)
 {
-	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
+	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->asContainer()) {
 		auto it = g_game.browseFields.find(asTile().get());
 		if (it != g_game.browseFields.end()) {
 			it->second->removeThing(item, item->getItemCount());
@@ -1414,7 +1414,7 @@ void Tile::setTileFlags(const std::shared_ptr<const Item>& item)
 		setFlag(TILESTATE_BLOCKSOLID);
 	}
 
-	if (const auto& container = item->getContainer()) {
+	if (const auto& container = item->asContainer()) {
 		if (container->getDepotLocker()) {
 			setFlag(TILESTATE_DEPOT);
 		}
@@ -1473,7 +1473,7 @@ void Tile::resetTileFlags(const std::shared_ptr<const Item>& item)
 		resetFlag(TILESTATE_TRASHHOLDER);
 	}
 
-	if (const auto& container = item->getContainer()) {
+	if (const auto& container = item->asContainer()) {
 		if (container->getDepotLocker()) {
 			resetFlag(TILESTATE_DEPOT);
 		}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1515,7 +1515,7 @@ std::shared_ptr<Item> Tile::getUseItem(int32_t index) const
 
 	// try getting door
 	for (const auto& item : *items | std::views::reverse) {
-		if (item->getDoor()) {
+		if (item->asDoor()) {
 			return item;
 		}
 	}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1415,7 +1415,7 @@ void Tile::setTileFlags(const std::shared_ptr<const Item>& item)
 	}
 
 	if (const auto& container = item->asContainer()) {
-		if (container->getDepotLocker()) {
+		if (container->asDepotLocker()) {
 			setFlag(TILESTATE_DEPOT);
 		}
 	}
@@ -1474,7 +1474,7 @@ void Tile::resetTileFlags(const std::shared_ptr<const Item>& item)
 	}
 
 	if (const auto& container = item->asContainer()) {
-		if (container->getDepotLocker()) {
+		if (container->asDepotLocker()) {
 			resetFlag(TILESTATE_DEPOT);
 		}
 	}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -136,14 +136,14 @@ std::shared_ptr<MagicField> Tile::getFieldItem() const
 		return nullptr;
 	}
 
-	if (ground && ground->getMagicField()) {
-		return ground->getMagicField();
+	if (ground && ground->asMagicField()) {
+		return ground->asMagicField();
 	}
 
 	if (const TileItemVector* items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-			if ((*it)->getMagicField()) {
-				return (*it)->getMagicField();
+			if ((*it)->asMagicField()) {
+				return (*it)->asMagicField();
 			}
 		}
 	}
@@ -870,7 +870,7 @@ void Tile::addThing(int32_t, const std::shared_ptr<Thing>& thing)
 				if (items) {
 					// remove old field item if exists
 					for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
-						if (const auto oldField = (*it)->getMagicField()) {
+						if (const auto oldField = (*it)->asMagicField()) {
 							if (oldField->isReplaceable()) {
 								removeThing(oldField, 1);
 								assert(oldField->getParent() == nullptr);
@@ -1404,7 +1404,7 @@ void Tile::setTileFlags(const std::shared_ptr<const Item>& item)
 		setFlag(TILESTATE_TELEPORT);
 	}
 
-	if (item->getMagicField()) {
+	if (item->asMagicField()) {
 		setFlag(TILESTATE_MAGICFIELD);
 	}
 
@@ -1467,7 +1467,7 @@ void Tile::resetTileFlags(const std::shared_ptr<const Item>& item)
 		resetFlag(TILESTATE_TELEPORT);
 	}
 
-	if (item->getMagicField()) {
+	if (item->asMagicField()) {
 		resetFlag(TILESTATE_MAGICFIELD);
 	}
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -156,14 +156,14 @@ std::shared_ptr<TrashHolder> Tile::getTrashHolder() const
 		return nullptr;
 	}
 
-	if (ground && ground->getTrashHolder()) {
-		return ground->getTrashHolder();
+	if (ground && ground->asTrashHolder()) {
+		return ground->asTrashHolder();
 	}
 
 	if (const TileItemVector* items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-			if ((*it)->getTrashHolder()) {
-				return (*it)->getTrashHolder();
+			if ((*it)->asTrashHolder()) {
+				return (*it)->asTrashHolder();
 			}
 		}
 	}
@@ -1406,7 +1406,7 @@ void Tile::setTileFlags(const std::shared_ptr<const Item>& item)
 		setFlag(TILESTATE_MAILBOX);
 	}
 
-	if (item->getTrashHolder()) {
+	if (item->asTrashHolder()) {
 		setFlag(TILESTATE_TRASHHOLDER);
 	}
 
@@ -1469,7 +1469,7 @@ void Tile::resetTileFlags(const std::shared_ptr<const Item>& item)
 		resetFlag(TILESTATE_MAILBOX);
 	}
 
-	if (item->getTrashHolder()) {
+	if (item->asTrashHolder()) {
 		resetFlag(TILESTATE_TRASHHOLDER);
 	}
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -176,14 +176,14 @@ std::shared_ptr<Mailbox> Tile::getMailbox() const
 		return nullptr;
 	}
 
-	if (ground && ground->getMailbox()) {
-		return ground->getMailbox();
+	if (ground && ground->asMailbox()) {
+		return ground->asMailbox();
 	}
 
 	if (const TileItemVector* items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
-			if ((*it)->getMailbox()) {
-				return (*it)->getMailbox();
+			if ((*it)->asMailbox()) {
+				return (*it)->asMailbox();
 			}
 		}
 	}
@@ -1275,18 +1275,12 @@ void Tile::postAddNotification(const std::shared_ptr<Thing>& thing, const std::s
 	}
 
 	if (link == LINK_OWNER) {
-		if (hasFlag(TILESTATE_TELEPORT)) {
-			if (const auto& teleport = getTeleportItem()) {
-				teleport->addThing(thing);
-			}
-		} else if (hasFlag(TILESTATE_TRASHHOLDER)) {
-			if (const auto& trashholder = getTrashHolder()) {
-				trashholder->addThing(thing);
-			}
-		} else if (hasFlag(TILESTATE_MAILBOX)) {
-			if (const auto& mailbox = getMailbox()) {
-				mailbox->addThing(thing);
-			}
+		if (const auto& teleport = getTeleportItem()) {
+			teleport->addThing(thing);
+		} else if (const auto& trashholder = getTrashHolder()) {
+			trashholder->addThing(thing);
+		} else if (const auto& mailbox = getMailbox()) {
+			mailbox->addThing(thing);
 		}
 
 		// calling movement scripts
@@ -1408,7 +1402,7 @@ void Tile::setTileFlags(const std::shared_ptr<const Item>& item)
 		setFlag(TILESTATE_MAGICFIELD);
 	}
 
-	if (item->getMailbox()) {
+	if (item->asMailbox()) {
 		setFlag(TILESTATE_MAILBOX);
 	}
 
@@ -1471,7 +1465,7 @@ void Tile::resetTileFlags(const std::shared_ptr<const Item>& item)
 		resetFlag(TILESTATE_MAGICFIELD);
 	}
 
-	if (item->getMailbox()) {
+	if (item->asMailbox()) {
 		resetFlag(TILESTATE_MAILBOX);
 	}
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -124,8 +124,8 @@ public:
 	Tile(const Tile&) = delete;
 	Tile& operator=(const Tile&) = delete;
 
-	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
-	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
+	std::shared_ptr<Thing> asReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> asReceiver() const override final { return shared_from_this(); }
 
 	std::shared_ptr<Tile> getTile() override final { return std::static_pointer_cast<Tile>(shared_from_this()); }
 	std::shared_ptr<const Tile> getTile() const override final

--- a/src/tile.h
+++ b/src/tile.h
@@ -139,8 +139,8 @@ public:
 		return std::static_pointer_cast<const Tile>(shared_from_this());
 	}
 
-	virtual std::shared_ptr<HouseTile> getHouseTile() { return nullptr; }
-	virtual std::shared_ptr<const HouseTile> getHouseTile() const { return nullptr; }
+	virtual std::shared_ptr<HouseTile> asHouseTile() { return nullptr; }
+	virtual std::shared_ptr<const HouseTile> asHouseTile() const { return nullptr; }
 
 	virtual TileItemVector* getItemList() = 0;
 	virtual const TileItemVector* getItemList() const = 0;

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -11,8 +11,8 @@ class TrashHolder final : public Item
 public:
 	explicit TrashHolder(uint16_t itemId) : Item{itemId} {}
 
-	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
-	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
+	std::shared_ptr<Thing> asReceiver() override final { return shared_from_this(); }
+	std::shared_ptr<const Thing> asReceiver() const override final { return shared_from_this(); }
 
 	std::shared_ptr<TrashHolder> asTrashHolder() override
 	{

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -14,11 +14,11 @@ public:
 	std::shared_ptr<Thing> getReceiver() override final { return shared_from_this(); }
 	std::shared_ptr<const Thing> getReceiver() const override final { return shared_from_this(); }
 
-	std::shared_ptr<TrashHolder> getTrashHolder() override
+	std::shared_ptr<TrashHolder> asTrashHolder() override
 	{
 		return std::static_pointer_cast<TrashHolder>(shared_from_this());
 	}
-	std::shared_ptr<const TrashHolder> getTrashHolder() const override
+	std::shared_ptr<const TrashHolder> asTrashHolder() const override
 	{
 		return std::static_pointer_cast<const TrashHolder>(shared_from_this());
 	}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This refactor standardizes optional object accessors by replacing misleading `get*` methods with explicit `as*` conversions, making nullable semantics clear and preventing incorrect assumptions about object existence.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and renamed internal accessors for containers, tiles, and special items to a consistent "asX" style across the codebase, improving internal type-safety and consistency. Functionality and public APIs remain unchanged; user-facing behavior is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->