### PR TITLE
fix(creature): invert follower path-update throttle check

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -901,7 +901,7 @@ void Creature::updateFollowersPaths()
 	            std::ranges::to<decltype(followers)>();
 
 	for (const auto& follower : followers | tfs::views::lock_weak_ptrs) {
-		if (follower->lastPathUpdate < std::chrono::steady_clock::now()) {
+		if (follower->lastPathUpdate >= std::chrono::steady_clock::now()) {
 			continue;
 		}
 


### PR DESCRIPTION
## Summary

Candidate fix for the progressive pathfinding/AI lag reported in atlas-kit/atlas#144.

The throttle check in `Creature::updateFollowersPaths` ([`src/creature.cpp` L900-L907](https://github.com/atlas-kit/atlas/blob/dev/src/creature.cpp#L900-L907)) was inverted relative to how `lastPathUpdate` is used elsewhere in the same file:

- `Creature::forceUpdatePath` (L145) sets `lastPathUpdate = now + PATHFINDING_DELAY` — i.e. `lastPathUpdate` stores the **next allowed** update time.
- `Creature::onWalk` (L194) uses `if (lastPathUpdate < now)` to mean *cooldown has expired → schedule update + reset*.
- `Creature::updateFollowersPaths` used the **same condition** but with `continue` inside — so it skipped followers whose cooldown had expired, and instead scheduled an `updateCreatureWalk` (A*) for followers **still inside the cooldown**, while pushing the cooldown forward.

### Change

```diff
 for (const auto& follower : followers | tfs::views::lock_weak_ptrs) {
-    if (follower->lastPathUpdate < std::chrono::steady_clock::now()) {
+    if (follower->lastPathUpdate >= std::chrono::steady_clock::now()) {
         continue;
     }

     g_dispatcher.addTask(createTask([id = follower->getID()]() { g_game.updateCreatureWalk(id); }));
     follower->lastPathUpdate = std::chrono::steady_clock::now() + std::chrono::milliseconds{getNumber(ConfigManager::PATHFINDING_DELAY)};
 }
```

One line. Same semantics now as the throttle on L194.

### Why this matches atlas-kit/atlas#144

When a creature starts chasing/following another (`setFollowCreature` at L865-L880), it adds itself to the target's `followers` set and calls `forceUpdatePath()` on itself, which sets `lastPathUpdate = now + 300ms` (default `pathfindingDelay`).

Each time the *target* takes a step, its `onWalk` calls `updateFollowersPaths` on its `followers`. With the bugged check:
1. For followers whose cooldown is still active (always the case while master walks faster than 300ms/tile — which is normal), the code schedules an A* path update **and bumps the cooldown forward to `now + 300ms` again**.
2. As long as the master keeps walking, the follower's cooldown never expires → an A* is scheduled on **every** master walk tick **per follower**.
3. `updateCreatureWalk` → `goToFollowCreature` → `updateFollowCreaturePath` → `getPathTo` (`Map::getPathMatching`, A*). Expensive.

With N followers chasing one master, that's N redundant A* invocations enqueued per master step. The dispatcher queue grows faster than it drains under heavy load, which explains:

- "Lag scales with number of active creatures" — N followers × steps/sec
- "Progressive lag" — dispatcher backlog grows over time
- "Increasing input/movement latency for the player" — player's own walk events compete with the backlog
- "Spread across screen, mutual combat" — maximizes follower-set sizes and chase rates

## :warning: This may not be the real (or only) cause

I want to be explicit about the limits of this diagnosis:

- **I have not reproduced the issue under a profiler.** The diagnosis is purely from reading the code and finding a condition that is internally inconsistent with the rest of the file and is consistent with the symptoms.
- **There may be additional contributors** to the lag (SpectatorCache invalidation, condition tick storms, Lua event scheduling, summon despawn checks on every move, etc.). Fixing this throttle could reduce the lag without eliminating it entirely.
- **The bug is inherited from upstream TFS.** I initially thought the `followers` architecture was atlas-specific, but tracing the history showed `updateFollowersPaths` came from OTLand TFS [PR #4637 "Optimize pathfinding"](https://github.com/otland/forgottenserver/pull/4637) (commit `8fe2872c`), and the inverted check has been there since then. The reporter's comment that "the problem wasn't present in TFS" may refer to a TFS revision predating PR #4637, or to a test with smaller follower density. The bug is real in atlas regardless.
- **The fix changes the timing of follower path updates.** Previously, followers got spammed with redundant A* during the cooldown window and never got a single legitimate update from this code path (since the cooldown-expired branch did `continue`). After the fix, each follower gets at most one A* per `pathfindingDelay` (300ms default) window, and a legitimate update when the cooldown actually expires. If anything in the codebase silently relied on the broken "spam A* until cooldown" behavior to keep summons visually glued to the master, that may need a separate look — but I see no evidence of such a dependency.

### Suggested verification before merge

1. With many summons or monsters spread across the screen (the repro from atlas-kit/atlas#144), check the dispatcher task count / tick time before vs. after this patch.
2. Confirm that follower behavior (summons keeping up with their master, monsters chasing targets) is still correct after the change — both visually and in combat.
3. Ideally run with a profiler (Tracy / `perf`) and confirm `Map::getPathMatching` / `updateCreatureWalk` time goes down.

If verification shows this didn't fully fix atlas-kit/atlas#144, the patch is still correct on its own merits (the inversion is a logic bug regardless of #144), and atlas-kit/atlas#144 can stay open for further investigation.

Refs atlas-kit/atlas#144.

## Test plan

- [ ] Build succeeds (CI)
- [ ] Repro scenario from atlas-kit/atlas#144 (many summons + monsters spread on screen, mutual combat, player movement) shows reduced/no progressive lag
- [ ] Summons still follow their master correctly after the change
- [ ] Monsters still chase/attack targets correctly after the change

:robot: Generated with [Claude Code](https://claude.com/claude-code)