### PR TITLE
refactor(condition): migrate condition system to smart pointers

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -609,9 +609,9 @@ void Combat::doCombat(const std::shared_ptr<Creature>& caster, const std::shared
 			if (params.origin != ORIGIN_MELEE) {
 				for (const auto& condition : params.conditionList) {
 					if (caster == target || !target->isImmune(condition->getType())) {
-						Condition* conditionCopy = condition->clone();
+						auto conditionCopy = condition->clone();
 						conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
-						target->addCombatCondition(conditionCopy);
+						target->addCombatCondition(std::move(conditionCopy));
 					}
 				}
 			}
@@ -693,13 +693,13 @@ void Combat::doCombat(const std::shared_ptr<Creature>& caster, const Position& p
 					    (caster != creature && Combat::canDoCombat(caster, creature) == RETURNVALUE_NOERROR)) {
 						for (const auto& condition : params.conditionList) {
 							if (caster == creature || !creature->isImmune(condition->getType())) {
-								Condition* conditionCopy = condition->clone();
+								auto conditionCopy = condition->clone();
 								if (caster) {
 									conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
 								}
 
 								// TODO: infight condition until all aggressive conditions has ended
-								creature->addCombatCondition(conditionCopy);
+								creature->addCombatCondition(std::move(conditionCopy));
 							}
 						}
 					}
@@ -767,13 +767,13 @@ void Combat::doTargetCombat(const std::shared_ptr<Creature>& caster, const std::
 		if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
 			for (const auto& condition : params.conditionList) {
 				if (caster == target || !target->isImmune(condition->getType())) {
-					Condition* conditionCopy = condition->clone();
+					auto conditionCopy = condition->clone();
 					if (caster) {
 						conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
 					}
 
 					// TODO: infight condition until all aggressive conditions has ended
-					target->addCombatCondition(conditionCopy);
+					target->addCombatCondition(std::move(conditionCopy));
 				}
 			}
 		}
@@ -935,13 +935,13 @@ void Combat::doAreaCombat(const std::shared_ptr<Creature>& caster, const Positio
 			if (damage.blockType == BLOCK_NONE || damage.blockType == BLOCK_ARMOR) {
 				for (const auto& condition : params.conditionList) {
 					if (caster == creature || !creature->isImmune(condition->getType())) {
-						Condition* conditionCopy = condition->clone();
+						auto conditionCopy = condition->clone();
 						if (caster) {
 							conditionCopy->setParam(CONDITION_PARAM_OWNER, caster->getID());
 						}
 
 						// TODO: infight condition until all aggressive conditions has ended
-						creature->addCombatCondition(conditionCopy);
+						creature->addCombatCondition(std::move(conditionCopy));
 					}
 				}
 			}
@@ -1334,7 +1334,7 @@ void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 	}
 
 	if (const ItemType& it = items[getID()]; it.conditionDamage) {
-		Condition* conditionCopy = it.conditionDamage->clone();
+		auto conditionCopy = it.conditionDamage->clone();
 
 		if (uint32_t ownerId = getOwner()) {
 			bool harmfulField = true;
@@ -1360,6 +1360,6 @@ void MagicField::onStepInField(const std::shared_ptr<Creature>& creature)
 			}
 		}
 
-		creature->addCondition(conditionCopy);
+		creature->addCondition(std::move(conditionCopy));
 	}
 }

--- a/src/combat.h
+++ b/src/combat.h
@@ -41,7 +41,7 @@ public:
 
 struct CombatParams
 {
-	std::vector<std::unique_ptr<const Condition>> conditionList = {};
+	std::vector<std::unique_ptr<Condition>> conditionList = {};
 
 	std::unique_ptr<ValueCallback> valueCallback = nullptr;
 	std::unique_ptr<TileCallback> tileCallback = nullptr;
@@ -118,7 +118,7 @@ public:
 
 	void setArea(AreaCombat* area);
 	bool hasArea() const { return area != nullptr; }
-	void addCondition(const Condition* condition) { params.conditionList.emplace_back(condition); }
+	void addCondition(std::unique_ptr<Condition> condition) { params.conditionList.push_back(std::move(condition)); }
 	void clearConditions() { params.conditionList.clear(); }
 	void setPlayerCombatValues(formulaType_t formulaType, double mina, double minb, double maxa, double maxb);
 	void postCombatEffects(const std::shared_ptr<Creature>& caster, const Position& pos) const

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -164,8 +164,9 @@ bool Condition::executeCondition(const std::shared_ptr<Creature>&, int32_t inter
 	return getEndTime() >= OTSYS_TIME();
 }
 
-Condition* Condition::createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param /* = 0*/,
-                                      bool buff /* = false*/, uint32_t subId /* = 0*/, bool aggressive /* = false */)
+std::unique_ptr<Condition> Condition::createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks,
+                                                      int32_t param /* = 0*/, bool buff /* = false*/,
+                                                      uint32_t subId /* = 0*/, bool aggressive /* = false */)
 {
 	switch (type) {
 		case CONDITION_POISON:
@@ -176,38 +177,39 @@ Condition* Condition::createCondition(ConditionId_t id, ConditionType_t type, in
 		case CONDITION_DAZZLED:
 		case CONDITION_CURSED:
 		case CONDITION_BLEEDING:
-			return new ConditionDamage(id, type, buff, subId, aggressive);
+			return std::make_unique<ConditionDamage>(id, type, buff, subId, aggressive);
 
 		case CONDITION_HASTE:
 		case CONDITION_PARALYZE:
-			return new ConditionSpeed(id, type, ticks, buff, subId, param, aggressive);
+			return std::make_unique<ConditionSpeed>(id, type, ticks, buff, subId, param, aggressive);
 
 		case CONDITION_INVISIBLE:
-			return new ConditionInvisible(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionInvisible>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_OUTFIT:
-			return new ConditionOutfit(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionOutfit>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_LIGHT:
-			return new ConditionLight(id, type, ticks, buff, subId, param & 0xFF, (param & 0xFF00) >> 8, aggressive);
+			return std::make_unique<ConditionLight>(id, type, ticks, buff, subId, param & 0xFF, (param & 0xFF00) >> 8,
+			                                        aggressive);
 
 		case CONDITION_REGENERATION:
-			return new ConditionRegeneration(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionRegeneration>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_SOUL:
-			return new ConditionSoul(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionSoul>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_ATTRIBUTES:
-			return new ConditionAttributes(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionAttributes>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_SPELLCOOLDOWN:
-			return new ConditionSpellCooldown(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionSpellCooldown>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_SPELLGROUPCOOLDOWN:
-			return new ConditionSpellGroupCooldown(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionSpellGroupCooldown>(id, type, ticks, buff, subId, aggressive);
 
 		case CONDITION_DRUNK:
-			return new ConditionDrunk(id, type, ticks, buff, subId, param, aggressive);
+			return std::make_unique<ConditionDrunk>(id, type, ticks, buff, subId, param, aggressive);
 
 		case CONDITION_INFIGHT:
 		case CONDITION_EXHAUST_WEAPON:
@@ -218,18 +220,18 @@ Condition* Condition::createCondition(ConditionId_t id, ConditionType_t type, in
 		case CONDITION_YELLTICKS:
 		case CONDITION_PACIFIED:
 		case CONDITION_MANASHIELD:
-			return new ConditionGeneric(id, type, ticks, buff, subId, aggressive);
 		case CONDITION_ROOT:
-			return new ConditionGeneric(id, type, ticks, buff, subId, aggressive);
+			return std::make_unique<ConditionGeneric>(id, type, ticks, buff, subId, aggressive);
+
 		case CONDITION_MANASHIELD_BREAKABLE:
-			return new ConditionManaShield(id, type, ticks, buff, subId);
+			return std::make_unique<ConditionManaShield>(id, type, ticks, buff, subId);
 
 		default:
 			return nullptr;
 	}
 }
 
-Condition* Condition::createCondition(PropStream& propStream)
+std::unique_ptr<Condition> Condition::createCondition(PropStream& propStream)
 {
 	uint8_t attr;
 	if (!propStream.read<uint8_t>(attr) || attr != CONDITIONATTR_TYPE) {

--- a/src/condition.h
+++ b/src/condition.h
@@ -4,6 +4,8 @@
 #ifndef FS_CONDITION_H
 #define FS_CONDITION_H
 
+#include <memory>
+
 #include "enums.h"
 
 class Creature;
@@ -81,7 +83,7 @@ public:
 	ConditionId_t getId() const { return id; }
 	uint32_t getSubId() const { return subId; }
 
-	virtual Condition* clone() const = 0;
+	virtual std::unique_ptr<Condition> clone() const = 0;
 
 	ConditionType_t getType() const { return conditionType; }
 	int64_t getEndTime() const { return endTime; }
@@ -89,9 +91,10 @@ public:
 	void setTicks(int32_t newTicks);
 	bool isAggressive() const { return aggressive; }
 
-	static Condition* createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks, int32_t param = 0,
-	                                  bool buff = false, uint32_t subId = 0, bool aggressive = false);
-	static Condition* createCondition(PropStream& propStream);
+	static std::unique_ptr<Condition> createCondition(ConditionId_t id, ConditionType_t type, int32_t ticks,
+	                                                  int32_t param = 0, bool buff = false, uint32_t subId = 0,
+	                                                  bool aggressive = false);
+	static std::unique_ptr<Condition> createCondition(PropStream& propStream);
 
 	virtual bool setParam(ConditionParam_t param, int32_t value);
 	virtual int32_t getParam(ConditionParam_t param);
@@ -131,7 +134,7 @@ public:
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 	uint64_t getIcons() const override;
 
-	ConditionGeneric* clone() const override { return new ConditionGeneric(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionGeneric>(*this); }
 };
 
 class ConditionAttributes final : public ConditionGeneric
@@ -150,7 +153,7 @@ public:
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
 
-	ConditionAttributes* clone() const override { return new ConditionAttributes(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionAttributes>(*this); }
 
 	// serialization
 	void serialize(PropWriteStream& propWriteStream) override;
@@ -188,7 +191,7 @@ public:
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
 
-	ConditionRegeneration* clone() const override { return new ConditionRegeneration(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionRegeneration>(*this); }
 
 	// serialization
 	void serialize(PropWriteStream& propWriteStream) override;
@@ -218,7 +221,7 @@ public:
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
 
-	ConditionSoul* clone() const override { return new ConditionSoul(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionSoul>(*this); }
 
 	// serialization
 	void serialize(PropWriteStream& propWriteStream) override;
@@ -241,7 +244,7 @@ public:
 	bool startCondition(const std::shared_ptr<Creature>& creature) override;
 	void endCondition(const std::shared_ptr<Creature>& creature) override;
 
-	ConditionInvisible* clone() const override { return new ConditionInvisible(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionInvisible>(*this); }
 };
 
 class ConditionDamage final : public Condition
@@ -261,7 +264,7 @@ public:
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 	uint64_t getIcons() const override;
 
-	ConditionDamage* clone() const override { return new ConditionDamage(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionDamage>(*this); }
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
@@ -314,7 +317,7 @@ public:
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 	uint64_t getIcons() const override;
 
-	ConditionSpeed* clone() const override { return new ConditionSpeed(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionSpeed>(*this); }
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
@@ -348,7 +351,7 @@ public:
 	void endCondition(const std::shared_ptr<Creature>& creature) override;
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
-	ConditionOutfit* clone() const override { return new ConditionOutfit(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionOutfit>(*this); }
 
 	void setOutfit(const Outfit_t& outfit);
 
@@ -373,7 +376,7 @@ public:
 	void endCondition(const std::shared_ptr<Creature>& creature) override;
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
-	ConditionLight* clone() const override { return new ConditionLight(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionLight>(*this); }
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	int32_t getParam(ConditionParam_t param) override;
@@ -399,7 +402,7 @@ public:
 	bool startCondition(const std::shared_ptr<Creature>& creature) override;
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
-	ConditionSpellCooldown* clone() const override { return new ConditionSpellCooldown(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionSpellCooldown>(*this); }
 };
 
 class ConditionSpellGroupCooldown final : public ConditionGeneric
@@ -413,7 +416,7 @@ public:
 	bool startCondition(const std::shared_ptr<Creature>& creature) override;
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
-	ConditionSpellGroupCooldown* clone() const override { return new ConditionSpellGroupCooldown(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionSpellGroupCooldown>(*this); }
 };
 
 class ConditionDrunk final : public Condition
@@ -434,7 +437,7 @@ public:
 	bool setParam(ConditionParam_t param, int32_t value) override;
 	void addCondition(const std::shared_ptr<Creature>& creature, const Condition* condition) override;
 
-	ConditionDrunk* clone() const override { return new ConditionDrunk(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionDrunk>(*this); }
 
 private:
 	uint8_t drunkenness = 25;
@@ -457,7 +460,7 @@ public:
 
 	bool setParam(ConditionParam_t param, int32_t value) override;
 
-	ConditionManaShield* clone() const override { return new ConditionManaShield(*this); }
+	std::unique_ptr<Condition> clone() const override { return std::make_unique<ConditionManaShield>(*this); }
 
 	// serialization
 	void serialize(PropWriteStream& propWriteStream) override;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -560,7 +560,7 @@ void Creature::onDeath()
 		g_game.removeCreature(asCreature(), false);
 	} else {
 		while (!conditions.empty()) {
-			removeCondition(conditions.back(), true);
+			removeCondition(conditions.back().get(), true);
 		}
 	}
 }
@@ -1073,7 +1073,7 @@ bool Creature::setMaster(const std::shared_ptr<Creature>& newMaster)
 	return true;
 }
 
-bool Creature::addCondition(Condition* condition, bool force /* = false*/)
+bool Creature::addCondition(std::unique_ptr<Condition> condition, bool force /* = false*/)
 {
 	if (!condition) {
 		return false;
@@ -1082,35 +1082,37 @@ bool Creature::addCondition(Condition* condition, bool force /* = false*/)
 	if (!force && condition->getType() == CONDITION_HASTE && hasCondition(CONDITION_PARALYZE)) {
 		int64_t walkDelay = getWalkDelay();
 		if (walkDelay > 0) {
-			g_scheduler.addEvent(
-			    createSchedulerTask(walkDelay, [=, id = getID()]() { g_game.forceAddCondition(id, condition); }));
+			auto conditionClone = condition->clone();
+			g_scheduler.addEvent(createSchedulerTask(
+			    walkDelay,
+			    [id = getID(), c = std::shared_ptr<Condition>(conditionClone.release())]() {
+				    g_game.forceAddCondition(id, c->clone());
+			    }));
 			return false;
 		}
 	}
 
 	Condition* prevCond = getCondition(condition->getType(), condition->getId(), condition->getSubId());
 	if (prevCond) {
-		prevCond->addCondition(asCreature(), condition);
-		delete condition;
+		prevCond->addCondition(asCreature(), condition.get());
 		return true;
 	}
 
 	if (condition->startCondition(asCreature())) {
-		conditions.push_back(condition);
-		onAddCondition(condition->getType());
+		ConditionType_t type = condition->getType();
+		conditions.push_back(std::move(condition));
+		onAddCondition(type);
 		return true;
 	}
 
-	delete condition;
 	return false;
 }
 
-bool Creature::addCombatCondition(Condition* condition)
+bool Creature::addCombatCondition(std::unique_ptr<Condition> condition)
 {
-	// Caution: condition variable could be deleted after the call to addCondition
 	ConditionType_t type = condition->getType();
 
-	if (!addCondition(condition)) {
+	if (!addCondition(std::move(condition))) {
 		return false;
 	}
 
@@ -1122,8 +1124,7 @@ void Creature::removeCondition(ConditionType_t type, bool force /* = false*/)
 {
 	auto it = conditions.begin();
 	while (it != conditions.end()) {
-		Condition* condition = *it;
-		if (condition->getType() != type) {
+		if ((*it)->getType() != type) {
 			++it;
 			continue;
 		}
@@ -1137,10 +1138,10 @@ void Creature::removeCondition(ConditionType_t type, bool force /* = false*/)
 			}
 		}
 
+		auto condition = std::move(*it);
 		it = conditions.erase(it);
 
 		condition->endCondition(asCreature());
-		delete condition;
 
 		onEndCondition(type);
 	}
@@ -1150,8 +1151,7 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 {
 	auto it = conditions.begin();
 	while (it != conditions.end()) {
-		Condition* condition = *it;
-		if (condition->getType() != type || condition->getId() != conditionId) {
+		if ((*it)->getType() != type || (*it)->getId() != conditionId) {
 			++it;
 			continue;
 		}
@@ -1165,10 +1165,10 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 			}
 		}
 
+		auto condition = std::move(*it);
 		it = conditions.erase(it);
 
 		condition->endCondition(asCreature());
-		delete condition;
 
 		onEndCondition(type);
 	}
@@ -1177,9 +1177,9 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 void Creature::removeCombatCondition(ConditionType_t type)
 {
 	std::vector<Condition*> removeConditions;
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getType() == type) {
-			removeConditions.push_back(condition);
+			removeConditions.push_back(condition.get());
 		}
 	}
 
@@ -1190,7 +1190,8 @@ void Creature::removeCombatCondition(ConditionType_t type)
 
 void Creature::removeCondition(Condition* condition, bool force /* = false*/)
 {
-	auto it = std::find(conditions.begin(), conditions.end(), condition);
+	auto it = std::find_if(conditions.begin(), conditions.end(),
+	                        [condition](const std::unique_ptr<Condition>& c) { return c.get() == condition; });
 	if (it == conditions.end()) {
 		return;
 	}
@@ -1204,18 +1205,18 @@ void Creature::removeCondition(Condition* condition, bool force /* = false*/)
 		}
 	}
 
+	auto owned = std::move(*it);
 	conditions.erase(it);
 
-	condition->endCondition(asCreature());
-	onEndCondition(condition->getType());
-	delete condition;
+	owned->endCondition(asCreature());
+	onEndCondition(owned->getType());
 }
 
 Condition* Creature::getCondition(ConditionType_t type) const
 {
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getType() == type) {
-			return condition;
+			return condition.get();
 		}
 	}
 	return nullptr;
@@ -1223,9 +1224,9 @@ Condition* Creature::getCondition(ConditionType_t type) const
 
 Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionId, uint32_t subId /* = 0*/) const
 {
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getType() == type && condition->getId() == conditionId && condition->getSubId() == subId) {
-			return condition;
+			return condition.get();
 		}
 	}
 	return nullptr;
@@ -1233,20 +1234,27 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(uint32_t interval)
 {
-	auto tempConditions = conditions;
+	std::vector<Condition*> tempConditions;
+	tempConditions.reserve(conditions.size());
+	for (const auto& condition : conditions) {
+		tempConditions.push_back(condition.get());
+	}
+
 	for (Condition* condition : tempConditions) {
-		auto it = std::find(conditions.begin(), conditions.end(), condition);
+		auto it = std::find_if(conditions.begin(), conditions.end(),
+		                        [condition](const std::unique_ptr<Condition>& c) { return c.get() == condition; });
 		if (it == conditions.end()) {
 			continue;
 		}
 
 		if (!condition->executeCondition(asCreature(), interval)) {
-			it = std::find(conditions.begin(), conditions.end(), condition);
+			it = std::find_if(conditions.begin(), conditions.end(),
+			                   [condition](const std::unique_ptr<Condition>& c) { return c.get() == condition; });
 			if (it != conditions.end()) {
+				auto owned = std::move(*it);
 				conditions.erase(it);
-				condition->endCondition(asCreature());
-				onEndCondition(condition->getType());
-				delete condition;
+				owned->endCondition(asCreature());
+				onEndCondition(owned->getType());
 			}
 		}
 	}
@@ -1259,7 +1267,7 @@ bool Creature::hasCondition(ConditionType_t type, uint32_t subId /* = 0*/) const
 	}
 
 	int64_t timeNow = OTSYS_TIME();
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getType() != type || condition->getSubId() != subId) {
 			continue;
 		}
@@ -1436,7 +1444,7 @@ bool FrozenPathingConditionCall::operator()(const Position& startPos, const Posi
 
 bool Creature::isInvisible() const
 {
-	return std::find_if(conditions.begin(), conditions.end(), [](const Condition* condition) {
+	return std::find_if(conditions.begin(), conditions.end(), [](const std::unique_ptr<Condition>& condition) {
 		       return condition->getType() == CONDITION_INVISIBLE;
 	       }) != conditions.end();
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -238,8 +238,8 @@ public:
 	virtual float getAttackFactor() const { return 1.0f; }
 	virtual float getDefenseFactor() const { return 1.0f; }
 
-	bool addCondition(Condition* condition, bool force = false);
-	bool addCombatCondition(Condition* condition);
+	bool addCondition(std::unique_ptr<Condition> condition, bool force = false);
+	bool addCombatCondition(std::unique_ptr<Condition> condition);
 	void removeCondition(ConditionType_t type, ConditionId_t conditionId, bool force = false);
 	void removeCondition(ConditionType_t type, bool force = false);
 	void removeCondition(Condition* condition, bool force = false);
@@ -365,7 +365,7 @@ protected:
 		int64_t ticks;
 	};
 
-	std::vector<Condition*> conditions;
+	std::vector<std::unique_ptr<Condition>> conditions;
 	CreatureIconHashMap creatureIcons;
 
 	std::vector<Direction> listWalkDir;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -562,8 +562,8 @@ bool Game::removeCreature(const std::shared_ptr<Creature>& creature, bool isLogo
 		creature->setMaster(nullptr);
 	}
 
-	for (const auto& condition : creature->getConditions()) {
-		creature->removeCondition(condition, true);
+	while (!creature->getConditions().empty()) {
+		creature->removeCondition(creature->getConditions().back().get(), true);
 	}
 
 	creature->getParent()->postRemoveNotification(creature, nullptr, 0);
@@ -3552,8 +3552,7 @@ bool Game::playerYell(const std::shared_ptr<Player>& player, const std::string& 
 			}
 		}
 
-		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_YELLTICKS, 30000, 0);
-		player->addCondition(condition);
+		player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_YELLTICKS, 30000, 0));
 	}
 
 	internalCreatureSay(player, TALKTYPE_YELL, boost::algorithm::to_upper_copy(text), false);
@@ -5374,15 +5373,14 @@ std::vector<std::shared_ptr<Item>> Game::getMarketItemList(uint16_t wareId, uint
 	return {};
 }
 
-void Game::forceAddCondition(uint32_t creatureId, Condition* condition)
+void Game::forceAddCondition(uint32_t creatureId, std::unique_ptr<Condition> condition)
 {
 	const auto& creature = getCreatureByID(creatureId);
 	if (!creature) {
-		delete condition;
 		return;
 	}
 
-	creature->addCondition(condition, true);
+	creature->addCondition(std::move(condition), true);
 }
 
 void Game::forceRemoveCondition(uint32_t creatureId, ConditionType_t type)

--- a/src/game.h
+++ b/src/game.h
@@ -80,7 +80,7 @@ public:
 
 	void start(ServiceManager* manager);
 
-	void forceAddCondition(uint32_t creatureId, Condition* condition);
+	void forceAddCondition(uint32_t creatureId, std::unique_ptr<Condition> condition);
 	void forceRemoveCondition(uint32_t creatureId, ConditionType_t type);
 
 	void loadMainMap(const std::string& filename);

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -191,12 +191,10 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 	PropStream propStream;
 	propStream.init(conditions.data(), conditions.size());
 
-	Condition* condition = Condition::createCondition(propStream);
+	auto condition = Condition::createCondition(propStream);
 	while (condition) {
 		if (condition->unserialize(propStream)) {
-			player->storedConditionList.push_front(condition);
-		} else {
-			delete condition;
+			player->storedConditionList.push_front(std::move(condition));
 		}
 		condition = Condition::createCondition(propStream);
 	}
@@ -602,7 +600,7 @@ bool IOLoginData::savePlayer(const std::shared_ptr<Player>& player)
 
 	// serialize conditions
 	PropWriteStream propWriteStream;
-	for (Condition* condition : player->conditions) {
+	for (const auto& condition : player->conditions) {
 		if (condition->isPersistent()) {
 			condition->serialize(propWriteStream);
 			propWriteStream.write<uint8_t>(CONDITIONATTR_END);

--- a/src/lua/modules/combat.cpp
+++ b/src/lua/modules/combat.cpp
@@ -132,6 +132,7 @@ int luaCombatAddCondition(lua_State* L)
 	} else {
 		lua_pushnil(L);
 	}
+
 	return 1;
 }
 

--- a/src/lua/modules/condition.cpp
+++ b/src/lua/modules/condition.cpp
@@ -15,9 +15,9 @@ int luaConditionCreate(lua_State* L)
 	ConditionType_t conditionType = tfs::lua::getNumber<ConditionType_t>(L, 2);
 	ConditionId_t conditionId = tfs::lua::getNumber<ConditionId_t>(L, 3, CONDITIONID_COMBAT);
 
-	Condition* condition = Condition::createCondition(conditionId, conditionType, 0, 0);
+	auto condition = Condition::createCondition(conditionId, conditionType, 0, 0);
 	if (condition) {
-		tfs::lua::pushUserdata(L, condition);
+		tfs::lua::pushUserdata(L, condition.release());
 		tfs::lua::setMetatable(L, -1, "Condition");
 	} else {
 		lua_pushnil(L);
@@ -101,7 +101,7 @@ int luaConditionClone(lua_State* L)
 	// condition:clone()
 	Condition* condition = tfs::lua::getUserdata<Condition>(L, 1);
 	if (condition) {
-		tfs::lua::pushUserdata(L, condition->clone());
+		tfs::lua::pushUserdata(L, condition->clone().release());
 		tfs::lua::setMetatable(L, -1, "Condition");
 	} else {
 		lua_pushnil(L);

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -67,17 +67,17 @@ bool Monsters::reload()
 	return loadFromXml(true);
 }
 
-ConditionDamage* Monsters::getDamageCondition(ConditionType_t conditionType, int32_t maxDamage, int32_t minDamage,
-                                              int32_t startDamage, uint32_t tickInterval)
+std::unique_ptr<ConditionDamage> Monsters::getDamageCondition(ConditionType_t conditionType, int32_t maxDamage,
+                                                              int32_t minDamage, int32_t startDamage,
+                                                              uint32_t tickInterval)
 {
-	ConditionDamage* condition =
-	    static_cast<ConditionDamage*>(Condition::createCondition(CONDITIONID_COMBAT, conditionType, 0, 0));
+	auto condition = Condition::createCondition(CONDITIONID_COMBAT, conditionType, 0, 0);
 	condition->setParam(CONDITION_PARAM_TICKINTERVAL, tickInterval);
 	condition->setParam(CONDITION_PARAM_MINVALUE, minDamage);
 	condition->setParam(CONDITION_PARAM_MAXVALUE, maxDamage);
 	condition->setParam(CONDITION_PARAM_STARTVALUE, startDamage);
 	condition->setParam(CONDITION_PARAM_DELAYED, 1);
-	return condition;
+	return std::unique_ptr<ConditionDamage>(static_cast<ConditionDamage*>(condition.release()));
 }
 
 static int32_t getMaxMeleeDamage(int32_t attackSkill, int32_t attackValue)
@@ -291,8 +291,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 			}
 
 			if (conditionType != CONDITION_NONE) {
-				Condition* condition = getDamageCondition(conditionType, maxDamage, minDamage, 0, tickInterval);
-				combat->addCondition(condition);
+				combat->addCondition(getDamageCondition(conditionType, maxDamage, minDamage, 0, tickInterval));
 			}
 
 			sb.range = 1;
@@ -370,10 +369,10 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 				conditionType = CONDITION_PARALYZE;
 			}
 
-			ConditionSpeed* condition = static_cast<ConditionSpeed*>(
-			    Condition::createCondition(CONDITIONID_COMBAT, conditionType, duration, 0));
-			condition->setFormulaVars(minSpeedChange / 1000.0, 0, maxSpeedChange / 1000.0, 0);
-			combat->addCondition(condition);
+			auto speedCondition = Condition::createCondition(CONDITIONID_COMBAT, conditionType, duration, 0);
+			static_cast<ConditionSpeed*>(speedCondition.get())
+			    ->setFormulaVars(minSpeedChange / 1000.0, 0, maxSpeedChange / 1000.0, 0);
+			combat->addCondition(std::move(speedCondition));
 		} else if (tmpName == "outfit") {
 			int32_t duration = 10000;
 
@@ -384,21 +383,19 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 			if ((attr = node.attribute("monster"))) {
 				MonsterType* mType = g_monsters.getMonsterType(attr.as_string());
 				if (mType) {
-					ConditionOutfit* condition = static_cast<ConditionOutfit*>(
-					    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0));
-					condition->setOutfit(mType->info.outfit);
+					auto condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0);
+					static_cast<ConditionOutfit*>(condition.get())->setOutfit(mType->info.outfit);
 					combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
-					combat->addCondition(condition);
+					combat->addCondition(std::move(condition));
 				}
 			} else if ((attr = node.attribute("item"))) {
 				Outfit_t outfit;
 				outfit.lookTypeEx = pugi::cast<uint16_t>(attr.value());
 
-				ConditionOutfit* condition = static_cast<ConditionOutfit*>(
-				    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0));
-				condition->setOutfit(outfit);
+				auto condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0);
+				static_cast<ConditionOutfit*>(condition.get())->setOutfit(outfit);
 				combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
-				combat->addCondition(condition);
+				combat->addCondition(std::move(condition));
 			}
 		} else if (tmpName == "invisible") {
 			int32_t duration = 10000;
@@ -407,9 +404,9 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 				duration = pugi::cast<int32_t>(attr.value());
 			}
 
-			Condition* condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INVISIBLE, duration, 0);
+			auto condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INVISIBLE, duration, 0);
 			combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
-			combat->addCondition(condition);
+			combat->addCondition(std::move(condition));
 		} else if (tmpName == "drunk") {
 			int32_t duration = 10000;
 			uint8_t drunkenness = 25;
@@ -422,9 +419,8 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 				drunkenness = pugi::cast<uint8_t>(attr.value());
 			}
 
-			Condition* condition =
-			    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_DRUNK, duration, drunkenness);
-			combat->addCondition(condition);
+			combat->addCondition(
+			    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_DRUNK, duration, drunkenness));
 		} else if (tmpName == "firefield") {
 			combat->setParam(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL);
 		} else if (tmpName == "poisonfield") {
@@ -483,8 +479,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 				}
 			}
 
-			Condition* condition = getDamageCondition(conditionType, maxDamage, minDamage, startDamage, tickInterval);
-			combat->addCondition(condition);
+			combat->addCondition(getDamageCondition(conditionType, maxDamage, minDamage, startDamage, tickInterval));
 		} else if (tmpName == "strength") {
 			//
 		} else if (tmpName == "effect") {
@@ -629,9 +624,8 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			int32_t conMaxDamage = std::abs(spell->conditionMaxDamage);
 			int32_t startDamage = std::abs(spell->conditionStartDamage);
 
-			Condition* condition =
-			    getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval);
-			combat->addCondition(condition);
+			combat->addCondition(
+			    getDamageCondition(conditionType, conMaxDamage, conMinDamage, startDamage, tickInterval));
 		}
 
 		std::string tmpName = boost::algorithm::to_lower_copy(spell->name);
@@ -701,10 +695,10 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 				conditionType = CONDITION_PARALYZE;
 			}
 
-			ConditionSpeed* condition = static_cast<ConditionSpeed*>(
-			    Condition::createCondition(CONDITIONID_COMBAT, conditionType, duration, 0));
-			condition->setFormulaVars(minSpeedChange / 1000.0, 0, maxSpeedChange / 1000.0, 0);
-			combat->addCondition(condition);
+			auto speedCondition = Condition::createCondition(CONDITIONID_COMBAT, conditionType, duration, 0);
+			static_cast<ConditionSpeed*>(speedCondition.get())
+			    ->setFormulaVars(minSpeedChange / 1000.0, 0, maxSpeedChange / 1000.0, 0);
+			combat->addCondition(std::move(speedCondition));
 		} else if (tmpName == "outfit") {
 			int32_t duration = 10000;
 
@@ -712,11 +706,10 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 				duration = spell->duration;
 			}
 
-			ConditionOutfit* condition = static_cast<ConditionOutfit*>(
-			    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0));
-			condition->setOutfit(spell->outfit);
+			auto condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0);
+			static_cast<ConditionOutfit*>(condition.get())->setOutfit(spell->outfit);
 			combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
-			combat->addCondition(condition);
+			combat->addCondition(std::move(condition));
 		} else if (tmpName == "invisible") {
 			int32_t duration = 10000;
 
@@ -724,9 +717,9 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 				duration = spell->duration;
 			}
 
-			Condition* condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INVISIBLE, duration, 0);
+			auto condition = Condition::createCondition(CONDITIONID_COMBAT, CONDITION_INVISIBLE, duration, 0);
 			combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
-			combat->addCondition(condition);
+			combat->addCondition(std::move(condition));
 		} else if (tmpName == "drunk") {
 			int32_t duration = 10000;
 			uint8_t drunkenness = 25;
@@ -739,9 +732,8 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 				drunkenness = spell->drunkenness;
 			}
 
-			Condition* condition =
-			    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_DRUNK, duration, drunkenness);
-			combat->addCondition(condition);
+			combat->addCondition(
+			    Condition::createCondition(CONDITIONID_COMBAT, CONDITION_DRUNK, duration, drunkenness));
 		} else if (tmpName == "firefield") {
 			combat->setParam(COMBAT_PARAM_CREATEITEM, ITEM_FIREFIELD_PVP_FULL);
 		} else if (tmpName == "poisonfield") {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -264,8 +264,8 @@ public:
 	std::map<std::string, std::set<std::string>> bestiary;
 
 private:
-	ConditionDamage* getDamageCondition(ConditionType_t conditionType, int32_t maxDamage, int32_t minDamage,
-	                                    int32_t startDamage, uint32_t tickInterval);
+	std::unique_ptr<ConditionDamage> getDamageCondition(ConditionType_t conditionType, int32_t maxDamage,
+	                                                    int32_t minDamage, int32_t startDamage, uint32_t tickInterval);
 	bool deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, const std::string& description = "");
 
 	MonsterType* loadMonster(const std::string& file, const std::string& monsterName, bool reloading = false);

--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -713,14 +713,13 @@ ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, const std::shared_ptr<Pla
 	}
 
 	if (it.abilities->invisible) {
-		Condition* condition = Condition::createCondition(static_cast<ConditionId_t>(slot), CONDITION_INVISIBLE, -1, 0);
-		player->addCondition(condition);
+		player->addCondition(
+		    Condition::createCondition(static_cast<ConditionId_t>(slot), CONDITION_INVISIBLE, -1, 0));
 	}
 
 	if (it.abilities->manaShield) {
-		Condition* condition =
-		    Condition::createCondition(static_cast<ConditionId_t>(slot), CONDITION_MANASHIELD, -1, 0);
-		player->addCondition(condition);
+		player->addCondition(
+		    Condition::createCondition(static_cast<ConditionId_t>(slot), CONDITION_MANASHIELD, -1, 0));
 	}
 
 	if (it.abilities->speed != 0) {
@@ -733,7 +732,7 @@ ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, const std::shared_ptr<Pla
 	}
 
 	if (it.abilities->regeneration) {
-		Condition* condition =
+		auto condition =
 		    Condition::createCondition(static_cast<ConditionId_t>(slot), CONDITION_REGENERATION, -1, 0);
 
 		if (it.abilities->healthGain != 0) {
@@ -752,7 +751,7 @@ ReturnValue MoveEvent::EquipItem(MoveEvent* moveEvent, const std::shared_ptr<Pla
 			condition->setParam(CONDITION_PARAM_MANATICKS, it.abilities->manaTicks);
 		}
 
-		player->addCondition(condition);
+		player->addCondition(std::move(condition));
 	}
 
 	// skill modifiers

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -397,7 +397,7 @@ float Player::getDefenseFactor() const
 uint64_t Player::getClientIcons() const
 {
 	uint64_t icons = 0;
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (!isSuppress(condition->getType())) {
 			icons |= condition->getIcons();
 		}
@@ -1001,8 +1001,8 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 
 	if (isLogin) {
 		// Restore conditions stored during previous logout
-		for (Condition* condition : storedConditionList) {
-			addCondition(condition);
+		for (auto& condition : storedConditionList) {
+			addCondition(std::move(condition));
 		}
 		storedConditionList.clear();
 
@@ -1284,8 +1284,8 @@ void Player::onCreatureMove(const std::shared_ptr<Creature>& creature, const std
 	if (teleport || oldPos.z != newPos.z) {
 		int32_t ticks = getNumber(ConfigManager::STAIRHOP_DELAY);
 		if (ticks > 0) {
-			if (Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_PACIFIED, ticks, 0)) {
-				addCondition(condition);
+			if (auto condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_PACIFIED, ticks, 0)) {
+				addCondition(std::move(condition));
 			}
 		}
 	}
@@ -1504,7 +1504,7 @@ uint32_t Player::isMuted() const
 	}
 
 	int32_t muteTicks = 0;
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getType() == CONDITION_MUTED && condition->getTicks() > muteTicks) {
 			muteTicks = condition->getTicks();
 		}
@@ -1537,8 +1537,7 @@ void Player::removeMessageBuffer()
 
 			uint32_t muteTime = 5 * muteCount * muteCount;
 			muteCountMap[guid] = muteCount + 1;
-			Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_MUTED, muteTime * 1000, 0);
-			addCondition(condition);
+			addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_MUTED, muteTime * 1000, 0));
 
 			sendTextMessage(MESSAGE_STATUS_SMALL, std::format("You are muted for {:d} seconds.", muteTime));
 		}
@@ -2081,13 +2080,12 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 
 		auto it = conditions.begin();
 		while (it != conditions.end()) {
-			Condition* condition = *it;
-			if (condition->isPersistent()) {
+			if ((*it)->isPersistent()) {
+				auto condition = std::move(*it);
 				it = conditions.erase(it);
 
 				condition->endCondition(asPlayer());
 				onEndCondition(condition->getType());
-				delete condition;
 			} else {
 				++it;
 			}
@@ -2097,13 +2095,12 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 
 		auto it = conditions.begin();
 		while (it != conditions.end()) {
-			Condition* condition = *it;
-			if (condition->isPersistent()) {
+			if ((*it)->isPersistent()) {
+				auto condition = std::move(*it);
 				it = conditions.erase(it);
 
 				condition->endCondition(asPlayer());
 				onEndCondition(condition->getType());
-				delete condition;
 			} else {
 				++it;
 			}
@@ -2187,9 +2184,8 @@ void Player::addInFightTicks(bool pzlock /*= false*/)
 		pzLocked = true;
 	}
 
-	Condition* condition =
-	    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, getNumber(ConfigManager::PZ_LOCKED), 0);
-	addCondition(condition);
+	addCondition(
+	    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, getNumber(ConfigManager::PZ_LOCKED), 0));
 }
 
 void Player::kickPlayer(bool displayEffect)
@@ -3561,9 +3557,8 @@ bool Player::onKilledCreature(const std::shared_ptr<Creature>& target, bool last
 
 			if (lastHit && hasCondition(CONDITION_INFIGHT)) {
 				pzLocked = true;
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT,
-				                                                  getNumber(ConfigManager::WHITE_SKULL_TIME) * 1000, 0);
-				addCondition(condition);
+				addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT,
+				                                        getNumber(ConfigManager::WHITE_SKULL_TIME) * 1000, 0));
 			}
 		}
 	}
@@ -4493,7 +4488,7 @@ size_t Player::getMaxDepotItems() const
 std::forward_list<Condition*> Player::getMuteConditions() const
 {
 	std::forward_list<Condition*> muteConditions;
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getTicks() <= 0) {
 			continue;
 		}
@@ -4503,7 +4498,7 @@ std::forward_list<Condition*> Player::getMuteConditions() const
 			continue;
 		}
 
-		muteConditions.push_front(condition);
+		muteConditions.push_front(condition.get());
 	}
 	return muteConditions;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -1355,7 +1355,7 @@ private:
 	std::forward_list<std::weak_ptr<Party>> invitePartyList;
 	std::forward_list<uint32_t> modalWindows;
 	std::forward_list<std::string> learnedInstantSpellList;
-	std::forward_list<Condition*>
+	std::forward_list<std::unique_ptr<Condition>>
 	    storedConditionList; // TODO: This variable is only temporarily used when logging in, get rid of it somehow
 
 	std::string name;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -741,21 +741,18 @@ void Spell::postCastSpell(const std::shared_ptr<Player>& player, bool finishedCa
 	if (finishedCast) {
 		if (!player->hasFlag(PlayerFlag_HasNoExhaustion)) {
 			if (cooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-				                                                  cooldown, 0, false, spellId);
-				player->addCondition(condition);
+				player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
+				                                                cooldown, 0, false, spellId));
 			}
 
 			if (groupCooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-				                                                  groupCooldown, 0, false, group);
-				player->addCondition(condition);
+				player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
+				                                                groupCooldown, 0, false, group));
 			}
 
 			if (secondaryGroupCooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-				                                                  secondaryGroupCooldown, 0, false, secondaryGroup);
-				player->addCondition(condition);
+				player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
+				                                                secondaryGroupCooldown, 0, false, secondaryGroup));
 			}
 		}
 
@@ -865,22 +862,19 @@ bool InstantSpell::playerCastInstant(const std::shared_ptr<Player>& player, std:
 			if (!target || target->isRemoved() || target->isDead()) {
 				if (!casterTargetOrDirection) {
 					if (cooldown > 0) {
-						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-						                                                  cooldown, 0, false, spellId);
-						player->addCondition(condition);
+						player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
+						                                                cooldown, 0, false, spellId));
 					}
 
 					if (groupCooldown > 0) {
-						Condition* condition = Condition::createCondition(
-						    CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
-						player->addCondition(condition);
+						player->addCondition(Condition::createCondition(
+						    CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group));
 					}
 
 					if (secondaryGroupCooldown > 0) {
-						Condition* condition =
+						player->addCondition(
 						    Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-						                               secondaryGroupCooldown, 0, false, secondaryGroup);
-						player->addCondition(condition);
+						                               secondaryGroupCooldown, 0, false, secondaryGroup));
 					}
 
 					player->sendCancelMessage(ret);
@@ -929,21 +923,18 @@ bool InstantSpell::playerCastInstant(const std::shared_ptr<Player>& player, std:
 
 			if (ret != RETURNVALUE_NOERROR) {
 				if (cooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
-					                                                  cooldown, 0, false, spellId);
-					player->addCondition(condition);
+					player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN,
+					                                                cooldown, 0, false, spellId));
 				}
 
 				if (groupCooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-					                                                  groupCooldown, 0, false, group);
-					player->addCondition(condition);
+					player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
+					                                                groupCooldown, 0, false, group));
 				}
 
 				if (secondaryGroupCooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
-					                                                  secondaryGroupCooldown, 0, false, secondaryGroup);
-					player->addCondition(condition);
+					player->addCondition(Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN,
+					                                                secondaryGroupCooldown, 0, false, secondaryGroup));
 				}
 
 				player->sendCancelMessage(ret);


### PR DESCRIPTION
## Summary

- Replace raw pointer ownership with `std::unique_ptr<Condition>` throughout the condition system
- `Condition::createCondition()` and `clone()` now return `std::unique_ptr<Condition>`
- Creature/Player condition vectors store `std::unique_ptr<Condition>`, ownership transferred via `std::move()`
- Non-owning access (`getCondition()`, iteration) remains raw pointer
- Lua boundary uses `.release()` since Lua GC manages lifetime via `__gc`
- Scheduler lambda captures use `std::shared_ptr` bridge for `std::function` copyability

## Files changed (17)

**Core condition system:** `condition.h`, `condition.cpp`
**Creature/Player:** `creature.h`, `creature.cpp`, `player.h`, `player.cpp`
**Game:** `game.h`, `game.cpp`
**Combat:** `combat.h`, `combat.cpp`
**Monsters:** `monsters.h`, `monsters.cpp`
**IO:** `iologindata.cpp`
**Movement/Spells:** `movement.cpp`, `spells.cpp`
**Lua bindings:** `lua/modules/condition.cpp`, `lua/modules/combat.cpp`

## Test plan

- [ ] Verify conditions (poison, fire, energy, haste, outfit, invisible) apply and expire correctly
- [ ] Verify condition persistence through login/logout cycle
- [ ] Verify spell cooldowns work correctly
- [ ] Verify monster condition attacks (drunk, paralyze, poison) function properly
- [ ] Verify equipment conditions (rings, amulets) apply on equip and remove on deequip
- [ ] Verify no memory leaks via valgrind/ASAN

Closes https://github.com/atlas-kit/atlas/issues/40