### PR TITLE
chore(docker): update libsimdutf version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:forky-slim AS build
 RUN apt-get update -q && apt-get install -yq \
   build-essential \
   cmake \
-  libboost-iostreams1.88-dev \
-  libboost-json1.88-dev \
-  libboost-system1.88-dev \
+  libboost-iostreams1.90-dev \
+  libboost-json1.90-dev \
+  libboost-system1.90-dev \
   liblua5.4-dev \
   libmariadb-dev \
   libpugixml-dev \
@@ -21,12 +21,12 @@ RUN cmake --preset default && cmake --build --config RelWithDebInfo --preset def
 
 FROM debian:forky-slim
 RUN apt-get update -q && apt-get install -yq \
-  libboost-iostreams1.88.0 \
-  libboost-json1.88.0 \
+  libboost-iostreams1.90.0 \
+  libboost-json1.90.0 \
   liblua5.4-0 \
   libmariadb3 \
   libpugixml1v5 \
-  libsimdutf29 \
+  libsimdutf31 \
   libspdlog1.15 \
   libssl3t64 \
   && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:forky-slim AS build
 RUN apt-get update -q && apt-get install -yq \
   build-essential \
   cmake \
-  libboost-iostreams1.90-dev \
-  libboost-json1.90-dev \
-  libboost-system1.90-dev \
+  libboost-iostreams1.88-dev \
+  libboost-json1.88-dev \
+  libboost-system1.88-dev \
   liblua5.4-dev \
   libmariadb-dev \
   libpugixml-dev \
@@ -21,8 +21,8 @@ RUN cmake --preset default && cmake --build --config RelWithDebInfo --preset def
 
 FROM debian:forky-slim
 RUN apt-get update -q && apt-get install -yq \
-  libboost-iostreams1.90.0 \
-  libboost-json1.90.0 \
+  libboost-iostreams1.88.0 \
+  libboost-json1.88.0 \
   liblua5.4-0 \
   libmariadb3 \
   libpugixml1v5 \


### PR DESCRIPTION
* Upgraded `libsimdutf` from version 29 to version 31 in the runtime dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the UTF-8 encoding processing library in the runtime container environment to improve system performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->