### PR TITLE
feat(schedule-event): add unregister to remove a single event

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -1054,6 +1054,8 @@ Event = {}
 ---@field time number|string|table<number, number|string|string[]> Interval(ms), "HH:MM:SS" string, or table mapping weekday constants to intervals or time string(s)
 ---@field onTrigger fun():nil Callback function executed when the event triggers
 ---@field register fun(self:ScheduleEvent):boolean Registers the event, returns true if successful
+---@field stop fun(self:ScheduleEvent):nil Stops the event's pending timers without removing it from tracking
+---@field unregister fun(self:ScheduleEvent):nil Stops the event and removes it from ScheduleEvent._events
 ---@operator call(number|string|table<number, number|string|string[]>):ScheduleEvent Creates a new ScheduleEvent instance
 ScheduleEvent = {}
 

--- a/data/scripts/lib/schedule_event.lua
+++ b/data/scripts/lib/schedule_event.lua
@@ -326,6 +326,21 @@ function ScheduleEvent:stop()
 	self._registered = false
 end
 
+function ScheduleEvent:unregister()
+	self:stop()
+	if not self._tracked then
+		return
+	end
+
+	for index, event in ipairs(ScheduleEvent._events) do
+		if event == self then
+			table.remove(ScheduleEvent._events, index)
+			self._tracked = false
+			return
+		end
+	end
+end
+
 function ScheduleEvent.clear()
 	for _, event in ipairs(ScheduleEvent._events) do
 		event:stop()


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed proper code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

## Summary

Closes #215.

`event:stop()` cancels pending timers but keeps the event in `ScheduleEvent._events` with `_tracked = true`. The only way to fully remove an event was the global `ScheduleEvent.clear()`, which also clobbers every other tracked event.

This PR adds `event:unregister()` to permanently remove a single event from the tracking table while also stopping its timers. `cpplinter.lua` is updated to document `stop()` and `unregister()`.

## API

```lua
local event = ScheduleEvent(30000)
event.onTrigger = function() ... end
event:register()

-- later, when the event should no longer exist:
event:unregister() -- stops timers AND removes from ScheduleEvent._events
```

## Test plan

- [ ] After `event:unregister()`, the event no longer appears in `ScheduleEvent._events`.
- [ ] `event:unregister()` followed by `event:register()` on the same instance correctly re-tracks it.
- [ ] Calling `event:unregister()` twice is a no-op (does not error).
- [ ] `ScheduleEvent.clear()` continues to work for events that were never `unregister`-ed.
