### PR TITLE
docs(readme): update project name, links and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
-forgottenserver [![Build Status](https://github.com/otland/forgottenserver/actions/workflows/build-vcpkg.yml/badge.svg?branch=master)](https://github.com/otland/forgottenserver/actions/workflows/build-vcpkg.yml "vcpkg build status") [![Build Status](https://github.com/otland/forgottenserver/actions/workflows/docker-image.yml/badge.svg?branch=master)](https://github.com/otland/forgottenserver/actions/workflows/docker-image.yml "Docker image build status")
+Atlas
 ===============
 
-The Forgotten Server is a free and open-source MMORPG server emulator written in C++. It is a fork of the [OpenTibia Server](https://github.com/opentibia/server) project. To connect to the server, you can use [OTClient](https://github.com/mehah/otclient).
+[![Build with vcpkg](https://github.com/atlas-kit/atlas/actions/workflows/build-vcpkg.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/build-vcpkg.yml)
+[![Build with MSBuild](https://github.com/atlas-kit/atlas/actions/workflows/build-msbuild.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/build-msbuild.yml)
+[![Docker image](https://github.com/atlas-kit/atlas/actions/workflows/docker-image.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/docker-image.yml)
+[![Unit tests](https://github.com/atlas-kit/atlas/actions/workflows/test.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/test.yml)
+[![Code style](https://github.com/atlas-kit/atlas/actions/workflows/clang-format.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/clang-format.yml)
+[![Lua check](https://github.com/atlas-kit/atlas/actions/workflows/lua-check.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/lua-check.yml)
+[![XML syntax](https://github.com/atlas-kit/atlas/actions/workflows/xml-syntax.yml/badge.svg?branch=dev)](https://github.com/atlas-kit/atlas/actions/workflows/xml-syntax.yml)
+
+Atlas is a free and open-source MMORPG server emulator written in C++. It is a fork of the [Forgotten Server](https://github.com/otland/forgottenserver) project. To connect to the server, you can use [OTClient](https://github.com/mehah/otclient).
 
 ### Getting Started
 
-* [Compiling](compiling/README.md) — guides for [Linux](compiling/linux.md), [Windows (CMake)](compiling/windows-cmake.md), [Windows (Visual Studio)](compiling/windows-visual-studio.md) and [Docker](compiling/docker.md). Alternatively download [releases](https://github.com/otland/forgottenserver/releases).
+* [Compiling](compiling/README.md) — guides for [Linux](compiling/linux.md), [Windows (CMake)](compiling/windows-cmake.md), [Windows (Visual Studio)](compiling/windows-visual-studio.md) and [Docker](compiling/docker.md).
 * [Scripting Reference](https://github.com/otland/forgottenserver/wiki/Script-Interface)
-* [Contributing](https://github.com/otland/forgottenserver/wiki/Contributing)
 
 ### Support
 
-If you need help, please visit the [support forum on OTLand](https://otland.net/forums/support.16/). Our issue tracker is not a support forum, and using it as one will result in your issue being closed. If you were unable to get assistance in the support forum, you should consider [becoming a premium user on OTLand](https://otland.net/account/upgrades) which grants you access to the premium support forum and supports OTLand financially.
+If you need help, please visit the [support forum on OTLand](https://otland.net/forums/support.16/). Our issue tracker is not a support forum, and using it as one will result in your issue being closed.
 
 ### Issues
 
-We use the [issue tracker on GitHub](https://github.com/otland/forgottenserver/issues). Keep in mind that everyone who is watching the repository gets notified by e-mail when there is activity, so be thoughtful and avoid writing comments that aren't meaningful for an issue (e.g. "+1"). If you'd like for an issue to be fixed faster, you should either fix it yourself and submit a pull request, or place a bounty on the issue.
+We use the [issue tracker on GitHub](https://github.com/atlas-kit/atlas/issues). Keep in mind that everyone who is watching the repository gets notified by e-mail when there is activity, so be thoughtful and avoid writing comments that aren't meaningful for an issue (e.g. "+1"). If you'd like for an issue to be fixed faster, you should either fix it yourself and submit a pull request, or place a bounty on the issue.


### PR DESCRIPTION
## Summary
- Replace all references from `otland/forgottenserver` to `atlas-kit/atlas`
- Update CI badge branch from `master` to `dev`
- Remove outdated links (forgottenserver releases, contributing wiki, premium OTLand promotion)
- Clarify that Atlas is a fork of the Forgotten Server (not OpenTibia Server directly)

## Test plan
- [ ] Verify badge images render correctly on the repo page
- [ ] Confirm all links point to valid destinations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README rewritten to present the project as Atlas, with all project links and status badges updated to point to the Atlas repository.
  * "Getting Started" streamlined to focus on compiling and scripting instructions; removed legacy contributing and alternative download links.
  * "Support" simplified to direct users to the OTLand support forum and the updated GitHub issue tracker, preserving contributor comment guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->