### PR TITLE
fix(monster): prevent spiral movement loop when overlaps creature

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -531,8 +531,11 @@ void Monster::goToFollowCreature()
 	if (simpleStep) {
 		auto direction = DIRECTION_NONE;
 		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {
-			hasFollowPath = true;
-			startAutoWalk(direction);
+			if (direction != DIRECTION_NONE) {
+				hasFollowPath = true;
+				startAutoWalk(direction);
+			}
+
 			onFollowCreatureComplete();
 			return;
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -527,7 +527,7 @@ void Monster::goToFollowCreature()
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
 
-	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist >= 1);
+	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
 	if (simpleStep) {
 		auto direction = DIRECTION_NONE;
 		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -527,17 +527,13 @@ void Monster::goToFollowCreature()
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
 
-		Direction dir = DIRECTION_NONE;
+	auto direction = DIRECTION_NONE;
 
-	bool simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
+	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
 	if (simpleStep) {
-		if (getDistanceStep(followCreature->getPosition(), dir, isFleeing())) {
-			listWalkDir.clear();
-			listWalkDir.push_back(dir);
-
+		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {
 			hasFollowPath = true;
-			startAutoWalk();
-
+			startAutoWalk(direction);
 			onFollowCreatureComplete();
 			return;
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -527,7 +527,7 @@ void Monster::goToFollowCreature()
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
 
-	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
+	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist >= 1);
 	if (simpleStep) {
 		auto direction = DIRECTION_NONE;
 		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -527,10 +527,9 @@ void Monster::goToFollowCreature()
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
 
-	auto direction = DIRECTION_NONE;
-
 	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
 	if (simpleStep) {
+		auto direction = DIRECTION_NONE;
 		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {
 			hasFollowPath = true;
 			startAutoWalk(direction);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -527,30 +527,23 @@ void Monster::goToFollowCreature()
 	FindPathParams fpp;
 	getPathSearchParams(followCreature, fpp);
 
-	if (!isSummon()) {
 		Direction dir = DIRECTION_NONE;
 
-		if (isFleeing()) {
-			getDistanceStep(followCreature->getPosition(), dir, true);
-		} else { // maxTargetDist > 1
-			if (!getDistanceStep(followCreature->getPosition(), dir)) {
-				// if we can't get anything then let the A* calculate
-				updateFollowCreaturePath(fpp);
-				return;
-			}
-		}
-
-		if (dir != DIRECTION_NONE) {
+	bool simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
+	if (simpleStep) {
+		if (getDistanceStep(followCreature->getPosition(), dir, isFleeing())) {
 			listWalkDir.clear();
 			listWalkDir.push_back(dir);
 
 			hasFollowPath = true;
 			startAutoWalk();
+
+			onFollowCreatureComplete();
+			return;
 		}
-	} else {
-		updateFollowCreaturePath(fpp);
 	}
 
+	updateFollowCreaturePath(fpp);
 	onFollowCreatureComplete();
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -531,8 +531,9 @@ void Monster::goToFollowCreature()
 	if (simpleStep) {
 		auto direction = DIRECTION_NONE;
 		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {
+			hasFollowPath = true;
+
 			if (direction != DIRECTION_NONE) {
-				hasFollowPath = true;
 				startAutoWalk(direction);
 			}
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Fixes a movement bug where monsters would enter a permanent "spiral loop" and lose their smooth walking ability when a player stood directly on top of them.

Previously, the nested logic in goToFollowCreature would get stuck in a state where it only performed jittery, step-by-step movements. Now, the logic to use a simplified simpleStep check and ensuring a clean fallback to the A* pathfinder (updateFollowCreaturePath), the creature can now correctly recalculate its route out of an overlap. This restores natural movement flow and prevents the "step-by-step" movement error.

Introduced in https://github.com/otland/forgottenserver/pull/4811
Issue address https://github.com/otland/forgottenserver/issues/4865

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable creature-following: short/simple movement steps used when appropriate for quicker adjustments.
  * Follow completion handling unified so follow actions consistently trigger target-list updates.
  * Target ordering now updates reliably after either simple moves or full path updates, improving follow prioritization and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->