### PR TITLE
fix(ci): unbreak docker-image workflow on Debian forky and PRs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,11 +49,12 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM debian:forky-slim AS build
 RUN apt-get update -q && apt-get install -yq \
   build-essential \
   cmake \
-  libboost-iostreams1.88-dev \
-  libboost-json1.88-dev \
-  libboost-system1.88-dev \
+  libboost-iostreams1.83-dev \
+  libboost-json1.83-dev \
+  libboost-system1.83-dev \
   liblua5.4-dev \
   libmariadb-dev \
   libpugixml-dev \
@@ -21,12 +21,12 @@ RUN cmake --preset default && cmake --build --config RelWithDebInfo --preset def
 
 FROM debian:forky-slim
 RUN apt-get update -q && apt-get install -yq \
-  libboost-iostreams1.88.0 \
-  libboost-json1.88.0 \
+  libboost-iostreams1.83.0 \
+  libboost-json1.83.0 \
   liblua5.4-0 \
   libmariadb3 \
   libpugixml1v5 \
-  libsimdutf31 \
+  libsimdutf33 \
   libspdlog1.15 \
   libssl3t64 \
   && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Changes Proposed

The `docker-image` workflow was failing on every PR and on `dev` for two independent reasons. Both are fixed here:

**1. `Dockerfile` referenced apt packages that don't exist in Debian forky**

- `libboost-iostreams1.88.0` / `libboost-json1.88.0` / `libboost-system1.88.0` → bumped to `1.83` (build) and `1.83.0` (runtime), which are the versions actually shipped in forky.
- `libsimdutf31` → `libsimdutf33`.

**2. Workflow tried to push images to GHCR on PR events**

PR-triggered runs don't have `packages: write` permission on the org registry, so the push step failed with `denied: installation not allowed to Write organization package`.

- `Build and push` step now sets `push: ${{ github.event_name != 'pull_request' }}` — PRs build the image (validating the Dockerfile) but skip the push.
- `Generate artifact attestation` step is gated with `if: github.event_name != 'pull_request'` because it also pushes to the registry.
- Pushes to `dev` and `v*` tags continue to publish normally.

### How to test

- This PR's own `docker-image` check should go green: build runs, push is skipped.
- After merge, the next push to `dev` should publish `ghcr.io/atlas-kit/atlas:dev` as before.