### PR TITLE
refactor(monster): remove dead code call to onIdleStatus in death sequence

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1826,7 +1826,6 @@ void Monster::death(const std::shared_ptr<Creature>&)
 
 	clearTargetList();
 	clearFriendList();
-	onIdleStatus();
 }
 
 std::shared_ptr<Item> Monster::getCorpse(const std::shared_ptr<Creature>& lastHitCreature,


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
This update streamlines the monster death sequence by removing a redundant call to the onIdleStatus method. Analysis of the Creature class revealed that onIdleStatus is guarded by an isDead check; since the monster's health is already less than or equal to zero during the death sequence, the call resulted in no operation.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined monster death behavior to prevent unintended state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->