### PR TITLE
refactor(creature): centralize follow and attack behavior in base Creature class

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -25,7 +25,7 @@ Creature::Creature() { onIdleStatus(); }
 Creature::~Creature()
 {
 	for (const auto& summon : summons | tfs::views::lock_weak_ptrs) {
-		summon->removeAttackedCreature();
+		summon->setAttackedCreature(nullptr);
 		summon->removeMaster();
 	}
 	assert(conditions.empty());
@@ -109,12 +109,26 @@ void Creature::onThink(uint32_t interval)
 {
 	if (const auto& followCreature = getFollowCreature();
 	    followCreature && !tfs::owner_equal(master, followCreature) && !canSeeCreature(followCreature)) {
-		onCreatureDisappear(followCreature, false);
+		setFollowCreature(nullptr);
+
+		if (const auto& player = asPlayer()) {
+			player->sendCancelTarget();
+			player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+		}
 	}
 
 	if (const auto& attackedCreature = getAttackedCreature();
 	    attackedCreature && !tfs::owner_equal(master, attackedCreature) && !canSeeCreature(attackedCreature)) {
-		onCreatureDisappear(attackedCreature, false);
+		setAttackedCreature(nullptr);
+
+		if (const auto& player = asPlayer()) {
+			player->sendCancelTarget();
+			player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+		}
+
+		if (const auto& monster = asMonster()) {
+			monster->resetAttackTicks();
+		}
 	}
 
 	blockTicks += interval;
@@ -295,19 +309,24 @@ void Creature::updateIcons() const
 
 void Creature::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool)
 {
-	onCreatureDisappear(creature, true);
-}
+	if (const auto& attackedCreature = getAttackedCreature(); creature == attackedCreature) {
+		setAttackedCreature(nullptr);
 
-void Creature::onCreatureDisappear(const std::shared_ptr<const Creature>& creature, bool isLogout)
-{
-	if (tfs::owner_equal(attackedCreature, creature)) {
-		removeAttackedCreature();
-		onAttackedCreatureDisappear(isLogout);
+		if (const auto& player = asPlayer()) {
+			player->sendCancelTarget();
+		}
+
+		if (const auto& monster = asMonster()) {
+			monster->resetAttackTicks();
+		}
 	}
 
-	if (tfs::owner_equal(followCreature, creature)) {
-		removeFollowCreature();
-		onFollowCreatureDisappear(isLogout);
+	if (const auto& followCreature = getFollowCreature(); creature == followCreature) {
+		setFollowCreature(nullptr);
+
+		if (const auto& player = asPlayer()) {
+			player->sendCancelTarget();
+		}
 	}
 }
 
@@ -326,14 +345,16 @@ void Creature::updateFollowCreaturePath(FindPathParams& fpp)
 void Creature::onChangeZone(ZoneType_t zone)
 {
 	if (const auto& attackedCreature = getAttackedCreature(); attackedCreature && zone == ZONE_PROTECTION) {
-		onCreatureDisappear(attackedCreature, false);
-	}
-}
+		setAttackedCreature(nullptr);
 
-void Creature::onAttackedCreatureChangeZone(ZoneType_t zone)
-{
-	if (const auto& attackedCreature = getAttackedCreature(); zone == ZONE_PROTECTION) {
-		onCreatureDisappear(attackedCreature, false);
+		if (const auto& player = asPlayer()) {
+			player->sendCancelTarget();
+			player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+		}
+
+		if (const auto& monster = asMonster()) {
+			monster->resetAttackTicks();
+		}
 	}
 }
 
@@ -380,14 +401,28 @@ void Creature::onCreatureMove(const std::shared_ptr<Creature>& creature, const s
 	if (const auto& followCreature = getFollowCreature();
 	    creature == followCreature || (creature.get() == this && followCreature)) {
 		if (newPos.z != oldPos.z || !canSee(followCreature->getPosition())) {
-			onCreatureDisappear(followCreature, false);
+			setFollowCreature(nullptr);
+
+			if (const auto& player = asPlayer()) {
+				player->sendCancelTarget();
+				player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			}
 		}
 	}
 
 	if (const auto& attackedCreature = getAttackedCreature();
 	    creature == attackedCreature || (creature.get() == this && attackedCreature)) {
 		if (newPos.z != oldPos.z || !canSee(attackedCreature->getPosition())) {
-			onCreatureDisappear(attackedCreature, false);
+			setAttackedCreature(nullptr);
+
+			if (const auto& player = asPlayer()) {
+				player->sendCancelTarget();
+				player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			}
+
+			if (const auto& monster = asMonster()) {
+				monster->resetAttackTicks();
+			}
 		} else {
 			if (hasExtraSwing()) {
 				// our target is moving lets see if we can get in hit
@@ -395,7 +430,47 @@ void Creature::onCreatureMove(const std::shared_ptr<Creature>& creature, const s
 			}
 
 			if (newTile->getZone() != oldTile->getZone()) {
-				onAttackedCreatureChangeZone(attackedCreature->getZone());
+				const auto zone = attackedCreature->getZone();
+
+				if (const auto& player = asPlayer()) {
+					if (zone == ZONE_PROTECTION) {
+						if (!player->hasFlag(PlayerFlag_IgnoreProtectionZone)) {
+							player->setAttackedCreature(nullptr);
+							player->sendCancelTarget();
+							player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+						}
+					} else if (zone == ZONE_NOPVP) {
+						if (attackedCreature->asPlayer()) {
+							if (!player->hasFlag(PlayerFlag_IgnoreProtectionZone)) {
+								player->setAttackedCreature(nullptr);
+								player->sendCancelTarget();
+								player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+							}
+						}
+					} else if (zone == ZONE_NORMAL) {
+						// attackedCreature can leave a pvp zone if not pzlocked
+						if (g_game.getWorldType() == WORLD_TYPE_NO_PVP) {
+							if (attackedCreature->asPlayer()) {
+								player->setAttackedCreature(nullptr);
+								player->sendCancelTarget();
+								player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+							}
+						}
+					}
+				} else {
+					if (zone == ZONE_PROTECTION) {
+						setAttackedCreature(nullptr);
+
+						if (const auto& player = asPlayer()) {
+							player->sendCancelTarget();
+							player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+						}
+
+						if (const auto& monster = asMonster()) {
+							monster->resetAttackTicks();
+						}
+					}
+				}
 			}
 		}
 	}
@@ -678,12 +753,32 @@ BlockType_t Creature::blockHit(const std::shared_ptr<Creature>& attacker, Combat
 
 void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 {
-	if (isAttackingCreature(creature)) {
+	if (!creature) {
+		attackedCreature.reset();
+
+		for (const auto& summon : summons | tfs::views::lock_weak_ptrs) {
+			summon->setAttackedCreature(nullptr);
+		}
+
+		if (const auto& player = asPlayer()) {
+			if (player->getFollowCreature()) {
+				player->setFollowCreature(nullptr);
+			}
+		}
 		return;
 	}
 
-	if (!canAttackCreature(creature)) {
-		removeAttackedCreature();
+	if (tfs::owner_equal(creature, attackedCreature)) {
+		return;
+	}
+
+	const auto& creaturePosition = creature->getPosition();
+	if (creaturePosition.z != getPosition().z || !canSee(creaturePosition)) {
+		setAttackedCreature(nullptr);
+
+		if (const auto& player = asPlayer()) {
+			player->sendCancelTarget();
+		}
 		return;
 	}
 
@@ -700,24 +795,20 @@ void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 	for (const auto& summon : summons | tfs::views::lock_weak_ptrs) {
 		summon->setAttackedCreature(creature);
 	}
-}
 
-void Creature::removeAttackedCreature()
-{
-	attackedCreature.reset();
+	if (const auto& player = asPlayer()) {
+		const auto& followCreature = player->getFollowCreature();
+		if (player->hasSecureMode()) {
+			if (followCreature != creature) {
+				// chase opponent
+				player->setFollowCreature(creature);
+			}
+		} else if (followCreature) {
+			player->setFollowCreature(nullptr);
+		}
 
-	for (const auto& summon : summons | tfs::views::lock_weak_ptrs) {
-		summon->removeAttackedCreature();
+		g_dispatcher.addTask([id = player->getID()]() { g_game.checkCreatureAttack(id); });
 	}
-}
-
-bool Creature::canAttackCreature(const std::shared_ptr<Creature>& creature)
-{
-	const auto& creaturePos = creature->getPosition();
-	if (creaturePos.z != getPosition().z) {
-		return false;
-	}
-	return canSee(creaturePos);
 }
 
 void Creature::getPathSearchParams(const std::shared_ptr<const Creature>&, FindPathParams& fpp) const
@@ -731,46 +822,45 @@ void Creature::getPathSearchParams(const std::shared_ptr<const Creature>&, FindP
 
 void Creature::setFollowCreature(const std::shared_ptr<Creature>& creature)
 {
-	if (isFollowingCreature(creature)) {
+	if (!creature) {
+		followCreature.reset();
+
+		hasFollowPath = false;
+
+		if (const auto& player = asPlayer()) {
+			player->stopWalk();
+		}
 		return;
 	}
 
-	if (!canFollowCreature(creature)) {
-		removeFollowCreature();
+	if (tfs::owner_equal(followCreature, creature)) {
+		return;
+	}
+
+	const auto& creaturePosition = creature->getPosition();
+	if (creaturePosition.z != getPosition().z || !canSee(creaturePosition)) {
+		setFollowCreature(nullptr);
+
+		if (const auto& player = asPlayer()) {
+			player->setAttackedCreature(nullptr);
+			player->sendCancelTarget();
+			player->sendCancelMessage(RETURNVALUE_THEREISNOWAY);
+			player->stopWalk();
+		}
 		return;
 	}
 
 	followCreature = creature;
 	creature->addFollower(asCreature());
 	hasFollowPath = false;
-	onFollowCreature(creature);
-	forceUpdatePath();
-}
 
-void Creature::removeFollowCreature()
-{
-	followCreature.reset();
-	onUnfollowCreature();
-}
-
-bool Creature::canFollowCreature(const std::shared_ptr<Creature>& creature)
-{
-	const auto& creaturePos = creature->getPosition();
-	if (creaturePos.z != getPosition().z) {
-		return false;
-	}
-	return canSee(creaturePos);
-}
-
-void Creature::onFollowCreature(const std::shared_ptr<const Creature>&)
-{
 	if (!listWalkDir.empty()) {
 		listWalkDir.clear();
 		onWalkAborted();
 	}
-}
 
-void Creature::onUnfollowCreature() { hasFollowPath = false; }
+	forceUpdatePath();
+}
 
 // Pathfinding Events
 void Creature::updateFollowersPaths()

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -797,7 +797,7 @@ void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 	}
 
 	attackedCreature = creature;
-	creature->addFollower(asCreature());
+
 	onAttackedCreature(creature);
 
 	if (const auto& player = creature->asPlayer()) {
@@ -812,7 +812,7 @@ void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 
 	if (const auto& player = asPlayer()) {
 		const auto& followCreature = player->getFollowCreature();
-		if (player->hasSecureMode()) {
+		if (player->getChaseMode()) {
 			if (followCreature != creature) {
 				// chase opponent
 				player->setFollowCreature(creature);
@@ -864,8 +864,12 @@ void Creature::setFollowCreature(const std::shared_ptr<Creature>& creature)
 		return;
 	}
 
-	followCreature = creature;
+	if (const auto& oldFollow = getFollowCreature()) {
+		oldFollow->removeFollower(asCreature());
+	}
 	creature->addFollower(asCreature());
+
+	followCreature = creature;
 	hasFollowPath = false;
 
 	if (!listWalkDir.empty()) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -461,11 +461,6 @@ void Creature::onCreatureMove(const std::shared_ptr<Creature>& creature, const s
 					if (zone == ZONE_PROTECTION) {
 						setAttackedCreature(nullptr);
 
-						if (const auto& player = asPlayer()) {
-							player->sendCancelTarget();
-							player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
-						}
-
 						if (const auto& monster = asMonster()) {
 							monster->resetAttackTicks();
 						}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -125,10 +125,6 @@ void Creature::onThink(uint32_t interval)
 			player->sendCancelTarget();
 			player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
 		}
-
-		if (const auto& monster = asMonster()) {
-			monster->resetAttackTicks();
-		}
 	}
 
 	blockTicks += interval;
@@ -344,16 +340,31 @@ void Creature::updateFollowCreaturePath(FindPathParams& fpp)
 
 void Creature::onChangeZone(ZoneType_t zone)
 {
-	if (const auto& attackedCreature = getAttackedCreature(); attackedCreature && zone == ZONE_PROTECTION) {
-		setAttackedCreature(nullptr);
+	if (zone == ZONE_PROTECTION) {
+		if (const auto& attackedCreature = getAttackedCreature()) {
+			setAttackedCreature(nullptr);
 
-		if (const auto& player = asPlayer()) {
-			player->sendCancelTarget();
-			player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			if (const auto& player = asPlayer()) {
+				player->sendCancelTarget();
+				player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			}
+
+			if (const auto& monster = asMonster()) {
+				monster->resetAttackTicks();
+			}
 		}
 
-		if (const auto& monster = asMonster()) {
-			monster->resetAttackTicks();
+		if (const auto& followCreature = getFollowCreature()) {
+			setFollowCreature(nullptr);
+
+			if (const auto& player = asPlayer()) {
+				player->sendCancelTarget();
+				player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			}
+
+			if (const auto& monster = asMonster()) {
+				monster->resetAttackTicks();
+			}
 		}
 	}
 }
@@ -406,6 +417,10 @@ void Creature::onCreatureMove(const std::shared_ptr<Creature>& creature, const s
 			if (const auto& player = asPlayer()) {
 				player->sendCancelTarget();
 				player->sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			}
+
+			if (const auto& monster = asMonster()) {
+				monster->resetAttackTicks();
 			}
 		}
 	}
@@ -759,6 +774,10 @@ void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 			if (player->getFollowCreature()) {
 				player->setFollowCreature(nullptr);
 			}
+		}
+
+		if (const auto& monster = asMonster()) {
+			monster->resetAttackTicks();
 		}
 		return;
 	}

--- a/src/creature.h
+++ b/src/creature.h
@@ -355,7 +355,7 @@ public:
 	std::shared_ptr<Creature> getFollowCreature() const { return followCreature.lock(); }
 	void setFollowCreature(const std::shared_ptr<Creature>& creature);
 
-	std::shared_ptr<Creature> getAttackedCreature() { return attackedCreature.lock(); }
+	std::shared_ptr<Creature> getAttackedCreature() const { return attackedCreature.lock(); }
 	void setAttackedCreature(const std::shared_ptr<Creature>& creature);
 
 protected:

--- a/src/creature.h
+++ b/src/creature.h
@@ -204,36 +204,12 @@ public:
 	virtual void onWalkAborted() {}
 	virtual void onWalkComplete() {}
 
-	// follow functions
-	std::shared_ptr<Creature> getFollowCreature() const { return followCreature.lock(); }
-	virtual void setFollowCreature(const std::shared_ptr<Creature>& creature);
-	virtual void removeFollowCreature();
-	bool canFollowCreature(const std::shared_ptr<Creature>& creature);
-	bool isFollowingCreature(const std::shared_ptr<Creature>& creature)
-	{
-		return tfs::owner_equal(followCreature, creature);
-	}
-
-	// follow events
-	virtual void onFollowCreature(const std::shared_ptr<const Creature>&);
-	virtual void onUnfollowCreature();
-
 	// Pathfinding functions
 	void addFollower(const std::shared_ptr<Creature>& creature) { followers.insert(creature); }
 	void removeFollower(const std::shared_ptr<Creature>& creature) { followers.erase(creature); }
 
 	// Pathfinding events
 	void updateFollowersPaths();
-
-	// combat functions
-	std::shared_ptr<Creature> getAttackedCreature() { return attackedCreature.lock(); }
-	virtual void setAttackedCreature(const std::shared_ptr<Creature>& creature);
-	virtual void removeAttackedCreature();
-	bool canAttackCreature(const std::shared_ptr<Creature>& creature);
-	bool isAttackingCreature(const std::shared_ptr<Creature>& creature)
-	{
-		return tfs::owner_equal(creature, attackedCreature);
-	}
 
 	virtual BlockType_t blockHit(const std::shared_ptr<Creature>& attacker, CombatType_t combatType, int32_t& damage,
 	                             bool checkDefense = false, bool checkArmor = false, bool field = false,
@@ -307,7 +283,6 @@ public:
 	virtual void onAttackedCreatureBlockHit(BlockType_t) {}
 	virtual void onBlockHit() {}
 	virtual void onChangeZone(ZoneType_t zone);
-	virtual void onAttackedCreatureChangeZone(ZoneType_t zone);
 	virtual void onIdleStatus();
 
 	virtual LightInfo getCreatureLight() const;
@@ -334,9 +309,6 @@ public:
 	virtual void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
 	                            const Position& newPos, const std::shared_ptr<const Tile>& oldTile,
 	                            const Position& oldPos, bool teleport);
-
-	virtual void onAttackedCreatureDisappear(bool) {}
-	virtual void onFollowCreatureDisappear(bool) {}
 
 	virtual void onCreatureSay(const std::shared_ptr<Creature>&, SpeakClasses, const std::string&) {}
 
@@ -379,6 +351,12 @@ public:
 	virtual void setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn = false);
 	virtual std::optional<int32_t> getStorageValue(uint32_t key) const;
 	const auto& getStorageMap() const { return storageMap; }
+
+	std::shared_ptr<Creature> getFollowCreature() const { return followCreature.lock(); }
+	void setFollowCreature(const std::shared_ptr<Creature>& creature);
+
+	std::shared_ptr<Creature> getAttackedCreature() { return attackedCreature.lock(); }
+	void setAttackedCreature(const std::shared_ptr<Creature>& creature);
 
 protected:
 	struct CountBlock_t
@@ -424,7 +402,6 @@ protected:
 	bool canUseDefense = true;
 	bool movementBlocked = false;
 
-	void onCreatureDisappear(const std::shared_ptr<const Creature>& creature, bool isLogout);
 	virtual void doAttacking(uint32_t) {}
 	virtual bool hasExtraSwing() { return false; }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3161,14 +3161,14 @@ void Game::playerSetAttackedCreature(uint32_t playerId, uint32_t creatureId)
 	}
 
 	if (player->getAttackedCreature() && creatureId == 0) {
-		player->removeAttackedCreature();
+		player->setAttackedCreature(nullptr);
 		player->sendCancelTarget();
 		return;
 	}
 
 	const auto& attackCreature = getCreatureByID(creatureId);
 	if (!attackCreature) {
-		player->removeAttackedCreature();
+		player->setAttackedCreature(nullptr);
 		player->sendCancelTarget();
 		return;
 	}
@@ -3177,7 +3177,7 @@ void Game::playerSetAttackedCreature(uint32_t playerId, uint32_t creatureId)
 	if (ret != RETURNVALUE_NOERROR) {
 		player->sendCancelMessage(ret);
 		player->sendCancelTarget();
-		player->removeAttackedCreature();
+		player->setAttackedCreature(nullptr);
 		return;
 	}
 
@@ -3193,12 +3193,12 @@ void Game::playerFollowCreature(uint32_t playerId, uint32_t creatureId)
 		return;
 	}
 
-	player->removeAttackedCreature();
+	player->setAttackedCreature(nullptr);
 
 	if (const auto& followCreature = getCreatureByID(creatureId)) {
 		player->setFollowCreature(followCreature);
 	} else {
-		player->removeFollowCreature();
+		player->setFollowCreature(nullptr);
 	}
 
 	g_dispatcher.addTask([this, id = player->getID()]() { updateCreatureWalk(id); });

--- a/src/lua/modules/creature.cpp
+++ b/src/lua/modules/creature.cpp
@@ -232,13 +232,8 @@ int luaCreatureSetTarget(lua_State* L)
 		return 1;
 	}
 
-	if (const auto& target = tfs::lua::getCreature(L, 2)) {
-		creature->setAttackedCreature(target);
-		tfs::lua::pushBoolean(L, creature->canAttackCreature(target));
-	} else {
-		creature->removeAttackedCreature();
-		tfs::lua::pushBoolean(L, true);
-	}
+	creature->setAttackedCreature(tfs::lua::getCreature(L, 2));
+	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
 
@@ -269,13 +264,8 @@ int luaCreatureSetFollowCreature(lua_State* L)
 		return 1;
 	}
 
-	if (const auto& followedCreature = tfs::lua::getCreature(L, 2)) {
-		creature->setFollowCreature(followedCreature);
-		tfs::lua::pushBoolean(L, creature->canFollowCreature(followedCreature));
-	} else {
-		creature->removeFollowCreature();
-		tfs::lua::pushBoolean(L, true);
-	}
+	creature->setFollowCreature(tfs::lua::getCreature(L, 2));
+	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -92,8 +92,6 @@ bool Monster::canWalkOnFieldType(CombatType_t combatType) const
 	}
 }
 
-void Monster::onAttackedCreatureDisappear(bool) { attackTicks = 0; }
-
 void Monster::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, MagicEffectClasses)
 {
 	if (creature.get() == this) {
@@ -621,23 +619,15 @@ bool Monster::selectTarget(const std::shared_ptr<Creature>& creature)
 		return false;
 	}
 
-	if (isHostile() || isSummon()) {
-		if (canAttackCreature(creature)) {
-			setAttackedCreature(creature);
-
-			if (isHostile()) {
-				g_dispatcher.addTask([id = getID()]() { g_game.checkCreatureAttack(id); });
-			}
-		} else {
-			removeAttackedCreature();
-		}
+	if (isSummon()) {
+		setAttackedCreature(creature);
+	} else if (isHostile()) {
+		setAttackedCreature(creature);
+		g_dispatcher.addTask([id = getID()]() { g_game.checkCreatureAttack(id); });
 	}
 
-	if (isFollowingCreature(creature) || canFollowCreature(creature)) {
-		setFollowCreature(creature);
-		return true;
-	}
-	return false;
+	setFollowCreature(creature);
+	return getFollowCreature() == creature;
 }
 
 void Monster::setIdle(bool idle)
@@ -741,7 +731,7 @@ void Monster::onThink(uint32_t interval)
 						setFollowCreature(master);
 					}
 				} else if (attackedCreature.get() == this) {
-					removeFollowCreature();
+					setFollowCreature(nullptr);
 				} else if (!tfs::owner_equal(attackedCreature, getFollowCreature())) {
 					// This happens just after a master orders an attack, so lets follow it as well.
 					setFollowCreature(attackedCreature);
@@ -1816,7 +1806,7 @@ bool Monster::canWalkTo(Position pos, Direction direction) const
 
 void Monster::death(const std::shared_ptr<Creature>&)
 {
-	removeAttackedCreature();
+	setAttackedCreature(nullptr);
 
 	for (const auto& summon : getSummons() | tfs::views::lock_weak_ptrs) {
 		summon->changeHealth(-summon->getHealth());

--- a/src/monster.h
+++ b/src/monster.h
@@ -78,8 +78,6 @@ public:
 	void setSpawn(Spawn* spawn) { this->spawn = spawn; }
 	bool canWalkOnFieldType(CombatType_t combatType) const;
 
-	void onAttackedCreatureDisappear(bool isLogout) override;
-
 	void onCreatureAppear(const std::shared_ptr<Creature>& creature, bool, MagicEffectClasses) override;
 	void onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout) override;
 	void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
@@ -153,6 +151,8 @@ public:
 	const MonsterType* getMonsterType() const { return mType; }
 
 	static uint32_t monsterAutoID;
+
+	void resetAttackTicks() { attackTicks = 0; }
 
 private:
 	boost::container::flat_set<std::weak_ptr<Creature>, std::owner_less<std::weak_ptr<Creature>>> friendList;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -664,14 +664,8 @@ int NpcScriptInterface::luaActionFollow(lua_State* L)
 		return 1;
 	}
 
-	const auto& followedPlayer = tfs::lua::getPlayer(L, 1);
-	if (followedPlayer) {
-		npc->setFollowCreature(followedPlayer);
-		tfs::lua::pushBoolean(L, npc->canFollowCreature(followedPlayer));
-	} else {
-		npc->removeFollowCreature();
-		tfs::lua::pushBoolean(L, true);
-	}
+	npc->setFollowCreature(tfs::lua::getPlayer(L, 1));
+	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1095,30 +1095,13 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 	tfs::events::player::onJoin(asPlayer());
 }
 
-void Player::onAttackedCreatureDisappear(bool isLogout)
-{
-	sendCancelTarget();
-
-	if (!isLogout) {
-		sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
-	}
-}
-
-void Player::onFollowCreatureDisappear(bool isLogout)
-{
-	sendCancelTarget();
-
-	if (!isLogout) {
-		sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
-	}
-}
-
 void Player::onChangeZone(ZoneType_t zone)
 {
 	if (zone == ZONE_PROTECTION) {
 		if (getAttackedCreature() && !hasFlag(PlayerFlag_IgnoreProtectionZone)) {
-			removeAttackedCreature();
-			onAttackedCreatureDisappear(false);
+			setAttackedCreature(nullptr);
+			sendCancelTarget();
+			sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
 		}
 
 		if (!group->access && isMounted()) {
@@ -1137,31 +1120,6 @@ void Player::onChangeZone(ZoneType_t zone)
 	sendIcons();
 }
 
-void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
-{
-	if (zone == ZONE_PROTECTION) {
-		if (!hasFlag(PlayerFlag_IgnoreProtectionZone)) {
-			removeAttackedCreature();
-			onAttackedCreatureDisappear(false);
-		}
-	} else if (zone == ZONE_NOPVP) {
-		if (const auto& attackedCreature = getAttackedCreature(); attackedCreature->asPlayer()) {
-			if (!hasFlag(PlayerFlag_IgnoreProtectionZone)) {
-				removeAttackedCreature();
-				onAttackedCreatureDisappear(false);
-			}
-		}
-	} else if (zone == ZONE_NORMAL) {
-		// attackedCreature can leave a pvp zone if not pzlocked
-		if (g_game.getWorldType() == WORLD_TYPE_NO_PVP) {
-			if (const auto& attackedCreature = getAttackedCreature(); attackedCreature->asPlayer()) {
-				removeAttackedCreature();
-				onAttackedCreatureDisappear(false);
-			}
-		}
-	}
-}
-
 void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
@@ -1174,7 +1132,7 @@ void Player::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool is
 		lastLogout = time(nullptr);
 
 		if (eventWalk != 0) {
-			removeFollowCreature();
+			setFollowCreature(nullptr);
 		}
 
 		if (!tradePartner.expired()) {
@@ -3241,60 +3199,6 @@ void Player::internalAddThing(uint32_t index, const std::shared_ptr<Thing>& thin
 	}
 }
 
-void Player::setFollowCreature(const std::shared_ptr<Creature>& creature)
-{
-	if (isFollowingCreature(creature)) {
-		return;
-	}
-
-	if (!canFollowCreature(creature)) {
-		removeFollowCreature();
-		removeAttackedCreature();
-		sendCancelTarget();
-		sendCancelMessage(RETURNVALUE_THEREISNOWAY);
-		stopWalk();
-		return;
-	}
-
-	Creature::setFollowCreature(creature);
-}
-
-void Player::setAttackedCreature(const std::shared_ptr<Creature>& creature)
-{
-	if (isAttackingCreature(creature)) {
-		return;
-	}
-
-	if (!canAttackCreature(creature)) {
-		removeAttackedCreature();
-		sendCancelTarget();
-		return;
-	}
-
-	Creature::setAttackedCreature(creature);
-
-	const auto& followCreature = getFollowCreature();
-	if (chaseMode) {
-		if (followCreature != creature) {
-			// chase opponent
-			setFollowCreature(creature);
-		}
-	} else if (followCreature) {
-		removeFollowCreature();
-	}
-
-	g_dispatcher.addTask([id = getID()]() { g_game.checkCreatureAttack(id); });
-}
-
-void Player::removeAttackedCreature()
-{
-	Creature::removeAttackedCreature();
-
-	if (getFollowCreature()) {
-		removeFollowCreature();
-	}
-}
-
 void Player::goToFollowCreature()
 {
 	const auto& followCreature = getFollowCreature();
@@ -3335,13 +3239,6 @@ uint64_t Player::getGainedExperience(const std::shared_ptr<Creature>& attacker) 
 	return 0;
 }
 
-void Player::onUnfollowCreature()
-{
-	Creature::onUnfollowCreature();
-
-	stopWalk();
-}
-
 void Player::setChaseMode(bool mode)
 {
 	bool prevChaseMode = chaseMode;
@@ -3354,7 +3251,7 @@ void Player::setChaseMode(bool mode)
 				setFollowCreature(attackedCreature);
 			}
 		} else {
-			removeFollowCreature();
+			setFollowCreature(nullptr);
 			cancelNextWalk = true;
 		}
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -450,11 +450,7 @@ public:
 	bool editVIP(uint32_t vipGuid, const std::string& description, uint32_t icon, bool notify);
 
 	// follow functions
-	void setFollowCreature(const std::shared_ptr<Creature>& creature) override;
 	void goToFollowCreature() override;
-
-	// follow events
-	void onUnfollowCreature() override;
 
 	// walk events
 	void onWalk(Direction& dir) override;
@@ -475,8 +471,6 @@ public:
 	void setSecureMode(bool mode) { secureMode = mode; }
 
 	// combat functions
-	void setAttackedCreature(const std::shared_ptr<Creature>& creature) override;
-	void removeAttackedCreature() override;
 	bool isImmune(CombatType_t type) const override;
 	bool isImmune(ConditionType_t type) const override;
 	bool hasShield() const;
@@ -545,7 +539,6 @@ public:
 	void onAttackedCreatureBlockHit(BlockType_t blockType) override;
 	void onBlockHit() override;
 	void onChangeZone(ZoneType_t zone) override;
-	void onAttackedCreatureChangeZone(ZoneType_t zone) override;
 	void onIdleStatus() override;
 
 	LightInfo getCreatureLight() const override;
@@ -836,9 +829,6 @@ public:
 	void onCreatureMove(const std::shared_ptr<Creature>& creature, const std::shared_ptr<const Tile>& newTile,
 	                    const Position& newPos, const std::shared_ptr<const Tile>& oldTile, const Position& oldPos,
 	                    bool teleport) override;
-
-	void onAttackedCreatureDisappear(bool isLogout) override;
-	void onFollowCreatureDisappear(bool isLogout) override;
 
 	// container
 	void onAddContainerItem(const std::shared_ptr<const Item>& item);


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Refactors the creature targeting and following system by moving logic from derived classes (Player, Monster) into the base Creature class, establishing a unified approach to chase and attack behavior.

**Key Changes:**

**Architecture:**
- Centralized follow/attack state management in `Creature` class by making `setFollowCreature()` and `setAttackedCreature()` the primary public interface
- Removed virtual hooks (`onAttackedCreatureDisappear`, `onFollowCreatureDisappear`, `onCreatureDisappear`, `onAttackedCreatureChangeZone`, etc.) that allowed per-subclass customization
- Replaced `remove*()` methods with direct state setters accepting `nullptr`

**Creature (base class):**
- Consolidated all follow/attack lifecycle logic into `setFollowCreature()` and `setAttackedCreature()` methods
- Added automatic propagation of state changes to summons
- Integrated player notifications (target cancel, text messages) directly in base class
- Added visibility and zone validation in setters

**Player class:**
- Removed 7 virtual override methods related to follow/attack behavior
- Simplified to use base class implementation (~100 lines removed)

**Monster class:**
- Removed `onAttackedCreatureDisappear` override
- Added `resetAttackTicks()` helper method
- Simplified `selectTarget()` logic

**Game & Lua:**
- Updated all call sites to use `setAttackedCreature(nullptr)` / `setFollowCreature(nullptr)` pattern
- Simplified Lua bindings to always call setters (handling nullptr internally)

**Benefits:**
- Single source of truth for follow/attack rules
- Consistent behavior across all creature types before Lua customization
- Reduced code duplication (~150 lines net reduction)
- Clearer state management flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined creature targeting and following mechanics with consolidated state management.

* **Bug Fixes**
  * Enhanced target loss detection and messaging—creatures now receive "Target lost." notifications when targets become invisible or change zones, ensuring consistent feedback across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->