### PR TITLE
refactor(creature): replace lastHitCreatureId with weak_ptr for safer memory management

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -140,7 +140,7 @@ void Creature::onIdleStatus()
 {
 	if (!isDead()) {
 		damageMap.clear();
-		lastHitCreature.reset();
+		lastAttacker.reset();
 	}
 }
 
@@ -405,7 +405,7 @@ void Creature::onDeath()
 {
 	bool lastHitUnjustified = false;
 	bool mostDamageUnjustified = false;
-	auto lastHitCreature = this->lastHitCreature.lock();
+	auto lastHitCreature = lastAttacker.lock();
 
 	std::shared_ptr<Creature> lastHitCreatureMaster = nullptr;
 	if (lastHitCreature) {
@@ -583,7 +583,7 @@ void Creature::drainHealth(const std::shared_ptr<Creature>& attacker, int32_t da
 	if (attacker) {
 		attacker->onAttackedCreatureDrainHealth(asCreature(), damage);
 	} else {
-		lastHitCreature.reset();
+		lastAttacker.reset();
 	}
 }
 
@@ -835,7 +835,7 @@ void Creature::addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_
 	cb.ticks = OTSYS_TIME();
 	cb.total += damagePoints;
 
-	lastHitCreature = attacker;
+	lastAttacker = attacker;
 }
 
 void Creature::onAddCondition(ConditionType_t type)

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -140,7 +140,7 @@ void Creature::onIdleStatus()
 {
 	if (!isDead()) {
 		damageMap.clear();
-		lastHitCreatureId = 0;
+		lastHitCreature.reset();
 	}
 }
 
@@ -405,7 +405,7 @@ void Creature::onDeath()
 {
 	bool lastHitUnjustified = false;
 	bool mostDamageUnjustified = false;
-	const auto& lastHitCreature = g_game.getCreatureByID(lastHitCreatureId);
+	auto lastHitCreature = this->lastHitCreature.lock();
 
 	std::shared_ptr<Creature> lastHitCreatureMaster = nullptr;
 	if (lastHitCreature) {
@@ -583,7 +583,7 @@ void Creature::drainHealth(const std::shared_ptr<Creature>& attacker, int32_t da
 	if (attacker) {
 		attacker->onAttackedCreatureDrainHealth(asCreature(), damage);
 	} else {
-		lastHitCreatureId = 0;
+		lastHitCreature.reset();
 	}
 }
 
@@ -835,7 +835,7 @@ void Creature::addDamagePoints(const std::shared_ptr<Creature>& attacker, int32_
 	cb.ticks = OTSYS_TIME();
 	cb.total += damagePoints;
 
-	lastHitCreatureId = attackerId;
+	lastHitCreature = attacker;
 }
 
 void Creature::onAddCondition(ConditionType_t type)

--- a/src/creature.h
+++ b/src/creature.h
@@ -398,7 +398,6 @@ protected:
 	uint32_t scriptEventsBitField = 0;
 	uint32_t eventWalk = 0;
 	uint32_t walkUpdateTicks = 0;
-	uint32_t lastHitCreatureId = 0;
 	uint32_t blockCount = 0;
 	uint32_t blockTicks = 0;
 	uint32_t lastStepCost = 1;
@@ -448,6 +447,7 @@ private:
 	std::weak_ptr<Creature> attackedCreature;
 	std::weak_ptr<Creature> master;
 	std::weak_ptr<Creature> followCreature;
+	std::weak_ptr<Creature> lastHitCreature;
 	boost::container::flat_set<std::weak_ptr<Creature>, std::owner_less<std::weak_ptr<Creature>>> followers;
 
 	std::vector<std::weak_ptr<Creature>> summons;

--- a/src/creature.h
+++ b/src/creature.h
@@ -447,7 +447,7 @@ private:
 	std::weak_ptr<Creature> attackedCreature;
 	std::weak_ptr<Creature> master;
 	std::weak_ptr<Creature> followCreature;
-	std::weak_ptr<Creature> lastHitCreature;
+	std::weak_ptr<Creature> lastAttacker;
 	boost::container::flat_set<std::weak_ptr<Creature>, std::owner_less<std::weak_ptr<Creature>>> followers;
 
 	std::vector<std::weak_ptr<Creature>> summons;


### PR DESCRIPTION
Cherry-picked from #174 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal tracking of recent attackers to reduce stale references and improve stability of combat and interaction outcomes.
  * Updates streamline how the system records and resets the last source of damage, enhancing reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->