### PR TITLE
Fix reference invalidation in container saving logic

### DIFF
--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -543,7 +543,7 @@ bool IOLoginData::saveItems(const std::shared_ptr<const Player>& player, const I
 	}
 
 	for (size_t i = 0; i < containers.size(); ++i) {
-		const auto& [container, parentId] = containers[i];
+		const auto [container, parentId] = containers[i];
 
 		for (const auto& item : container->getItemList()) {
 			++runningId;


### PR DESCRIPTION
Changed containers loop to use structured binding by value. This prevents a crash when emplace_back reallocates the underlying vector storage. Caught by AddressSanitizer.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->