### PR TITLE
fix(http): disable deprecated-declarations errors to compile boost 1.83 with clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,12 +154,13 @@ set(tfs_HDR
 set(tfs_MAIN ${CMAKE_CURRENT_LIST_DIR}/otserv.cpp)
 
 add_library(tfslib ${tfs_SRC})
+target_compile_definitions(tfslib PRIVATE SPDLOG_HEADER_ONLY)
 target_link_libraries(tfslib PRIVATE
 	Boost::iostreams
 	OpenSSL::Crypto
 	pugixml::pugixml
 	simdutf::simdutf
-	spdlog::spdlog
+	spdlog::spdlog_header_only
 	ZLIB::ZLIB
 	${CMAKE_THREAD_LIBS_INIT}
 	${LUA_LIBRARIES}

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -23,6 +23,10 @@ set(http_HDR
 add_library(http OBJECT ${http_SRC})
 target_link_libraries(http PRIVATE Boost::json)
 
+if(NOT MSVC)
+    target_compile_options(http PRIVATE -Wno-deprecated-declarations) # maybe this could be removed when updating to boost greater than 1.83.0
+endif()
+
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -50,7 +50,7 @@ bool Spawns::loadFromXml(const std::filesystem::path& filename, bool isCalledByL
 			continue;
 		}
 
-		auto& spawn = spawnList.emplace_back(centerPos, radius);
+		auto& spawn = spawnList.emplace_back(centerPos);
 
 		for (auto childNode : spawnNode.children()) {
 			if (boost::iequals(childNode.name(), "monsters")) {

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -22,7 +22,7 @@ struct spawnBlock_t
 class Spawn
 {
 public:
-	Spawn(const Position& pos, int32_t radius) : centerPos{pos}, radius{radius} {}
+	explicit Spawn(const Position& pos) : centerPos{pos} {}
 	~Spawn();
 
 	// non-copyable
@@ -53,7 +53,6 @@ private:
 	std::map<uint32_t, spawnBlock_t> spawnMap;
 
 	Position centerPos;
-	int32_t radius;
 
 	uint32_t interval = 60000;
 	uint32_t checkSpawnEvent = 0;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
The problem is that the boost 1.83.0 has some issues when compiling with clang 21.1.8 used by http part.
spdlog fails to link on release build when it is not header-only.
There was an unused radius variable in spawn.

**How to test:** <!-- Write here how to test changes. -->
Try to compile with boost 1.83.0 and clang 21.1.8 without this patch. It won't work.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched logging dependency to header-only mode for simpler build behavior
  * Added compiler warning suppression for deprecated declarations on non-MSVC platforms

* **Refactor**
  * Simplified spawn entity initialization by removing the radius parameter from construction and internal storage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->