### PR TITLE
fix(game): use safe loop to clear conditions on creature removal

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -557,8 +557,8 @@ bool Game::removeCreature(const std::shared_ptr<Creature>& creature, bool isLogo
 		creature->setMaster(nullptr);
 	}
 
-	for (const auto& condition : creature->getConditions()) {
-		creature->removeCondition(condition.get(), true);
+	while (!creature->getConditions().empty()) {
+		creature->removeCondition(creature->getConditions().back().get(), true);
 	}
 
 	creature->getParent()->postRemoveNotification(creature, nullptr, 0);


### PR DESCRIPTION
Closes #151 (follow-up to #230)

## What was happening (in plain terms)

Every creature (player, monster, NPC) can have active "conditions" — poison, fire, paralyze, regeneration, etc. These conditions are stored in a list inside the creature.

When a creature is removed from the game (leaves the map, dies, logs out), the server needs to clean up those conditions one by one. The code was doing this with a `for` loop — basically saying "go through each condition in the list and remove it."

The problem is: every time a condition is removed, it gets **deleted from the list while we're still walking through it**. Imagine you're reading a book and someone rips out the page you're about to turn to — that's what was happening to the loop's internal pointer. In C++ this is called **iterator invalidation**, and it's undefined behavior: the program might skip conditions, crash, or corrupt memory — anything can happen.

This bug was mostly silent because during normal gameplay most creatures have zero or one condition when removed, so the loop only runs once and the problem doesn't manifest. With two or more active conditions at removal time, the risk kicks in.

## What changed

Replaced the `for` loop with a `while` loop that always removes the **last** condition in the list, checking if the list is empty before each iteration. This is the same safe pattern already used in `Creature::onDeath` — no iterator involved, no invalidation possible.

**Before (broken):**
```cpp
for (const auto& condition : creature->getConditions()) {
    creature->removeCondition(condition.get(), true);  // erases from the list we're iterating
}
```

**After (safe):**
```cpp
while (!creature->getConditions().empty()) {
    creature->removeCondition(creature->getConditions().back().get(), true);
}
```

## Why this fix is safe

- The `while` loop doesn't rely on iterators — it just checks if the list is empty and always pops the last element.
- `removeCondition(..., true)` with `force=true` always erases the condition without deferring, so the loop always makes progress.
- This is the exact same pattern used in `Creature::onDeath` (src/creature.cpp), which has been working correctly.
- No change in behavior for the normal case — conditions are still fully cleaned up with `endCondition()` and `onEndCondition()` firing for each one.