### PR TITLE
fix(lua): use integer division in server save broadcast message

### DIFF
--- a/data/scripts/scheduleevents/server_save.lua
+++ b/data/scripts/scheduleevents/server_save.lua
@@ -24,7 +24,7 @@ local function ServerSaveWarning(time)
 	local remainingTime = tonumber(time) - 60000
 
 	if configManager.getBoolean(configKeys.SERVER_SAVE_NOTIFY_MESSAGE) then
-		Game.broadcastMessage("Server is saving game in " .. (remainingTime/60000) .. " minute(s). Please logout.", MESSAGE_STATUS_WARNING)
+		Game.broadcastMessage("Server is saving game in " .. (remainingTime // 60000) .. " minute(s). Please logout.", MESSAGE_STATUS_WARNING)
 	end
 
 	if remainingTime > 60000 then
@@ -39,7 +39,7 @@ local event = ScheduleEvent("09:55:00")
 event.onTrigger = function()
 	local remainingTime = configManager.getNumber(configKeys.SERVER_SAVE_NOTIFY_DURATION) * 60000
 	if configManager.getBoolean(configKeys.SERVER_SAVE_NOTIFY_MESSAGE) then
-		Game.broadcastMessage("Server is saving game in " .. (remainingTime/60000) .. " minute(s). Please logout.", MESSAGE_STATUS_WARNING)
+		Game.broadcastMessage("Server is saving game in " .. (remainingTime // 60000) .. " minute(s). Please logout.", MESSAGE_STATUS_WARNING)
 	end
 
 	addEvent(ServerSaveWarning, 60000, remainingTime)


### PR DESCRIPTION
## Summary
- Use `//` (integer division) instead of `/` in server save broadcast messages to prevent Lua 5.3+ from displaying floating-point values (e.g., "5.0" instead of "5")

Closes #162

## Test plan
- [ ] Trigger a server shutdown on a Linux-based build using Lua 5.3+
- [ ] Verify the broadcast message displays "Server is saving game in 5 minute(s)" (integer) instead of "5.0 minute(s)" (float)

🤖 Generated with [Claude Code](https://claude.com/claude-code)