### PR TITLE
ci: pin clang-format to version 21

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,11 +31,12 @@ jobs:
 
       - name: Setup LLVM repository
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
+          source /etc/os-release
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | sudo tee /usr/share/keyrings/llvm.gpg > /dev/null
+          sudo echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-21 main" | sudo tee /etc/apt/sources.list.d/llvm.list
 
       - name: Install dependencies
-        run: sudo apt update -qq && sudo apt install -yqq clang-format
+        run: sudo apt-get update -yqq && sudo apt-get install -yqq clang-format-21
 
       - name: Check code style
-        run: clang-format -n -style=file --Werror src/*.{cpp,h}
+        run: clang-format-21 -n -style=file --Werror src/*.{cpp,h}


### PR DESCRIPTION
clang-format-22 was recently added to the LLVM repo but is not
yet installing correctly due to unmet dependencies.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow and repository setup. Formatting checks now run with a specific newer clang-format release and the package/install handling was modernized to ensure consistent, reproducible formatting verification across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->