### PR TITLE
fix(creature): remove unreachable destructor assertion on conditions

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -28,7 +28,6 @@ Creature::~Creature()
 		summon->setAttackedCreature(nullptr);
 		summon->removeMaster();
 	}
-	assert(conditions.empty());
 }
 
 bool Creature::canSee(const Position& myPos, const Position& pos, int32_t viewRangeX, int32_t viewRangeY)


### PR DESCRIPTION
Closes #151

## What was happening (in plain terms)

Every creature in the server (player, monster, NPC) can have active "conditions" — things like poison, fire, paralyze, mana regeneration, etc. These conditions live inside the creature object for as long as they last.

The `Creature` destructor (the function that runs when the object is wiped from memory) had a check that essentially said: **"if we got here and conditions is not empty, something is wrong — crash the server"**. That check was `assert(conditions.empty())`.

The problem is that this expectation isn't always true. On the normal path, when a creature dies or leaves the map, `Game::removeCreature` clears the conditions before the object is destroyed. But there are paths where this doesn't happen — the most obvious one is **server shutdown**: when the game shuts down, the containers holding players/monsters/NPCs are destroyed directly, without calling `removeCreature` on each one. The creatures still have active conditions, the `assert` fires, and the server crashes with:

```
Assertion failed: conditions.empty(), file src/creature.cpp, line 31
```

## What changed

Just removed the assertion.

The `conditions` field is `std::vector<std::unique_ptr<Condition>>`. When a `Creature` is destroyed, the vector is destroyed automatically, and each `unique_ptr` automatically deletes the `Condition` it owns. No manual cleanup is needed — the assertion was the only thing turning a tolerable situation into a crash.

## Why this fix is safe

- **It doesn't change the normal flow:** when a creature is removed from the map via `Game::removeCreature`, conditions are still cleared exactly as before (with `endCondition()` and `onEndCondition()` firing normally). The destructor's job is just to release memory, which the `unique_ptr` vector already handles.
- **No memory leaks:** `std::unique_ptr` guarantees the `Condition` is deleted when the vector goes out of scope.
- **It avoids unsafe calls:** we don't try to fire `endCondition()` / `onEndCondition()` from inside the destructor, which would be undefined behavior (`asCreature()` uses `shared_from_this()`, and virtual methods would dispatch to a partially-destroyed object).

## What may change in behavior

If a condition was being destroyed outside the normal flow, its `endCondition()` wasn't called **and the server crashed**. Now `endCondition()` still isn't called in that case, but the server keeps running. In practice, during shutdown this is harmless — there is nobody left to observe the condition ending. At runtime, if a creature is being destroyed without `removeCreature`, the game state was already inconsistent — this fix just prevents that from turning into a crash.

## How to test

1. Start the server and let players/monsters accumulate active conditions (poison, paralyze, regen, summons).
2. Shut the server down (`/shutdown`).
3. Before: crash with the assertion message. After: clean shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and robustness during resource cleanup operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->