### PR TITLE
fix(items): prevent monsters from pushing beds

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -1404,15 +1404,9 @@
 		<attribute key="rotateTo" value="1751" />
 		<attribute key="type" value="container" />
 	</item>
-	<item fromid="1754" toid="1755" article="a" name="bed">
-		<attribute key="moveable" value="true" />
-	</item>
-	<item fromid="1756" toid="1759" article="a" name="cot">
-		<attribute key="moveable" value="true" />
-	</item>
-	<item fromid="1760" toid="1761" article="a" name="bed">
-		<attribute key="moveable" value="true" />
-	</item>
+	<item fromid="1754" toid="1755" article="a" name="bed" />
+	<item fromid="1756" toid="1759" article="a" name="cot" />
+	<item fromid="1760" toid="1761" article="a" name="bed" />
 	<item fromid="1762" toid="1765" article="a" name="bed" />
 	<item fromid="1766" toid="1769" article="a" name="cot" />
 	<item id="1770" article="a" name="barrel">
@@ -7462,9 +7456,7 @@
 		<attribute key="rotateTo" value="3834" />
 		<attribute key="type" value="container" />
 	</item>
-	<item fromid="3836" toid="3839" article="a" name="hammock">
-		<attribute key="moveable" value="true" />
-	</item>
+	<item fromid="3836" toid="3839" article="a" name="hammock" />
 	<item fromid="3840" toid="3843" article="a" name="hammock" />
 	<item fromid="3844" toid="3847" article="a" name="grass mat" />
 	<item fromid="3848" toid="3851" article="a" name="straw mat" />
@@ -9247,9 +9239,7 @@
 	<item fromid="5481" toid="5482" name="shackles" />
 	<item fromid="5483" toid="5484" name="wall chains" />
 	<item fromid="5485" toid="5495" name="straw" />
-	<item fromid="5496" toid="5499" article="a" name="straw mat">
-		<attribute key="moveable" value="true" />
-	</item>
+	<item fromid="5496" toid="5499" article="a" name="straw mat" />
 	<item fromid="5500" toid="5503" article="a" name="straw mat" />
 	<item id="5504" article="a" name="wooden column" />
 	<item fromid="5505" toid="5512" article="a" name="pulley" />


### PR DESCRIPTION
## Summary

Closes #149 — monsters were able to push beds, cots, hammocks and straw mats around as they walked over them.

Only removes the `moveable="true"` attribute from the "free" parts of those bed-like items in [data/items/items.xml](data/items/items.xml). No C++ or Lua changes.

## Why this bug happened (plain-English explanation)

When #89 migrated the bed logic from C++ to Lua, it rewrote `items.xml` and accidentally added this line:

```xml
<item fromid="1754" toid="1755" article="a" name="bed">
    <attribute key="moveable" value="true" />   <!-- ← this was added -->
</item>
```

Think of `moveable="true"` as a sticker glued onto the bed saying **"this object can be pushed around"**. Before #89, that sticker did not exist — beds were treated as fixed furniture.

The server engine has a rule in `src/monster.cpp` that essentially says:

> "When a monster steps onto a tile, if there is an item there that **(1) has the movable sticker** **and (2) blocks the path**, push it to a neighboring tile."

Beds have height/blocking (condition 2), and they now also had the movable sticker (condition 1) — so they suddenly matched the rule perfectly and monsters started shoving them. It was as if the bed had grown wheels by accident.

## Why this fix is safe

- **Restores the exact pre-#89 XML.** The "occupied" parts of these beds (IDs 1762-1765, 1766-1769, 3840-3843, 5500-5503) already had no `moveable` attribute — now the "free" parts match them again, the way it always was.
- **Does not break sleep/wake-up.** Sleeping does not physically move the bed — it swaps the item ID from "free" to "occupied" via `item:transform()`. I verified this in `data/scripts/systems/beds/core/bed.lua` and `sleep.lua`: neither relies on the bed being movable.
- **No Lua script and no `house.cpp` reads the `moveable` flag for beds.** Grepped the whole project.
- **Minimal change:** 5 lines removed, 5 tags collapsed to self-closing. No C++, no Lua, no OTB.

## Affected items

| Range | Item | Before | After |
|---|---|---|---|
| 1754-1755 | bed | `moveable=true` | (no attributes) |
| 1756-1759 | cot | `moveable=true` | (no attributes) |
| 1760-1761 | bed | `moveable=true` | (no attributes) |
| 3836-3839 | hammock | `moveable=true` | (no attributes) |
| 5496-5499 | straw mat | `moveable=true` | (no attributes) |

## Test plan

- [ ] Spawn a monster with `canpushitems="1"` (e.g. `rat`) next to a bed (ID 1754) on an open tile outside a house
- [ ] Verify the bed **stays on the same tile** after the monster walks past several times
- [ ] Lie down on a bed with a premium character in a PZ → should sleep normally (ID transform still works)
- [ ] Log back in → should wake up to the original ID
- [ ] Verify GMs can still create/remove beds via `/i` and admin commands
- [ ] Repeat the test with a hammock (3836) and a straw mat (5496)