### PR TITLE
fix: adjusting the direction of the spawn.xml guidelines

### DIFF
--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -77,7 +77,12 @@ bool Spawns::loadFromXml(const std::filesystem::path& filename, bool isCalledByL
 				uint16_t totalChance = 0;
 				spawnBlock_t sb;
 				sb.pos = pos;
-				sb.direction = DIRECTION_NORTH;
+				pugi::xml_attribute directionAttribute = childNode.attribute("direction");
+				if (directionAttribute) {
+					sb.direction = static_cast<Direction>(pugi::cast<uint16_t>(directionAttribute.value()));
+				} else {
+					sb.direction = DIRECTION_NORTH;
+				}
 				sb.interval = interval;
 				sb.lastSpawn = 0;
 
@@ -304,6 +309,8 @@ bool Spawn::spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& p
 		return false;
 	}
 
+	monster->setDirection(dir);
+
 	if (startup) {
 		// No need to send out events to the surrounding since there is no one out there to listen!
 		if (!g_game.internalPlaceCreature(monster, pos, true)) {
@@ -316,8 +323,6 @@ bool Spawn::spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& p
 			return false;
 		}
 	}
-
-	monster->setDirection(dir);
 	monster->setSpawn(this);
 	monster->setMasterPos(pos);
 


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- The <monsters> tag now reads the direction attribute from the XML (previously it was hardcoded DIRECTION_NORTH)
- monster->setDirection(dir) moved before placeCreature, ensuring the client receives the correct direction upon respawn

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** #167 

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where monsters did not consistently face the correct direction when spawned. Monster orientation is now properly initialized across all spawn scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->