### PR TITLE
refactor(schedule-event): use hash table for tracked event ids

### DIFF
--- a/data/scripts/lib/schedule_event.lua
+++ b/data/scripts/lib/schedule_event.lua
@@ -47,22 +47,13 @@ local function safeCall(callback, ...)
 	return true, result
 end
 
-local function clearEventId(self, eventId)
-	for index, id in ipairs(self._eventIds) do
-		if id == eventId then
-			table.remove(self._eventIds, index)
-			return
-		end
-	end
-end
-
 local function schedule(self, callback, delay, ...)
 	local eventId
 	eventId = addEvent(function(...)
-		clearEventId(self, eventId)
+		self._eventIds[eventId] = nil
 		callback(...)
 	end, math.max(SCHEDULER_MINTICKS, delay), ...)
-	table.insert(self._eventIds, eventId)
+	self._eventIds[eventId] = true
 	return eventId
 end
 
@@ -318,7 +309,7 @@ function ScheduleEvent:register()
 end
 
 function ScheduleEvent:stop()
-	for _, eventId in ipairs(self._eventIds) do
+	for eventId in pairs(self._eventIds) do
 		stopEvent(eventId)
 	end
 


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed proper code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

## Summary

Closes #216.

`self._eventIds` was a sequence walked with `ipairs` + `table.remove` on every timer fire — O(n) for the lookup plus O(n) for the shift. Switching to event-id-as-key makes insert, remove and iterate all O(1). `clearEventId` is folded into the `addEvent` closure since it becomes a single line.

Behavior is unchanged: `stop()` still cancels every pending timer, and `clear()` still works.

## Test plan

- [ ] All existing `data/scripts/scheduleevents/*` files still trigger correctly (raids, server save, world light, world time).
- [ ] `/reload scripts` cancels pending timers via `ScheduleEvent.clear()` as before.
- [ ] An interval schedule with many overlapping pending timers stops cleanly via `event:stop()`.
