### PR TITLE
fix(schedule-event): sleep until target weekday for interval schedules

### DIFF
--- a/data/scripts/lib/schedule_event.lua
+++ b/data/scripts/lib/schedule_event.lua
@@ -196,6 +196,7 @@ function ScheduleEvent:scheduleDays(dayTimes, dayIntervals)
 	end
 
 	-- A weekday interval runs repeatedly at the configured interval, but only while that weekday is active.
+	-- When the target day is not the current day, sleep until 00:00:00 of the next occurrence instead of polling.
 	for day, interval in pairs(dayIntervals) do
 		local function loop()
 			if not self._registered then
@@ -204,23 +205,17 @@ function ScheduleEvent:scheduleDays(dayTimes, dayIntervals)
 
 			if os.date("*t").wday == day then
 				safeCall(self.callback, interval)
-			end
-			schedule(self, loop, interval)
-		end
-
-		local function scheduleInitial()
-			if not self._registered then
-				return
-			end
-
-			if os.date("*t").wday == day then
 				schedule(self, loop, interval)
 			else
-				schedule(self, scheduleInitial, interval)
+				schedule(self, loop, nextWeekdayDelay(day, 0, 0, 0))
 			end
 		end
 
-		scheduleInitial()
+		if os.date("*t").wday == day then
+			schedule(self, loop, interval)
+		else
+			schedule(self, loop, nextWeekdayDelay(day, 0, 0, 0))
+		end
 	end
 
 	return true


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed proper code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

## Summary

Closes #214.

The weekday interval mode (`ScheduleEvent({ [FRIDAY] = 30000 })`) was waking the scheduler every `interval` ms on **every day of the week**, just to immediately return when the day check failed. For a 30-second interval that is ~2,880 no-op wakeups per day on each of the 6 wrong days.

This change calculates the delay until the start of the next target weekday and sleeps until then, reusing the existing `nextWeekdayDelay(day, 0, 0, 0)` helper that the daily-time mode already relied on.

## Behavior

- **Target day matches `interval` mode**: first callback after `interval` ms, then every `interval` ms while the day still matches (unchanged from before).
- **Target day no longer matches**: schedule next loop iteration for 00:00:00 of the next occurrence of the configured weekday — not a poll at `interval`.
- **Initial registration on a non-target day**: same as above, sleeps until the target day's start instead of polling every `interval` ms.
- Self-correcting against clock changes / DST: each loop iteration re-evaluates `os.date("*t").wday` and recomputes via `nextWeekdayDelay`.

## Test plan

- [ ] Register `ScheduleEvent({ [<current weekday>] = 5000 })` — fires every 5s today.
- [ ] Register `ScheduleEvent({ [<tomorrow's weekday>] = 5000 })` — does not fire until tomorrow at 00:00:00, then every 5s.
- [ ] `/reload scripts` still cancels pending timers cleanly via `ScheduleEvent.clear()`.
