### PR TITLE
fix: capture stable eventId in luaAddEvent scheduler lambda

### DIFF
--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -435,12 +435,12 @@ int luaAddEvent(lua_State* L)
 	eventDesc.function = luaL_ref(L, LUA_REGISTRYINDEX);
 	eventDesc.scriptId = tfs::lua::getScriptEnv()->getScriptId();
 
-	auto& lastTimerEventId = g_luaEnvironment.lastEventTimerId;
-	eventDesc.eventId = g_scheduler.addEvent(
-	    createSchedulerTask(delay, [=]() { g_luaEnvironment.executeTimerEvent(lastTimerEventId); }));
+	uint32_t timerId = g_luaEnvironment.lastEventTimerId++;
+	eventDesc.eventId =
+	    g_scheduler.addEvent(createSchedulerTask(delay, [timerId] { g_luaEnvironment.executeTimerEvent(timerId); }));
 
-	g_luaEnvironment.timerEvents.emplace(lastTimerEventId, std::move(eventDesc));
-	tfs::lua::pushNumber(L, lastTimerEventId++);
+	g_luaEnvironment.timerEvents.emplace(timerId, std::move(eventDesc));
+	tfs::lua::pushNumber(L, timerId);
 	return 1;
 }
 


### PR DESCRIPTION
The previous code captured `lastEventTimerId` through a reference alias, causing the scheduled lambda to reference the mutable global counter. When executed later, the lambda could use a different ID than the one inserted into `timerEvents`.

Snapshot `lastEventTimerId++` into a local `eventId` and capture it by value to ensure the lambda uses the correct identifier.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->
Compile with clang and try to talk to the Banker npc.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal event scheduling: timer IDs are now managed locally to ensure stable, predictable identifiers for scheduled events.
  * Streamlined task scheduling and event registration for more reliable timer execution and reduced risk of identifier-related races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->