### PR TITLE
fix: prevent ATTR_CHARGES truncation during item load

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -352,10 +352,15 @@ void Item::setSubType(uint16_t n)
 void Item::readAttr(AttrTypes_t attr, OTB::iterator& first, const OTB::iterator& last)
 {
 	switch (attr) {
-		case ATTR_CHARGES:
 		case ATTR_COUNT:
 		case ATTR_RUNE_CHARGES: {
 			auto count = OTB::read<uint8_t>(first, last);
+			setSubType(count);
+			break;
+		}
+
+		case ATTR_CHARGES: {
+			auto count = OTB::read<uint16_t>(first, last);
 			setSubType(count);
 			break;
 		}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed proper The Forgotten Server code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

This PR fixes an issue where item charge counts above 255 were being truncated when items were loaded. Specifically, ATTR_CHARGES is now read as a 16‑bit value so large charge totals (e.g., 500 on exercise weapons) persist correctly across logout/login.

**Issues addressed:** #159

**How to test:** 
1. Create or obtain an item with charges (e.g. an exercise weapon).
2. Set `ITEM_ATTRIBUTE_CHARGES` to a value greater than 255.
3. Log out and log back in.
4. Verify that charges are preserved correctly and no crash occurs.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item charge attribute parsing to properly support larger value ranges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->