### PR TITLE
refactor(spells): use virtual getters in registerEvent

### DIFF
--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -119,7 +119,13 @@ std::unique_ptr<Event> Spells::getEvent(const std::string& nodeName)
 
 bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 {
-	if (std::unique_ptr<InstantSpell> instant{dynamic_cast<InstantSpell*>(event.get())}) {
+	Spell* spell = dynamic_cast<Spell*>(event.get());
+	if (!spell) {
+		return false;
+	}
+
+	if (InstantSpell* instantPtr = spell->getInstantSpell()) {
+		std::unique_ptr<InstantSpell> instant{instantPtr};
 		auto result = instants.emplace(instant->getWords(), std::move(*instant));
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerEvent] Duplicate registered instant spell with words: "
@@ -128,7 +134,8 @@ bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 		return result.second;
 	}
 
-	if (std::unique_ptr<RuneSpell> rune{dynamic_cast<RuneSpell*>(event.get())}) {
+	if (RuneSpell* runePtr = spell->getRuneSpell()) {
+		std::unique_ptr<RuneSpell> rune{runePtr};
 		auto result = runes.emplace(rune->getRuneItemId(), std::move(*rune));
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerEvent] Duplicate registered rune with id: "


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed proper Atlas code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixes #213. Natural follow-up to #139.

Replaces the two leftover `dynamic_cast` usages in `Spells::registerEvent` with a single `dynamic_cast<Spell*>` followed by the virtual getters `getInstantSpell()` / `getRuneSpell()` introduced in #139, keeping the file aligned with the pattern adopted in the rest of the spell module.

#### Before

```cpp
bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
{
    if (std::unique_ptr<InstantSpell> instant{dynamic_cast<InstantSpell*>(event.get())}) {
        ...
    }
    if (std::unique_ptr<RuneSpell> rune{dynamic_cast<RuneSpell*>(event.get())}) {
        ...
    }
    return false;
}
```

#### After

```cpp
bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
{
    Spell* spell = dynamic_cast<Spell*>(event.get());
    if (!spell) {
        return false;
    }

    if (InstantSpell* instantPtr = spell->getInstantSpell()) {
        std::unique_ptr<InstantSpell> instant{instantPtr};
        ...
    }
    if (RuneSpell* runePtr = spell->getRuneSpell()) {
        std::unique_ptr<RuneSpell> rune{runePtr};
        ...
    }
    return false;
}
```

### Notes

- **Behavior preserved 1:1** — same emplace, same warning messages, same return values. The inner `unique_ptr` wrapping pattern is kept identical to the previous code on purpose, so ownership semantics do not change in this PR.
- One `dynamic_cast` remains (Event* → Spell*) because the `Event` base class is shared with non-spell events, so the defensive check is still required.
- `registerEvent` runs only at startup (XML spell loading), so the performance impact is negligible. The motivation here is consistency with the rest of the spell module, not throughput.