### PR TITLE
fix(combat): correct mana shield damage subtraction

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4092,8 +4092,8 @@ bool Game::combatChangeHealth(const std::shared_ptr<Creature>& attacker, const s
 				Condition* condition = targetPlayer->getCondition(CONDITION_MANASHIELD_BREAKABLE);
 				if (ConditionManaShield* conditionManaShield =
 				        condition ? condition->getConditionManaShield() : nullptr) {
-					if (int32_t remainingManaDamage =
-					        conditionManaShield->onDamageTaken(targetPlayer, manaDamage) != 0) {
+					int32_t remainingManaDamage = conditionManaShield->onDamageTaken(targetPlayer, manaDamage);
+					if (remainingManaDamage != 0) {
 						manaDamage -= remainingManaDamage;
 						targetPlayer->removeCondition(CONDITION_MANASHIELD_BREAKABLE);
 					}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed proper Atlas code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes #212.

The breakable mana shield was subtracting only **0 or 1** point of mana damage instead of the real leftover damage returned by `ConditionManaShield::onDamageTaken`, because the assignment and the `!= 0` comparison were on the same line and C++ operator precedence bound the comparison to the `onDamageTaken(...)` result, so `remainingManaDamage` received the boolean (`0` or `1`) instead of the actual integer.

Before:

```cpp
if (int32_t remainingManaDamage =
        conditionManaShield->onDamageTaken(targetPlayer, manaDamage) != 0) {
    manaDamage -= remainingManaDamage;  // always subtracts at most 1
    ...
}
```

After:

```cpp
int32_t remainingManaDamage = conditionManaShield->onDamageTaken(targetPlayer, manaDamage);
if (remainingManaDamage != 0) {
    manaDamage -= remainingManaDamage;  // subtracts the real leftover damage
    ...
}
```

#### Behavior comparison

| `onDamageTaken` returns | Before this PR | After this PR |
| --- | --- | --- |
| `0` (fully absorbed) | skips the block ✓ | skips the block ✓ |
| `47` (leftover) | `manaDamage -= 1` ✗ | `manaDamage -= 47` ✓ |
| `200` (leftover) | `manaDamage -= 1` ✗ | `manaDamage -= 200` ✓ |

### Notes

- Pre-existing bug spotted during the review of #139.
- Scope intentionally kept minimal: only the precedence bug is fixed. Whether `removeCondition(CONDITION_MANASHIELD_BREAKABLE)` should run on every leftover-damage event or only when the shield is fully depleted is a separate behavioral discussion and is not addressed here.