### PR TITLE
fix: resolve chrono migration regressions from PR #166

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -91,8 +91,8 @@ bool Condition::unserializeProp(ConditionAttr_t attr, PropStream& propStream)
 		}
 
 		case CONDITIONATTR_TICKS: {
-			uint32_t _ticks;
-			if (!propStream.read<uint32_t>(_ticks)) {
+			int32_t _ticks;
+			if (!propStream.read<int32_t>(_ticks)) {
 				return false;
 			}
 
@@ -141,7 +141,7 @@ void Condition::serialize(PropWriteStream& propWriteStream)
 	propWriteStream.write<uint32_t>(id);
 
 	propWriteStream.write<uint8_t>(CONDITIONATTR_TICKS);
-	propWriteStream.write<uint32_t>(ticks.count());
+	propWriteStream.write<int32_t>(static_cast<int32_t>(ticks.count()));
 
 	propWriteStream.write<uint8_t>(CONDITIONATTR_ISBUFF);
 	propWriteStream.write<uint8_t>(isBuff);
@@ -263,8 +263,8 @@ std::unique_ptr<Condition> Condition::createCondition(PropStream& propStream)
 		return nullptr;
 	}
 
-	uint32_t _ticks;
-	if (!propStream.read<uint32_t>(_ticks)) {
+	int32_t _ticks;
+	if (!propStream.read<int32_t>(_ticks)) {
 		return nullptr;
 	}
 	auto ticks = std::chrono::milliseconds{_ticks};

--- a/src/creature.h
+++ b/src/creature.h
@@ -370,8 +370,8 @@ protected:
 
 	std::vector<Direction> listWalkDir;
 
-	std::chrono::steady_clock::time_point lastStep = std::chrono::steady_clock::time_point::min();
-	std::chrono::steady_clock::time_point lastPathUpdate = std::chrono::steady_clock::time_point::min();
+	std::chrono::steady_clock::time_point lastStep{};
+	std::chrono::steady_clock::time_point lastPathUpdate{};
 	uint32_t id = 0;
 	uint32_t scriptEventsBitField = 0;
 	uint32_t eventWalk = 0;


### PR DESCRIPTION
## Summary

Fixes two bugs introduced by #166 (refactor: use chrono library for time handling):

- **Condition ticks serialization** (`condition.cpp`): ticks were being read/written as `uint32_t`, which broke the `-1` sentinel used for permanent/infinite conditions. The value `-1` was deserialized as `4294967295ms` (~49.7 days) instead of staying `-1ms`. Changed back to `int32_t` to preserve the original serialization format.

- **Creature lastStep initialization** (`creature.h`): `lastStep` and `lastPathUpdate` were initialized with `time_point::min()` but `getTimeSinceLastMove()` compared against `time_point{}` (epoch). Since `min() != epoch`, the check never detected "never moved" creatures, computing `now() - min()` (an astronomically large value) instead of returning `max()`. Changed initialization to `time_point{}` to match the existing comparisons.

Closes #217
Closes #218

## Test plan

- [ ] Verify permanent conditions (ticks = -1) persist correctly across server saves/loads
- [ ] Verify newly spawned creatures move correctly on their first step
- [ ] Verify existing condition behavior (finite ticks, buff timers) is unaffected
- [ ] Verify creature pathfinding works normally after the lastStep fix

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of condition data serialization to ensure proper value preservation across save/load cycles.
  * Enhanced creature state initialization for more reliable time-tracking operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->