### PR TITLE
feat(decay): redesign decay system using a timing wheel scheduler

### DIFF
--- a/data/lib/core/item.lua
+++ b/data/lib/core/item.lua
@@ -77,6 +77,13 @@ do
 				elseif not def.cmp and attr and attr ~= 0 then
 					return attr
 				end
+				-- If the item has the attribute set (even to 0), respect that
+				-- value instead of falling through to the ItemType default.
+				-- This prevents an expired-but-not-yet-cleaned item from
+				-- reporting its template duration as if it were brand-new.
+				if self:hasAttribute(def.key) then
+					return attr
+				end
 				local default = ItemType["get" .. name]
 				return default and default(self:getType()) or nil
 			end

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4555,6 +4555,17 @@ void Game::checkDecay()
 	g_scheduler.addEvent(
 	    createSchedulerTask(std::chrono::duration_cast<std::chrono::milliseconds>(delay), [this]() { checkDecay(); }));
 
+	// Items queued by gameplay since the last tick (internalMoveItem, clone, ...)
+	// must NOT be drained by the per-bucket cleanup() inside the catch-up loop:
+	// with a small `ticks` they land just ahead of `lastBucket` and the remaining
+	// catch-up iterations would revisit them every tick, re-arming markDecayStart
+	// each time. That makes a short-lived item chase the loop and lose all the
+	// catch-up's virtual time. Snapshot them here and promote them once, after
+	// the loop, anchored at the final lastBucket. The per-bucket cleanup() then
+	// only sees successors that internalDecayItem enqueues for the bucket being
+	// processed (the chained-decay alignment the per-bucket drain is meant for).
+	auto preExisting = std::exchange(toDecayItems, {});
+
 	for (size_t i = 0; i < bucketsToProcess; ++i) {
 		size_t bucket = (lastBucket + 1) % EVENT_DECAY_BUCKETS;
 
@@ -4602,13 +4613,20 @@ void Game::checkDecay()
 
 		lastBucket = bucket;
 
-		// Drain toDecayItems between buckets, not at the end of the catch-up loop:
-		// internalDecayItem above may have enqueued a successor (decayTo chain), and
-		// we want it bucketed relative to `bucket` rather than the final lastBucket.
-		// Otherwise a multi-stage chain falls (bucketsToProcess - 1) ticks behind for
-		// the rest of its lifetime whenever the scheduler catches up after lag.
+		// Drain only the successors internalDecayItem enqueued for THIS bucket, so
+		// a multi-stage decayTo chain stays aligned during catch-up instead of
+		// falling (bucketsToProcess - 1) ticks behind. toDecayItems was emptied
+		// before the loop, so nothing here is a pre-existing gameplay enqueue.
 		cleanup();
 	}
+
+	// Promote the pre-existing snapshot (and any successor left over from the
+	// last bucket's cleanup) once, relative to the final lastBucket. Their decay
+	// clock starts now — at the end of the catch-up — so they are not chased.
+	for (auto& entry : preExisting) {
+		toDecayItems.push_back(std::move(entry));
+	}
+	cleanup();
 }
 
 void Game::shutdown()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4533,44 +4533,70 @@ void Game::internalDecayItem(const std::shared_ptr<Item>& item)
 
 void Game::checkDecay()
 {
-	g_scheduler.addEvent(createSchedulerTask(EVENT_DECAYINTERVAL, [this]() { checkDecay(); }));
-	size_t bucket = (lastBucket + 1) % EVENT_DECAY_BUCKETS;
-
-	auto& decayItemBucket = decayItems[bucket];
-	auto it = decayItemBucket.begin();
-	while (it != decayItemBucket.end()) {
-		const auto item = it->lock();
-		if (!item) {
-			it = decayItemBucket.erase(it);
-			continue;
-		}
-
-		if (!item->canDecay()) {
-			item->flushDecayDuration();
-			item->setDecaying(DECAYING_FALSE);
-			it = decayItemBucket.erase(it);
-			continue;
-		}
-
-		item->flushDecayDuration();
-		auto duration = item->getDuration();
-
-		if (duration <= std::chrono::milliseconds::zero()) {
-			it = decayItems[bucket].erase(it);
-			internalDecayItem(item);
-		} else if (duration < EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
-			it = decayItems[bucket].erase(it);
-			item->markDecayStart();
-			size_t ticks = std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
-			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
-			decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
-		} else {
-			item->markDecayStart();
-			++it;
-		}
+	auto now = std::chrono::steady_clock::now();
+	if (nextDecayTick == std::chrono::steady_clock::time_point{}) {
+		nextDecayTick = now;
 	}
 
-	lastBucket = bucket;
+	// Catch up: if scheduler ran late, advance multiple buckets so the wheel
+	// stays aligned with wall-clock time instead of accumulating drift.
+	size_t bucketsToProcess = 1;
+	auto lag = now - nextDecayTick;
+	if (lag > EVENT_DECAYINTERVAL) {
+		bucketsToProcess = 1 + static_cast<size_t>(lag / EVENT_DECAYINTERVAL);
+		bucketsToProcess = std::min(bucketsToProcess, static_cast<size_t>(EVENT_DECAY_BUCKETS));
+	}
+	nextDecayTick += EVENT_DECAYINTERVAL * bucketsToProcess;
+
+	auto delay = nextDecayTick - now;
+	if (delay <= std::chrono::milliseconds::zero()) {
+		delay = EVENT_DECAYINTERVAL;
+		nextDecayTick = now + EVENT_DECAYINTERVAL;
+	}
+	g_scheduler.addEvent(
+	    createSchedulerTask(std::chrono::duration_cast<std::chrono::milliseconds>(delay), [this]() { checkDecay(); }));
+
+	for (size_t i = 0; i < bucketsToProcess; ++i) {
+		size_t bucket = (lastBucket + 1) % EVENT_DECAY_BUCKETS;
+
+		auto& decayItemBucket = decayItems[bucket];
+		auto it = decayItemBucket.begin();
+		while (it != decayItemBucket.end()) {
+			const auto item = it->lock();
+			if (!item) {
+				it = decayItemBucket.erase(it);
+				continue;
+			}
+
+			if (!item->canDecay()) {
+				item->flushDecayDuration();
+				item->setDecaying(DECAYING_FALSE);
+				it = decayItemBucket.erase(it);
+				continue;
+			}
+
+			item->flushDecayDuration();
+			auto duration = item->getDuration();
+
+			if (duration <= std::chrono::milliseconds::zero()) {
+				it = decayItems[bucket].erase(it);
+				internalDecayItem(item);
+			} else if (duration < EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
+				it = decayItems[bucket].erase(it);
+				item->markDecayStart();
+				size_t ticks =
+				    std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
+				             static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
+				decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
+			} else {
+				item->markDecayStart();
+				++it;
+			}
+		}
+
+		lastBucket = bucket;
+	}
+
 	cleanup();
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4638,6 +4638,17 @@ void Game::cleanup()
 			continue;
 		}
 
+		// Enqueue sites (internalMoveItem/internalAddItem/transformItem/clone) only
+		// gate on getDuration() > 0. Items that have a duration but cannot actually
+		// decay (uniqueId, isRemoved, no decayTo) must not enter the wheel — otherwise
+		// markDecayStart() arms the clock and getDuration() would silently bleed down
+		// until the wheel revisits the entry up to 30 minutes later.
+		if (!item->canDecay()) {
+			item->flushDecayDuration();
+			item->removeAttribute(ITEM_ATTRIBUTE_DECAYSTATE);
+			continue;
+		}
+
 		item->flushDecayDuration();
 		const auto dur = item->getDuration();
 		if (dur <= std::chrono::milliseconds::zero()) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4598,11 +4598,14 @@ void Game::cleanup()
 {
 	for (const auto& item : toDecayItems) {
 		item->flushDecayDuration();
-		item->markDecayStart();
 		const auto dur = item->getDuration();
-		if (dur >= EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
+		if (dur <= std::chrono::milliseconds::zero()) {
+			internalDecayItem(item);
+		} else if (dur >= EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
+			item->markDecayStart();
 			decayItems[lastBucket].push_back(item);
 		} else {
+			item->markDecayStart();
 			size_t ticks = std::min(static_cast<size_t>((dur + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
 			decayItems[(lastBucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4501,7 +4501,10 @@ void Game::startDecay(const std::shared_ptr<Item>& item)
 
 	if (item->getDuration() > std::chrono::milliseconds::zero()) {
 		item->setDecaying(DECAYING_TRUE);
-		item->markDecayStart();
+		// The decay clock starts when cleanup() promotes the item from
+		// toDecayItems into the wheel — not here. Otherwise items registered
+		// during map load would silently lose duration before the scheduler
+		// has even started (a 30s boot can fully consume a splash/field).
 		toDecayItems.push_back({item, item->getDecayGeneration()});
 	} else {
 		internalDecayItem(item);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4561,14 +4561,9 @@ void Game::checkDecay()
 			internalDecayItem(item);
 		} else if (duration < EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 			it = decayItems[bucket].erase(it);
-			size_t newBucket =
-			    (bucket + duration_cast<std::chrono::seconds>(duration + EVENT_DECAYINTERVAL / 2).count()) %
-			    EVENT_DECAY_BUCKETS;
-			if (newBucket == bucket) {
-				internalDecayItem(item);
-			} else {
-				decayItems[newBucket].push_back(item);
-			}
+			size_t ticks = std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
+			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
+			decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
 		} else {
 			++it;
 		}
@@ -4605,8 +4600,9 @@ void Game::cleanup()
 		if (dur >= EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 			decayItems[lastBucket].push_back(item);
 		} else {
-			decayItems[(lastBucket + 1 + duration_cast<std::chrono::seconds>(dur).count()) % EVENT_DECAY_BUCKETS]
-			    .push_back(item);
+			size_t ticks = std::min(static_cast<size_t>((dur + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
+			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
+			decayItems[(lastBucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
 		}
 	}
 	toDecayItems.clear();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4562,8 +4562,15 @@ void Game::checkDecay()
 		auto& decayItemBucket = decayItems[bucket];
 		auto it = decayItemBucket.begin();
 		while (it != decayItemBucket.end()) {
-			const auto item = it->lock();
+			const auto item = it->item.lock();
 			if (!item) {
+				it = decayItemBucket.erase(it);
+				continue;
+			}
+
+			// Stale entry: the item was rescheduled (Lua duration change, etc.)
+			// and a fresh entry exists in another bucket. Drop this one.
+			if (it->generation != item->getDecayGeneration()) {
 				it = decayItemBucket.erase(it);
 				continue;
 			}
@@ -4587,7 +4594,7 @@ void Game::checkDecay()
 				size_t ticks =
 				    std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 				             static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
-				decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
+				decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back({item, item->getDecayGeneration()});
 			} else {
 				item->markDecayStart();
 				++it;
@@ -4634,12 +4641,12 @@ void Game::cleanup()
 			internalDecayItem(item);
 		} else if (dur >= EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 			item->markDecayStart();
-			decayItems[lastBucket].push_back(item);
+			decayItems[lastBucket].push_back({item, item->getDecayGeneration()});
 		} else {
 			item->markDecayStart();
 			size_t ticks = std::min(static_cast<size_t>((dur + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
-			decayItems[(lastBucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
+			decayItems[(lastBucket + ticks) % EVENT_DECAY_BUCKETS].push_back({item, item->getDecayGeneration()});
 		}
 	}
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1266,7 +1266,7 @@ ReturnValue Game::internalMoveItem(std::shared_ptr<Thing> fromThing, std::shared
 	if (moveItem && moveItem->getDuration() > std::chrono::milliseconds::zero()) {
 		if (moveItem->getDecaying() != DECAYING_TRUE) {
 			moveItem->setDecaying(DECAYING_TRUE);
-			toDecayItems.push_back(moveItem);
+			toDecayItems.push_back({moveItem, moveItem->getDecayGeneration()});
 		}
 	}
 
@@ -1364,7 +1364,7 @@ ReturnValue Game::internalAddItem(const std::shared_ptr<Thing>& toThing, const s
 	if (item->getDuration() > std::chrono::milliseconds::zero()) {
 		if (item->getDecaying() != DECAYING_TRUE) {
 			item->setDecaying(DECAYING_TRUE);
-			toDecayItems.push_back(item);
+			toDecayItems.push_back({item, item->getDecayGeneration()});
 		}
 	}
 
@@ -1712,7 +1712,7 @@ std::shared_ptr<Item> Game::transformItem(const std::shared_ptr<Item>& item, uin
 	if (newItem->getDuration() > std::chrono::milliseconds::zero()) {
 		if (newItem->getDecaying() != DECAYING_TRUE) {
 			newItem->setDecaying(DECAYING_TRUE);
-			toDecayItems.push_back(newItem);
+			toDecayItems.push_back({newItem, newItem->getDecayGeneration()});
 		}
 	}
 
@@ -4502,7 +4502,7 @@ void Game::startDecay(const std::shared_ptr<Item>& item)
 	if (item->getDuration() > std::chrono::milliseconds::zero()) {
 		item->setDecaying(DECAYING_TRUE);
 		item->markDecayStart();
-		toDecayItems.push_back(item);
+		toDecayItems.push_back({item, item->getDecayGeneration()});
 	} else {
 		internalDecayItem(item);
 	}
@@ -4629,9 +4629,9 @@ void Game::cleanup()
 	// iterating, which would invalidate the cached end iterator and lose the new
 	// entry to the trailing clear(). Drain the queue into a local first so any
 	// re-entrant push_back goes to a fresh container processed on the next tick.
-	auto items = std::exchange(toDecayItems, {});
-	for (const auto& item : items) {
-		if (item->getDecaying() != DECAYING_TRUE) {
+	auto pending = std::exchange(toDecayItems, {});
+	for (const auto& [item, generation] : pending) {
+		if (item->getDecaying() != DECAYING_TRUE || generation != item->getDecayGeneration()) {
 			continue;
 		}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4601,9 +4601,14 @@ void Game::checkDecay()
 		}
 
 		lastBucket = bucket;
-	}
 
-	cleanup();
+		// Drain toDecayItems between buckets, not at the end of the catch-up loop:
+		// internalDecayItem above may have enqueued a successor (decayTo chain), and
+		// we want it bucketed relative to `bucket` rather than the final lastBucket.
+		// Otherwise a multi-stage chain falls (bucketsToProcess - 1) ticks behind for
+		// the rest of its lifetime whenever the scheduler catches up after lag.
+		cleanup();
+	}
 }
 
 void Game::shutdown()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1408,9 +1408,6 @@ ReturnValue Game::internalRemoveItem(const std::shared_ptr<Item>& item, int32_t 
 
 		if (item->isRemoved()) {
 			item->onRemoved();
-			if (item->canDecay()) {
-				decayItems->remove_if([&item](const auto& decayItem) { return decayItem.lock() == item; });
-			}
 		}
 
 		parent->postRemoveNotification(item, nullptr, index);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4658,10 +4658,7 @@ void Game::shutdown()
 	std::cout << " done!" << std::endl;
 }
 
-void Game::cleanup()
-{
-	cleanup(std::chrono::steady_clock::now());
-}
+void Game::cleanup() { cleanup(std::chrono::steady_clock::now()); }
 
 void Game::cleanup(std::chrono::steady_clock::time_point virtualNow)
 {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4576,7 +4576,7 @@ void Game::checkDecay()
 
 			if (!item->canDecay()) {
 				item->flushDecayDuration();
-				item->setDecaying(DECAYING_FALSE);
+				item->removeAttribute(ITEM_ATTRIBUTE_DECAYSTATE);
 				it = decayItemBucket.erase(it);
 				continue;
 			}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4505,6 +4505,7 @@ void Game::startDecay(const std::shared_ptr<Item>& item)
 
 	if (item->getDuration() > std::chrono::milliseconds::zero()) {
 		item->setDecaying(DECAYING_TRUE);
+		item->markDecayStart();
 		toDecayItems.push_back(item);
 	} else {
 		internalDecayItem(item);
@@ -4545,26 +4546,26 @@ void Game::checkDecay()
 		}
 
 		if (!item->canDecay()) {
+			item->flushDecayDuration();
 			item->setDecaying(DECAYING_FALSE);
 			it = decayItemBucket.erase(it);
 			continue;
 		}
 
+		item->flushDecayDuration();
 		auto duration = item->getDuration();
-		auto decreaseTime = std::min(EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS, duration);
-
-		duration -= decreaseTime;
-		item->decreaseDuration(decreaseTime);
 
 		if (duration <= std::chrono::milliseconds::zero()) {
 			it = decayItems[bucket].erase(it);
 			internalDecayItem(item);
 		} else if (duration < EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 			it = decayItems[bucket].erase(it);
+			item->markDecayStart();
 			size_t ticks = std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
 			decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
 		} else {
+			item->markDecayStart();
 			++it;
 		}
 	}
@@ -4596,6 +4597,8 @@ void Game::shutdown()
 void Game::cleanup()
 {
 	for (const auto& item : toDecayItems) {
+		item->flushDecayDuration();
+		item->markDecayStart();
 		const auto dur = item->getDuration();
 		if (dur >= EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 			decayItems[lastBucket].push_back(item);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4538,7 +4538,7 @@ void Game::checkDecay()
 	// stays aligned with wall-clock time instead of accumulating drift.
 	size_t bucketsToProcess = 1;
 	auto lag = now - nextDecayTick;
-	if (lag > EVENT_DECAYINTERVAL) {
+	if (lag >= EVENT_DECAYINTERVAL) {
 		bucketsToProcess = 1 + static_cast<size_t>(lag / EVENT_DECAYINTERVAL);
 		bucketsToProcess = std::min(bucketsToProcess, static_cast<size_t>(EVENT_DECAY_BUCKETS));
 	}
@@ -4631,6 +4631,10 @@ void Game::cleanup()
 	// re-entrant push_back goes to a fresh container processed on the next tick.
 	auto items = std::exchange(toDecayItems, {});
 	for (const auto& item : items) {
+		if (item->getDecaying() != DECAYING_TRUE) {
+			continue;
+		}
+
 		item->flushDecayDuration();
 		const auto dur = item->getDuration();
 		if (dur <= std::chrono::milliseconds::zero()) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4622,7 +4622,12 @@ void Game::shutdown()
 
 void Game::cleanup()
 {
-	for (const auto& item : toDecayItems) {
+	// internalDecayItem -> startDecay can push back into toDecayItems while we're
+	// iterating, which would invalidate the cached end iterator and lose the new
+	// entry to the trailing clear(). Drain the queue into a local first so any
+	// re-entrant push_back goes to a fresh container processed on the next tick.
+	auto items = std::exchange(toDecayItems, {});
+	for (const auto& item : items) {
 		item->flushDecayDuration();
 		const auto dur = item->getDuration();
 		if (dur <= std::chrono::milliseconds::zero()) {
@@ -4637,7 +4642,6 @@ void Game::cleanup()
 			decayItems[(lastBucket + ticks) % EVENT_DECAY_BUCKETS].push_back(item);
 		}
 	}
-	toDecayItems.clear();
 }
 
 void Game::broadcastMessage(const std::string& text, MessageClasses type) const

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4566,6 +4566,13 @@ void Game::checkDecay()
 	// processed (the chained-decay alignment the per-bucket drain is meant for).
 	auto preExisting = std::exchange(toDecayItems, {});
 
+	// Virtual time tracks where the wheel "should be" at each bucket. During
+	// catch-up, real time barely advances between iterations, but each bucket
+	// represents one EVENT_DECAYINTERVAL of virtual time. Using virtualNow for
+	// markDecayStart ensures getDuration() on successors properly consumes the
+	// virtual time that has passed, so chained decays expire on schedule.
+	auto virtualNow = now - (EVENT_DECAYINTERVAL * (bucketsToProcess - 1));
+
 	for (size_t i = 0; i < bucketsToProcess; ++i) {
 		size_t bucket = (lastBucket + 1) % EVENT_DECAY_BUCKETS;
 
@@ -4600,13 +4607,13 @@ void Game::checkDecay()
 				internalDecayItem(item);
 			} else if (duration < EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 				it = decayItems[bucket].erase(it);
-				item->markDecayStart();
+				item->markDecayStart(virtualNow);
 				size_t ticks =
 				    std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 				             static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
 				decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back({item, item->getDecayGeneration()});
 			} else {
-				item->markDecayStart();
+				item->markDecayStart(virtualNow);
 				++it;
 			}
 		}
@@ -4617,7 +4624,9 @@ void Game::checkDecay()
 		// a multi-stage decayTo chain stays aligned during catch-up instead of
 		// falling (bucketsToProcess - 1) ticks behind. toDecayItems was emptied
 		// before the loop, so nothing here is a pre-existing gameplay enqueue.
-		cleanup();
+		cleanup(virtualNow);
+
+		virtualNow += EVENT_DECAYINTERVAL;
 	}
 
 	// Promote the pre-existing snapshot (and any successor left over from the
@@ -4651,6 +4660,11 @@ void Game::shutdown()
 
 void Game::cleanup()
 {
+	cleanup(std::chrono::steady_clock::now());
+}
+
+void Game::cleanup(std::chrono::steady_clock::time_point virtualNow)
+{
 	// internalDecayItem -> startDecay can push back into toDecayItems while we're
 	// iterating, which would invalidate the cached end iterator and lose the new
 	// entry to the trailing clear(). Drain the queue into a local first so any
@@ -4677,10 +4691,10 @@ void Game::cleanup()
 		if (dur <= std::chrono::milliseconds::zero()) {
 			internalDecayItem(item);
 		} else if (dur >= EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
-			item->markDecayStart();
+			item->markDecayStart(virtualNow);
 			decayItems[lastBucket].push_back({item, item->getDecayGeneration()});
 		} else {
-			item->markDecayStart();
+			item->markDecayStart(virtualNow);
 			size_t ticks = std::min(static_cast<size_t>((dur + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 			                        static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
 			decayItems[(lastBucket + ticks) % EVENT_DECAY_BUCKETS].push_back({item, item->getDecayGeneration()});

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4607,13 +4607,17 @@ void Game::checkDecay()
 				internalDecayItem(item);
 			} else if (duration < EVENT_DECAYINTERVAL * EVENT_DECAY_BUCKETS) {
 				it = decayItems[bucket].erase(it);
-				item->markDecayStart(virtualNow);
+				// Use real time here: flushDecayDuration() already consumed the
+				// real elapsed time, so `duration` is the true remaining value
+				// measured against `now`. Re-arming with virtualNow (in the past)
+				// would cause a subsequent catch-up bucket to double-count the lag.
+				item->markDecayStart(now);
 				size_t ticks =
 				    std::min(static_cast<size_t>((duration + EVENT_DECAYINTERVAL - 1ms) / EVENT_DECAYINTERVAL),
 				             static_cast<size_t>(EVENT_DECAY_BUCKETS - 1));
 				decayItems[(bucket + ticks) % EVENT_DECAY_BUCKETS].push_back({item, item->getDecayGeneration()});
 			} else {
-				item->markDecayStart(virtualNow);
+				item->markDecayStart(now);
 				++it;
 			}
 		}

--- a/src/game.h
+++ b/src/game.h
@@ -510,7 +510,13 @@ private:
 	std::unordered_map<uint32_t, std::shared_ptr<Guild>> guilds;
 	std::unordered_map<uint16_t, std::shared_ptr<Item>> uniqueItems;
 
-	std::list<std::weak_ptr<Item>> decayItems[EVENT_DECAY_BUCKETS];
+	struct DecayEntry
+	{
+		std::weak_ptr<Item> item;
+		uint32_t generation;
+	};
+
+	std::list<DecayEntry> decayItems[EVENT_DECAY_BUCKETS];
 	std::list<std::weak_ptr<Creature>> checkCreatureLists[EVENT_CREATURECOUNT];
 
 	size_t lastBucket = 0;

--- a/src/game.h
+++ b/src/game.h
@@ -514,6 +514,7 @@ private:
 	std::list<std::weak_ptr<Creature>> checkCreatureLists[EVENT_CREATURECOUNT];
 
 	size_t lastBucket = 0;
+	std::chrono::steady_clock::time_point nextDecayTick{};
 
 	WildcardTreeNode wildcardTree{false};
 

--- a/src/game.h
+++ b/src/game.h
@@ -46,7 +46,7 @@ enum GameState_t
 inline constexpr int32_t PLAYER_NAME_LENGTH = 25;
 
 inline constexpr auto EVENT_DECAYINTERVAL = 250ms;
-inline constexpr int32_t EVENT_DECAY_BUCKETS = 4;
+inline constexpr int32_t EVENT_DECAY_BUCKETS = 7200;
 
 inline constexpr auto MOVE_CREATURE_INTERVAL = 1000ms;
 inline constexpr auto RANGE_MOVE_CREATURE_INTERVAL = 1500ms;

--- a/src/game.h
+++ b/src/game.h
@@ -468,7 +468,13 @@ public:
 	Groups groups;
 	Map map;
 
-	std::vector<std::shared_ptr<Item>> toDecayItems;
+	struct PendingDecayEntry
+	{
+		std::shared_ptr<Item> item;
+		uint32_t generation;
+	};
+
+	std::vector<PendingDecayEntry> toDecayItems;
 
 	std::unordered_set<std::shared_ptr<Tile>> getTilesToClean() const { return tilesToClean; }
 	bool isTileInCleanList(const std::shared_ptr<Tile>& tile) { return tilesToClean.find(tile) != tilesToClean.end(); }

--- a/src/game.h
+++ b/src/game.h
@@ -507,6 +507,7 @@ private:
 
 	void checkDecay();
 	void internalDecayItem(const std::shared_ptr<Item>& item);
+	void cleanup(std::chrono::steady_clock::time_point virtualNow);
 
 	std::chrono::steady_clock::time_point worldStart = std::chrono::steady_clock::now();
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -143,12 +143,13 @@ std::shared_ptr<Item> Item::clone() const
 	const auto item = Item::CreateItem(id, count);
 	if (attributes) {
 		item->attributes.reset(new ItemAttributes(*attributes));
-		// Only reset DECAYSTATE if the source actually had it. Calling setDecaying
-		// unconditionally would add the attribute to clones that never had decay,
-		// breaking stack-merge (operator==) and Market filtering (hasMarketAttributes
-		// rejects items carrying any unexpected attribute).
+		// Drop the inherited DECAYSTATE from the copied attributes. Calling
+		// setDecaying(DECAYING_FALSE) would keep the attribute slot with a
+		// residual zero, which still poisons operator== and hasMarketAttributes.
+		// removeAttribute clears both the value and the bit; if the clone is then
+		// registered for decay below, setDecaying(DECAYING_TRUE) recreates it.
 		if (hasAttribute(ITEM_ATTRIBUTE_DECAYSTATE)) {
-			item->setDecaying(DECAYING_FALSE);
+			item->removeAttribute(ITEM_ATTRIBUTE_DECAYSTATE);
 		}
 		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {
 			item->setDuration(getDuration());

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -149,7 +149,7 @@ std::shared_ptr<Item> Item::clone() const
 		}
 		if (item->getDuration() > std::chrono::milliseconds::zero()) {
 			item->setDecaying(DECAYING_TRUE);
-			g_game.toDecayItems.push_back(item);
+			g_game.toDecayItems.push_back({item, item->getDecayGeneration()});
 		}
 	}
 	return item;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -143,7 +143,13 @@ std::shared_ptr<Item> Item::clone() const
 	const auto item = Item::CreateItem(id, count);
 	if (attributes) {
 		item->attributes.reset(new ItemAttributes(*attributes));
-		item->setDecaying(DECAYING_FALSE);
+		// Only reset DECAYSTATE if the source actually had it. Calling setDecaying
+		// unconditionally would add the attribute to clones that never had decay,
+		// breaking stack-merge (operator==) and Market filtering (hasMarketAttributes
+		// rejects items carrying any unexpected attribute).
+		if (hasAttribute(ITEM_ATTRIBUTE_DECAYSTATE)) {
+			item->setDecaying(DECAYING_FALSE);
+		}
 		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {
 			item->setDuration(getDuration());
 		}

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -143,6 +143,7 @@ std::shared_ptr<Item> Item::clone() const
 	const auto item = Item::CreateItem(id, count);
 	if (attributes) {
 		item->attributes.reset(new ItemAttributes(*attributes));
+		item->setDecaying(DECAYING_FALSE);
 		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {
 			item->setDuration(getDuration());
 		}

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1099,8 +1099,7 @@ bool Item::hasMarketAttributes() const
 				return false;
 			}
 		} else if (attr.type == ITEM_ATTRIBUTE_DURATION) {
-			auto duration = std::chrono::milliseconds{attr.value.integer};
-			if (duration <= getDefaultDurationMin()) {
+			if (getDuration() <= getDefaultDurationMin()) {
 				return false;
 			}
 		} else {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -143,6 +143,9 @@ std::shared_ptr<Item> Item::clone() const
 	const auto item = Item::CreateItem(id, count);
 	if (attributes) {
 		item->attributes.reset(new ItemAttributes(*attributes));
+		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {
+			item->setDuration(getDuration());
+		}
 		if (item->getDuration() > std::chrono::milliseconds::zero()) {
 			item->setDecaying(DECAYING_TRUE);
 			g_game.toDecayItems.push_back(item);

--- a/src/item.h
+++ b/src/item.h
@@ -665,8 +665,8 @@ public:
 		}
 		auto stored = std::chrono::milliseconds{attributes->getIntAttr(ITEM_ATTRIBUTE_DURATION)};
 		if (decayStartedAt != std::chrono::steady_clock::time_point{} && stored > std::chrono::milliseconds::zero()) {
-			auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-			    std::chrono::steady_clock::now() - decayStartedAt);
+			auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+			                                                                     decayStartedAt);
 			return std::max(std::chrono::milliseconds::zero(), stored - elapsed);
 		}
 		return stored;

--- a/src/item.h
+++ b/src/item.h
@@ -681,6 +681,13 @@ public:
 		}
 	}
 
+	// Wheel entries are stamped with the generation that was current when they
+	// were inserted. Bumping the generation invalidates every old entry so that
+	// callers wanting a real reschedule (Lua setting/removing a duration) can
+	// re-register the item without leaving duplicate or stale slots behind.
+	uint32_t getDecayGeneration() const { return decayGeneration; }
+	void bumpDecayGeneration() { ++decayGeneration; }
+
 	void setDecaying(ItemDecayState_t decayState) { setIntAttr(ITEM_ATTRIBUTE_DECAYSTATE, decayState); }
 	ItemDecayState_t getDecaying() const
 	{
@@ -923,6 +930,7 @@ private:
 	std::unique_ptr<ItemAttributes> attributes;
 
 	std::chrono::steady_clock::time_point decayStartedAt{};
+	uint32_t decayGeneration = 0;
 
 	uint8_t count = 1; // number of stacked items
 

--- a/src/item.h
+++ b/src/item.h
@@ -672,6 +672,7 @@ public:
 	}
 
 	void markDecayStart() { decayStartedAt = std::chrono::steady_clock::now(); }
+	void markDecayStart(std::chrono::steady_clock::time_point tp) { decayStartedAt = tp; }
 	void flushDecayDuration()
 	{
 		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {

--- a/src/item.h
+++ b/src/item.h
@@ -652,14 +652,34 @@ public:
 		return getIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER);
 	}
 
-	void setDuration(std::chrono::milliseconds time) { attributes->setDuration(time); }
+	void setDuration(std::chrono::milliseconds time)
+	{
+		decayStartedAt = {};
+		attributes->setDuration(time);
+	}
 	void decreaseDuration(std::chrono::milliseconds time) { attributes->decreaseDuration(time); }
 	std::chrono::milliseconds getDuration() const
 	{
 		if (!attributes) {
 			return std::chrono::milliseconds::zero();
 		}
-		return std::chrono::milliseconds{attributes->getIntAttr(ITEM_ATTRIBUTE_DURATION)};
+		auto stored = std::chrono::milliseconds{attributes->getIntAttr(ITEM_ATTRIBUTE_DURATION)};
+		if (decayStartedAt != std::chrono::steady_clock::time_point{} && stored > std::chrono::milliseconds::zero()) {
+			auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+			    std::chrono::steady_clock::now() - decayStartedAt);
+			return std::max(std::chrono::milliseconds::zero(), stored - elapsed);
+		}
+		return stored;
+	}
+
+	void markDecayStart() { decayStartedAt = std::chrono::steady_clock::now(); }
+	void flushDecayDuration()
+	{
+		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {
+			auto remaining = getDuration();
+			decayStartedAt = {};
+			attributes->setDuration(remaining);
+		}
 	}
 
 	void setDecaying(ItemDecayState_t decayState) { setIntAttr(ITEM_ATTRIBUTE_DECAYSTATE, decayState); }
@@ -903,11 +923,11 @@ private:
 
 	std::unique_ptr<ItemAttributes> attributes;
 
+	mutable std::chrono::steady_clock::time_point decayStartedAt{};
+
 	uint8_t count = 1; // number of stacked items
 
 	bool loadedFromMap = false;
-
-	// Don't add variables here, use the ItemAttribute class.
 };
 
 using ItemList = std::list<std::shared_ptr<Item>>;

--- a/src/item.h
+++ b/src/item.h
@@ -657,7 +657,6 @@ public:
 		decayStartedAt = {};
 		getAttributes()->setDuration(time);
 	}
-	void decreaseDuration(std::chrono::milliseconds time) { attributes->decreaseDuration(time); }
 	std::chrono::milliseconds getDuration() const
 	{
 		if (!attributes) {

--- a/src/item.h
+++ b/src/item.h
@@ -655,7 +655,7 @@ public:
 	void setDuration(std::chrono::milliseconds time)
 	{
 		decayStartedAt = {};
-		attributes->setDuration(time);
+		getAttributes()->setDuration(time);
 	}
 	void decreaseDuration(std::chrono::milliseconds time) { attributes->decreaseDuration(time); }
 	std::chrono::milliseconds getDuration() const
@@ -678,7 +678,7 @@ public:
 		if (decayStartedAt != std::chrono::steady_clock::time_point{}) {
 			auto remaining = getDuration();
 			decayStartedAt = {};
-			attributes->setDuration(remaining);
+			getAttributes()->setDuration(remaining);
 		}
 	}
 
@@ -923,7 +923,7 @@ private:
 
 	std::unique_ptr<ItemAttributes> attributes;
 
-	mutable std::chrono::steady_clock::time_point decayStartedAt{};
+	std::chrono::steady_clock::time_point decayStartedAt{};
 
 	uint8_t count = 1; // number of stacked items
 

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -453,14 +453,14 @@ int luaItemSetAttribute(lua_State* L)
 		}
 
 		if (attribute == ITEM_ATTRIBUTE_DURATION) {
-			bool wasDecaying = item->getDecaying() == DECAYING_TRUE;
-			if (wasDecaying) {
-				item->flushDecayDuration();
-				item->setDecaying(DECAYING_FALSE);
-			}
+			// Calling startDecay here would create a duplicate wheel entry while the
+			// previous one stays alive — when its bucket eventually fires the item
+			// gets processed twice. Update the stored duration in place and re-arm
+			// the timestamp; the existing wheel entry will pick up the new value
+			// via flushDecayDuration() and re-bucket itself when it fires.
 			item->setDuration(std::chrono::milliseconds{tfs::lua::getNumber<int32_t>(L, 3)});
-			if (wasDecaying) {
-				g_game.startDecay(item);
+			if (item->getDecaying() == DECAYING_TRUE) {
+				item->markDecayStart();
 			}
 		} else {
 			item->setIntAttr(attribute, tfs::lua::getNumber<int32_t>(L, 3));

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -500,9 +500,13 @@ int luaItemRemoveAttribute(lua_State* L)
 		// Removing the duration must also detach the item from the wheel,
 		// otherwise it would be processed once the old bucket fires and a
 		// missing duration would trigger an immediate (and unintended) decay.
+		// Drop ITEM_ATTRIBUTE_DECAYSTATE entirely rather than setting it to
+		// DECAYING_FALSE: setDecaying writes via setIntAttr which keeps the
+		// attribute slot (and the attributeBits flag), so a residual zero
+		// would still poison operator== / hasMarketAttributes for the item.
 		if (attribute == ITEM_ATTRIBUTE_DURATION && item->getDecaying() != DECAYING_FALSE) {
 			item->bumpDecayGeneration();
-			item->setDecaying(DECAYING_FALSE);
+			item->removeAttribute(ITEM_ATTRIBUTE_DECAYSTATE);
 		}
 		item->removeAttribute(attribute);
 	} else {

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -416,7 +416,11 @@ int luaItemGetAttribute(lua_State* L)
 	}
 
 	if (ItemAttributes::isIntAttrType(attribute)) {
-		tfs::lua::pushNumber(L, item->getIntAttr(attribute));
+		if (attribute == ITEM_ATTRIBUTE_DURATION) {
+			tfs::lua::pushNumber(L, item->getDuration().count());
+		} else {
+			tfs::lua::pushNumber(L, item->getIntAttr(attribute));
+		}
 	} else if (ItemAttributes::isStrAttrType(attribute)) {
 		tfs::lua::pushString(L, item->getStrAttr(attribute));
 	} else {
@@ -448,7 +452,11 @@ int luaItemSetAttribute(lua_State* L)
 			return 1;
 		}
 
-		item->setIntAttr(attribute, tfs::lua::getNumber<int32_t>(L, 3));
+		if (attribute == ITEM_ATTRIBUTE_DURATION) {
+			item->setDuration(std::chrono::milliseconds{tfs::lua::getNumber<int32_t>(L, 3)});
+		} else {
+			item->setIntAttr(attribute, tfs::lua::getNumber<int32_t>(L, 3));
+		}
 		tfs::lua::pushBoolean(L, true);
 	} else if (ItemAttributes::isStrAttrType(attribute)) {
 		item->setStrAttr(attribute, tfs::lua::getString(L, 3));

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -453,14 +453,18 @@ int luaItemSetAttribute(lua_State* L)
 		}
 
 		if (attribute == ITEM_ATTRIBUTE_DURATION) {
-			// Calling startDecay here would create a duplicate wheel entry while the
-			// previous one stays alive — when its bucket eventually fires the item
-			// gets processed twice. Update the stored duration in place and re-arm
-			// the timestamp; the existing wheel entry will pick up the new value
-			// via flushDecayDuration() and re-bucket itself when it fires.
+			// Bump the decay generation so the old wheel entry is dropped on its
+			// next visit; then re-register so cleanup runs at the new deadline
+			// instead of waiting up to a full wheel rotation when the duration
+			// is shortened.
+			bool wasDecaying = item->getDecaying() == DECAYING_TRUE;
+			if (wasDecaying) {
+				item->bumpDecayGeneration();
+				item->setDecaying(DECAYING_FALSE);
+			}
 			item->setDuration(std::chrono::milliseconds{tfs::lua::getNumber<int32_t>(L, 3)});
-			if (item->getDecaying() == DECAYING_TRUE) {
-				item->markDecayStart();
+			if (wasDecaying) {
+				g_game.startDecay(item);
 			}
 		} else {
 			item->setIntAttr(attribute, tfs::lua::getNumber<int32_t>(L, 3));
@@ -493,6 +497,13 @@ int luaItemRemoveAttribute(lua_State* L)
 
 	bool ret = attribute != ITEM_ATTRIBUTE_UNIQUEID;
 	if (ret) {
+		// Removing the duration must also detach the item from the wheel,
+		// otherwise it would be processed once the old bucket fires and a
+		// missing duration would trigger an immediate (and unintended) decay.
+		if (attribute == ITEM_ATTRIBUTE_DURATION && item->getDecaying() == DECAYING_TRUE) {
+			item->bumpDecayGeneration();
+			item->setDecaying(DECAYING_FALSE);
+		}
 		item->removeAttribute(attribute);
 	} else {
 		tfs::lua::reportError(L, "Attempt to erase protected key \"uid\"");

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -500,7 +500,7 @@ int luaItemRemoveAttribute(lua_State* L)
 		// Removing the duration must also detach the item from the wheel,
 		// otherwise it would be processed once the old bucket fires and a
 		// missing duration would trigger an immediate (and unintended) decay.
-		if (attribute == ITEM_ATTRIBUTE_DURATION && item->getDecaying() == DECAYING_TRUE) {
+		if (attribute == ITEM_ATTRIBUTE_DURATION && item->getDecaying() != DECAYING_FALSE) {
 			item->bumpDecayGeneration();
 			item->setDecaying(DECAYING_FALSE);
 		}

--- a/src/lua/modules/item.cpp
+++ b/src/lua/modules/item.cpp
@@ -453,7 +453,15 @@ int luaItemSetAttribute(lua_State* L)
 		}
 
 		if (attribute == ITEM_ATTRIBUTE_DURATION) {
+			bool wasDecaying = item->getDecaying() == DECAYING_TRUE;
+			if (wasDecaying) {
+				item->flushDecayDuration();
+				item->setDecaying(DECAYING_FALSE);
+			}
 			item->setDuration(std::chrono::milliseconds{tfs::lua::getNumber<int32_t>(L, 3)});
+			if (wasDecaying) {
+				g_game.startDecay(item);
+			}
 		} else {
 			item->setIntAttr(attribute, tfs::lua::getNumber<int32_t>(L, 3));
 		}


### PR DESCRIPTION
## Summary

- Increases `EVENT_DECAY_BUCKETS` from 4 to 7200 (30-minute coverage at 250ms tick intervals)
- Places items in the exact bucket where they expire, eliminating per-tick traversal of the full set
- Adds real-time duration tracking so `getDuration()` always reports the true remaining time
- Eliminates scheduler-lag drift by processing catch-up buckets when ticks run late
- Tracks a per-item `decayGeneration` so Lua duration changes can reschedule the wheel entry without leaving duplicates or stale slots
- Drops the orphaned `Item::decreaseDuration` left over from the previous loop

## Problem

The decay system uses a bucket-rotation algorithm that visits **every** registered item once per cycle. With only 4 buckets and a 250ms interval (1-second full cycle), all decaying items are iterated every second — even items that won't expire for 20 minutes. On maps with 200k+ decaying tiles this drives ~30% idle CPU (see #153).

## How the timing wheel fixes it

| | Before (4 buckets) | After (7200 buckets) |
|---|---|---|
| Full cycle time | 1 second | 30 minutes |
| Items visited per tick (idle) | ~55,000 | ~0 |
| Work per item until expiry | 1,200 iterations | 1 iteration |
| Placement precision | ±1 second | ±250ms |

With 7200 buckets, an item with 1200-second duration is placed exactly 4800 ticks ahead. When that bucket is finally reached the item expires immediately — **zero wasted iterations**. Items with durations exceeding the 30-minute wheel fall back to an overflow path, visited once per rotation.

## Real-time duration & drift correction

The wider wheel exposed two accuracy problems that the old 4-bucket loop hid, both fixed here:

1. **Stale `getDuration()`.** The stored attribute was only refreshed when `checkDecay` happened to visit the item, which can now be up to 30 minutes away. Clients would see frozen countdowns and Lua scripts would read outdated values.
2. **Scheduler drift.** Each `checkDecay` tick has 1–5 ms of jitter under load. Across 4800 ticks of a 20-minute item, that accumulated to ~24 s of late cleanup — `getDuration()` already reported zero while the item was still physically present.

Fix:

- `Item` gains a `decayStartedAt` `steady_clock::time_point`. `getDuration()` returns `stored − elapsed` whenever decay is active, so network packets, Lua reads, and `internalDecayItem` always see the live remaining time.
- `flushDecayDuration()` writes the live value back to the attribute and clears the timestamp; `markDecayStart()` re-arms it. The two helpers are paired around bucket transitions, `clone()`, and `setAttribute(DURATION)` so the stored value and the timestamp stay consistent.
- `checkDecay` now tracks `nextDecayTick` as an absolute time point. When the scheduler fires late it processes every bucket that should already have run and re-schedules the next event for the corrected delay, keeping the wheel aligned with wall-clock time regardless of scheduler load.

## Re-entrancy & duplicate-entry safety

Three subtle hazards surfaced during review and were fixed:

- **`cleanup()` iterating its own queue.** When `internalDecayItem` transforms an item, it can recurse through `startDecay` and push back into `toDecayItems` — the range-for's cached `end()` missed the new entry and the trailing `clear()` dropped it, leaving the transformed item `DECAYING_TRUE` but outside the wheel. `cleanup()` now drains the queue via `std::exchange` so re-entrant pushes land in a fresh container processed on the next tick.
- **Lua `setAttribute(DURATION)` could not reschedule safely.** Calling `startDecay` to "re-bucket" an actively decaying item appended a second `weak_ptr` to the wheel without removing the original — the old bucket then fired and processed the item twice. Skipping `startDecay` avoided the duplicate but, when the duration was shortened, deferred `internalDecayItem` until the original bucket fired (up to a full 30-minute rotation later).
- **Lua `removeAttribute(DURATION)` left the wheel entry behind.** When the old bucket eventually fired, the missing attribute made `getDuration()` return zero and triggered an unintended decay.

The fix is a per-item `decayGeneration` counter. Every wheel entry is stamped with the generation that was current when it was inserted. Operations that need a real reschedule — `setAttribute(DURATION)`, `removeAttribute(DURATION)` — bump the counter, clear `DECAYING_TRUE`, and (for set) call `startDecay` to register a fresh entry at the new deadline. When `checkDecay` visits an entry whose stamp no longer matches the item's counter, it drops the entry without acting on it. Result: no duplicates, no late cleanup, no orphan triggers.

## Relationship to #231

This PR is **complementary** to #231 (data fix removing shallow water decay). Either alone solves the immediate issue from #153; together they provide defense in depth:

- **#231** removes the root cause (219k tiles that never needed to decay)
- **This PR** hardens the engine so similar data in the future scales gracefully

## Changes

- `src/game.h` — `EVENT_DECAY_BUCKETS` 4 → 7200; new `nextDecayTick` member; `decayItems` now holds `DecayEntry { weak_ptr<Item>, uint32_t generation }`
- `src/game.cpp`
  - `checkDecay` — catch-up loop, drift-corrected re-schedule, integrated bucket re-placement, `flushDecayDuration` before reading duration, drops entries whose generation doesn't match the item
  - `cleanup` — drains via `std::exchange` to survive re-entrant `startDecay`; expired items go straight to `internalDecayItem` instead of waiting a full rotation
  - `startDecay` — calls `markDecayStart` after registration
- `src/item.h`
  - `decayStartedAt` member, `markDecayStart()`, `flushDecayDuration()`
  - `decayGeneration` member, `getDecayGeneration()`, `bumpDecayGeneration()`
  - `getDuration()` returns the live (`stored − elapsed`) value
  - `setDuration()` clears the timestamp via the null-safe `getAttributes()` accessor
  - Orphaned `Item::decreaseDuration` removed (no callers after the rewrite)
- `src/item.cpp` (`clone`) — preserves in-progress decay and re-registers the clone with the wheel without double-registration
- `src/lua/modules/item.cpp`
  - `getAttribute(DURATION)` returns the live value
  - `setAttribute(DURATION)` bumps generation, clears `DECAYING`, applies the new value, and calls `startDecay` to register a fresh entry at the new deadline
  - `removeAttribute(DURATION)` bumps generation and clears `DECAYING` so the orphaned entry doesn't trigger an unintended decay

## Memory impact

- 7200 empty `std::list` slots in the wheel: ~170 KB
- 8 bytes (`time_point`) + 4 bytes (`decayGeneration`) per `Item`: ~2.4 MB on a 200k-item map
- 4 bytes per `DecayEntry` over the previous bare `weak_ptr`: only paid for items currently in the wheel

All negligible compared with the existing per-item footprint.

## Test plan

- [ ] Server boots without errors on a large real-life map
- [ ] Idle CPU near 0% (with or without #231)
- [ ] Items still decay at correct times (corpses, splashes, equipment)
- [ ] Life Ring / Soft Boots and other `showClientDuration` items show a live countdown on the client
- [ ] `item:setAttribute(ITEM_ATTRIBUTE_DURATION, n)` from Lua: shorter durations cleanup near the new deadline (not at the old one), longer durations still decay correctly, and the original wheel slot does not produce a duplicate cleanup
- [ ] `item:removeAttribute(ITEM_ATTRIBUTE_DURATION)` on an actively decaying item leaves the item present and untransformed when the original bucket fires
- [ ] Items that transform on decay (corpses → bones, etc.) chain correctly through `internalDecayItem` without losing the chained item
- [ ] Fishing on shallow water tiles works normally
- [ ] `/reload items` does not break decay timing

Fixes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable item decay handling with stale-entry pruning and accurate catch-up scheduling.
  * Item cloning now preserves remaining decay progress and avoids losing decay state.

* **Improvements**
  * Duration is tracked as time-based remaining duration for more accurate expirations.
  * Scripting interfaces updated for precise duration reads/writes and safer restart of decay when durations change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/236)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->