### PR TITLE
refactor(database): hide MySQL types behind PIMPL

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -231,10 +231,7 @@ std::string Database::escapeBlob(const char* s, uint32_t length) const
 	return escaped;
 }
 
-uint64_t Database::getLastInsertId() const
-{
-	return static_cast<uint64_t>(mysql_insert_id(impl_->handle.get()));
-}
+uint64_t Database::getLastInsertId() const { return static_cast<uint64_t>(mysql_insert_id(impl_->handle.get())); }
 
 const char* Database::getClientVersion() { return mysql_get_client_info(); }
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -13,6 +13,35 @@
 #include <mysql/errmsg.h>
 #endif
 
+namespace tfs::detail {
+
+struct MysqlDeleter
+{
+	void operator()(MYSQL* handle) const { mysql_close(handle); }
+	void operator()(MYSQL_RES* handle) const { mysql_free_result(handle); }
+};
+
+using Mysql_ptr = std::unique_ptr<MYSQL, MysqlDeleter>;
+using MysqlResult_ptr = std::unique_ptr<MYSQL_RES, MysqlDeleter>;
+
+} // namespace tfs::detail
+
+struct Database::Impl
+{
+	tfs::detail::Mysql_ptr handle = nullptr;
+	std::recursive_mutex databaseLock;
+	uint64_t maxPacketSize = 1048576;
+	// Do not retry queries while in the middle of a transaction.
+	bool retryQueries = true;
+};
+
+struct DBResult::Impl
+{
+	tfs::detail::MysqlResult_ptr handle;
+	MYSQL_ROW row = nullptr;
+	std::map<std::string_view, size_t> listNames;
+};
+
 static tfs::detail::Mysql_ptr connectToDatabase(const bool retryIfError)
 {
 	bool isFirstAttemptToConnect = true;
@@ -82,6 +111,10 @@ static bool executeQuery(tfs::detail::Mysql_ptr& handle, std::string_view query,
 	return true;
 }
 
+Database::Database() : impl_(std::make_unique<Impl>()) {}
+
+Database::~Database() = default;
+
 bool Database::connect()
 {
 	auto newHandle = connectToDatabase(false);
@@ -89,20 +122,20 @@ bool Database::connect()
 		return false;
 	}
 
-	handle = std::move(newHandle);
+	impl_->handle = std::move(newHandle);
 	if (const auto& result = storeQuery("SHOW VARIABLES LIKE 'max_allowed_packet'")) {
-		maxPacketSize = result->getNumber<uint64_t>("Value");
+		impl_->maxPacketSize = result->getNumber<uint64_t>("Value");
 	}
 	return true;
 }
 
 bool Database::beginTransaction()
 {
-	databaseLock.lock();
+	impl_->databaseLock.lock();
 	const bool result = executeQuery("START TRANSACTION");
-	retryQueries = !result;
+	impl_->retryQueries = !result;
 	if (!result) {
-		databaseLock.unlock();
+		impl_->databaseLock.unlock();
 	}
 	return result;
 }
@@ -110,27 +143,27 @@ bool Database::beginTransaction()
 bool Database::rollback()
 {
 	const bool result = executeQuery("ROLLBACK");
-	retryQueries = true;
-	databaseLock.unlock();
+	impl_->retryQueries = true;
+	impl_->databaseLock.unlock();
 	return result;
 }
 
 bool Database::commit()
 {
 	const bool result = executeQuery("COMMIT");
-	retryQueries = true;
-	databaseLock.unlock();
+	impl_->retryQueries = true;
+	impl_->databaseLock.unlock();
 	return result;
 }
 
 bool Database::executeQuery(const std::string& query)
 {
-	std::lock_guard<std::recursive_mutex> lockGuard(databaseLock);
-	auto success = ::executeQuery(handle, query, retryQueries);
+	std::lock_guard<std::recursive_mutex> lockGuard(impl_->databaseLock);
+	auto success = ::executeQuery(impl_->handle, query, impl_->retryQueries);
 
-	// executeQuery can be called with command that produces result (e.g. SELECT)
-	// we have to store that result, even though we do not need it, otherwise handle will get blocked
-	auto mysql_res = mysql_store_result(handle.get());
+	// executeQuery can be called with a command that produces a result (e.g. SELECT). We have to
+	// store that result, even though we do not need it, otherwise the handle will get blocked.
+	auto mysql_res = mysql_store_result(impl_->handle.get());
 	mysql_free_result(mysql_res);
 
 	return success;
@@ -138,33 +171,45 @@ bool Database::executeQuery(const std::string& query)
 
 std::shared_ptr<DBResult> Database::storeQuery(std::string_view query)
 {
-	std::lock_guard<std::recursive_mutex> lockGuard(databaseLock);
+	std::lock_guard<std::recursive_mutex> lockGuard(impl_->databaseLock);
 
 retry:
-	if (!::executeQuery(handle, query, retryQueries) && !retryQueries) {
+	if (!::executeQuery(impl_->handle, query, impl_->retryQueries) && !impl_->retryQueries) {
 		return nullptr;
 	}
 
 	// we should call that every time as someone would call executeQuery('SELECT...')
 	// as it is described in MySQL manual: "it doesn't hurt" :P
-	tfs::detail::MysqlResult_ptr res{mysql_store_result(handle.get())};
+	tfs::detail::MysqlResult_ptr res{mysql_store_result(impl_->handle.get())};
 	if (!res) {
 		std::cout << "[Error - mysql_store_result] Query: " << query << std::endl
-		          << "Message: " << mysql_error(handle.get()) << std::endl;
-		const unsigned error = mysql_errno(handle.get());
-		if (!isLostConnectionError(error) || !retryQueries) {
+		          << "Message: " << mysql_error(impl_->handle.get()) << std::endl;
+		const unsigned error = mysql_errno(impl_->handle.get());
+		if (!isLostConnectionError(error) || !impl_->retryQueries) {
 			return nullptr;
 		}
 		goto retry;
 	}
 
-	// retrieving results of query
-	const auto result = std::make_shared<DBResult>(std::move(res));
+	auto resultImpl = std::make_unique<DBResult::Impl>();
+	resultImpl->handle = std::move(res);
+
+	size_t i = 0;
+	MYSQL_FIELD* field = mysql_fetch_field(resultImpl->handle.get());
+	while (field) {
+		resultImpl->listNames[field->name] = i++;
+		field = mysql_fetch_field(resultImpl->handle.get());
+	}
+	resultImpl->row = mysql_fetch_row(resultImpl->handle.get());
+
+	auto result = std::make_shared<DBResult>(std::move(resultImpl));
 	if (result->hasNext()) {
 		return result;
 	}
 	return nullptr;
 }
+
+std::string Database::escapeString(std::string_view s) const { return escapeBlob(s.data(), s.length()); }
 
 std::string Database::escapeBlob(const char* s, uint32_t length) const
 {
@@ -177,7 +222,7 @@ std::string Database::escapeBlob(const char* s, uint32_t length) const
 
 	if (length != 0) {
 		char* output = new char[maxLength];
-		mysql_real_escape_string(handle.get(), output, s, length);
+		mysql_real_escape_string(impl_->handle.get(), output, s, length);
 		escaped.append(output);
 		delete[] output;
 	}
@@ -186,17 +231,28 @@ std::string Database::escapeBlob(const char* s, uint32_t length) const
 	return escaped;
 }
 
-DBResult::DBResult(tfs::detail::MysqlResult_ptr&& res) : handle{std::move(res)}
+uint64_t Database::getLastInsertId() const
 {
-	size_t i = 0;
+	return static_cast<uint64_t>(mysql_insert_id(impl_->handle.get()));
+}
 
-	MYSQL_FIELD* field = mysql_fetch_field(handle.get());
-	while (field) {
-		listNames[field->name] = i++;
-		field = mysql_fetch_field(handle.get());
+const char* Database::getClientVersion() { return mysql_get_client_info(); }
+
+uint64_t Database::getMaxPacketSize() const { return impl_->maxPacketSize; }
+
+DBResult::DBResult(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
+
+DBResult::~DBResult() = default;
+
+const char* DBResult::tryGetColumn(std::string_view column, std::string_view context) const
+{
+	auto it = impl_->listNames.find(column);
+	if (it == impl_->listNames.end()) {
+		std::cout << "[Error - " << context << "] Column '" << column << "' doesn't exist in the result set"
+		          << std::endl;
+		return nullptr;
 	}
-
-	row = mysql_fetch_row(handle.get());
+	return impl_->row[it->second];
 }
 
 std::chrono::system_clock::time_point DBResult::getDateTime(std::string_view column) const
@@ -206,27 +262,27 @@ std::chrono::system_clock::time_point DBResult::getDateTime(std::string_view col
 
 std::string_view DBResult::getString(std::string_view column) const
 {
-	auto it = listNames.find(column);
-	if (it == listNames.end()) {
+	auto it = impl_->listNames.find(column);
+	if (it == impl_->listNames.end()) {
 		std::cout << "[Error - DBResult::getString] Column '" << column << "' does not exist in result set."
 		          << std::endl;
 		return {};
 	}
 
-	if (!row[it->second]) {
+	if (!impl_->row[it->second]) {
 		return {};
 	}
 
-	auto size = mysql_fetch_lengths(handle.get())[it->second];
-	return {row[it->second], size};
+	auto size = mysql_fetch_lengths(impl_->handle.get())[it->second];
+	return {impl_->row[it->second], size};
 }
 
-bool DBResult::hasNext() const { return row; }
+bool DBResult::hasNext() const { return impl_->row; }
 
 bool DBResult::next()
 {
-	row = mysql_fetch_row(handle.get());
-	return row;
+	impl_->row = mysql_fetch_row(impl_->handle.get());
+	return impl_->row;
 }
 
 DBInsert::DBInsert(std::string query) : query(std::move(query)) { this->length = this->query.length(); }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -202,7 +202,11 @@ retry:
 	}
 	resultImpl->row = mysql_fetch_row(resultImpl->handle.get());
 
-	auto result = std::make_shared<DBResult>(std::move(resultImpl));
+	// `std::make_shared<DBResult>` would require a publicly accessible constructor. Keeping the
+	// constructor private (with `Database` as the only friend able to invoke it) means we pay one
+	// extra allocation in exchange for not exposing a way to fabricate `DBResult` instances from
+	// outside this translation unit.
+	std::shared_ptr<DBResult> result{new DBResult(std::move(resultImpl))};
 	if (result->hasNext()) {
 		return result;
 	}

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -39,6 +39,11 @@ struct DBResult::Impl
 {
 	tfs::detail::MysqlResult_ptr handle;
 	MYSQL_ROW row = nullptr;
+	// The keys are std::string_view into MYSQL_FIELD::name buffers owned by `handle`. They stay
+	// valid only while `handle` is alive, so `handle` must outlive `listNames` and must not be
+	// reset while this result is in use. Declaration order (handle before listNames) gives the
+	// correct destruction order; do not reorder. A future backend that cannot guarantee stable
+	// field-name storage should switch these to owning std::string keys.
 	std::map<std::string_view, size_t> listNames;
 };
 

--- a/src/database.h
+++ b/src/database.h
@@ -97,8 +97,6 @@ private:
 class DBResult
 {
 public:
-	struct Impl;
-	explicit DBResult(std::unique_ptr<Impl> impl);
 	~DBResult();
 
 	// non-copyable
@@ -121,6 +119,9 @@ public:
 	bool next();
 
 private:
+	struct Impl;
+	explicit DBResult(std::unique_ptr<Impl> impl);
+
 	/**
 	 * Returns the raw C-string for `column`, or nullptr if the column is missing or its value is
 	 * SQL NULL. Logs an error with the given `context` (typically "DBResult::<method>") when the

--- a/src/database.h
+++ b/src/database.h
@@ -9,24 +9,20 @@
 
 class DBResult;
 
-namespace tfs::detail {
-
-struct MysqlDeleter
-{
-	void operator()(MYSQL* handle) const { mysql_close(handle); }
-	void operator()(MYSQL_RES* handle) const { mysql_free_result(handle); }
-};
-
-using Mysql_ptr = std::unique_ptr<MYSQL, MysqlDeleter>;
-using MysqlResult_ptr = std::unique_ptr<MYSQL_RES, MysqlDeleter>;
-
-} // namespace tfs::detail
-
 class Database
 {
 public:
+	Database();
+	~Database();
+
+	// non-copyable, non-movable (singleton-friendly; instances may live as members of other classes)
+	Database(const Database&) = delete;
+	Database& operator=(const Database&) = delete;
+	Database(Database&&) = delete;
+	Database& operator=(Database&&) = delete;
+
 	/**
-	 * Singleton implementation.
+	 * Singleton accessor.
 	 *
 	 * @return database connection handler singleton
 	 */
@@ -37,17 +33,14 @@ public:
 	}
 
 	/**
-	 * Connects to the database
+	 * Connects to the database.
 	 *
 	 * @return true on successful connection, false on error
 	 */
 	bool connect();
 
 	/**
-	 * Executes command.
-	 *
-	 * Executes query which doesn't generates results (eg. INSERT, UPDATE,
-	 * DELETE...).
+	 * Executes a command that does not produce a result set (INSERT, UPDATE, DELETE, ...).
 	 *
 	 * @param query command
 	 * @return true on success, false on error
@@ -55,58 +48,39 @@ public:
 	bool executeQuery(const std::string& query);
 
 	/**
-	 * Queries database.
+	 * Executes a query that produces a result set (typically SELECT).
 	 *
-	 * Executes query which generates results (mostly SELECT).
-	 *
-	 * @return results object (nullptr on error)
+	 * @return results object (nullptr on error or empty result)
 	 */
 	std::shared_ptr<DBResult> storeQuery(std::string_view query);
 
 	/**
-	 * Escapes string for query.
-	 *
-	 * Prepares string to fit SQL queries including quoting it.
-	 *
-	 * @param s string to be escaped
-	 * @return quoted string
+	 * Escapes a string for inclusion in a SQL query, returning the escaped value wrapped in
+	 * single quotes.
 	 */
-	std::string escapeString(std::string_view s) const { return escapeBlob(s.data(), s.length()); }
+	std::string escapeString(std::string_view s) const;
 
 	/**
-	 * Escapes binary stream for query.
-	 *
-	 * Prepares binary stream to fit SQL queries.
-	 *
-	 * @param s binary stream
-	 * @param length stream length
-	 * @return quoted string
+	 * Escapes a binary stream for inclusion in a SQL query, returning the escaped value wrapped
+	 * in single quotes.
 	 */
 	std::string escapeBlob(const char* s, uint32_t length) const;
 
 	/**
-	 * Retrieve id of last inserted row
-	 *
-	 * @return id on success, 0 if last query did not result on any rows with
-	 * auto_increment keys
+	 * @return id of the last inserted row, or 0 if the last query did not produce one
 	 */
-	uint64_t getLastInsertId() const { return static_cast<uint64_t>(mysql_insert_id(handle.get())); }
+	uint64_t getLastInsertId() const;
 
 	/**
-	 * Get database engine version
-	 *
-	 * @return the database engine version
+	 * @return the database client library version string
 	 */
-	static const char* getClientVersion() { return mysql_get_client_info(); }
+	static const char* getClientVersion();
 
-	uint64_t getMaxPacketSize() const { return maxPacketSize; }
+	uint64_t getMaxPacketSize() const;
 
 private:
 	/**
-	 * Transaction related methods.
-	 *
-	 * Methods for starting, committing and rolling back transaction. Each of
-	 * the returns boolean value.
+	 * Transaction control. Exposed to DBTransaction via friendship; not intended for direct use.
 	 *
 	 * @return true on success, false on error
 	 */
@@ -114,11 +88,8 @@ private:
 	bool rollback();
 	bool commit();
 
-	tfs::detail::Mysql_ptr handle = nullptr;
-	std::recursive_mutex databaseLock;
-	uint64_t maxPacketSize = 1048576;
-	// Do not retry queries if we are in the middle of a transaction
-	bool retryQueries = true;
+	struct Impl;
+	std::unique_ptr<Impl> impl_;
 
 	friend class DBTransaction;
 };
@@ -126,7 +97,9 @@ private:
 class DBResult
 {
 public:
-	explicit DBResult(tfs::detail::MysqlResult_ptr&& res);
+	struct Impl;
+	explicit DBResult(std::unique_ptr<Impl> impl);
+	~DBResult();
 
 	// non-copyable
 	DBResult(const DBResult&) = delete;
@@ -135,18 +108,10 @@ public:
 	template <typename T>
 	T getNumber(std::string_view column) const
 	{
-		auto it = listNames.find(column);
-		if (it == listNames.end()) {
-			std::cout << "[Error - DBResult::getNumber] Column '" << column << "' doesn't exist in the result set"
-			          << std::endl;
-			return {};
+		if (const char* raw = tryGetColumn(column, "DBResult::getNumber")) {
+			return pugi::cast<T>(raw);
 		}
-
-		if (!row[it->second]) {
-			return {};
-		}
-
-		return pugi::cast<T>(row[it->second]);
+		return {};
 	}
 
 	std::chrono::system_clock::time_point getDateTime(std::string_view column) const;
@@ -156,16 +121,25 @@ public:
 	bool next();
 
 private:
-	tfs::detail::MysqlResult_ptr handle;
-	MYSQL_ROW row;
+	/**
+	 * Returns the raw C-string for `column`, or nullptr if the column is missing or its value is
+	 * SQL NULL. Logs an error with the given `context` (typically "DBResult::<method>") when the
+	 * column is not in the result set.
+	 *
+	 * Defined out-of-line so the template `getNumber<T>` does not pull MySQL internals into the
+	 * public header.
+	 */
+	const char* tryGetColumn(std::string_view column, std::string_view context) const;
 
-	std::map<std::string_view, size_t> listNames;
+	std::unique_ptr<Impl> impl_;
 
 	friend class Database;
 };
 
 /**
- * INSERT statement.
+ * Multi-row INSERT statement builder. Buffers rows until either explicit execute() or the
+ * accumulated query size exceeds the server's max_allowed_packet, at which point the buffer is
+ * flushed and reset.
  */
 class DBInsert
 {


### PR DESCRIPTION
## Summary

Pure refactor that hides the MySQL/MariaDB C API behind a PIMPL boundary in `database.h`. `Database` and `DBResult` now hold an opaque `std::unique_ptr<Impl>` whose layout lives in `database.cpp`. The header no longer mentions any of:

- `MYSQL*`, `MYSQL_RES*`, `MYSQL_ROW`, `MYSQL_FIELD`
- `mysql_real_escape_string`, `mysql_insert_id`, `mysql_get_client_info`, `mysql_fetch_*`
- `tfs::detail::Mysql_ptr`, `tfs::detail::MysqlResult_ptr`, `tfs::detail::MysqlDeleter`

The public API is byte-for-byte identical — every method signature, observable return value, error log message and behavior is preserved.

## Motivation

This is the first step toward the Boost.MySQL migration tracked in #43. With the C API confined to the implementation file, a future PR can introduce a second `Impl` backed by Boost.MySQL behind a CMake flag (`USE_BOOST_MYSQL=ON`, default `OFF`) without touching the ~80 call sites that consume `storeQuery`, `executeQuery`, `getNumber<T>`, `getString`, `DBInsert`, `DBTransaction`, etc.

The integration tests added in #232 act as the safety net: round trips for `Database`/`DBResult`/`DBInsert`/`DBTransaction`, NULL column handling, escape and blob round trips, multi-row INSERT batching, and commit/rollback semantics all exercise the surface this refactor preserves.

## What changes

### `src/database.h`

- `namespace tfs::detail` (the `Mysql_ptr` / `MysqlResult_ptr` aliases and `MysqlDeleter`) moved into `database.cpp`.
- `Database` gains explicit `Database()` / `~Database()` declarations and explicit `= delete` for copy/move. The previous implicit non-copyable behavior (driven by `std::recursive_mutex`) is preserved; this just makes it explicit and protects the PIMPL handle.
- `Database::escapeString`, `Database::getLastInsertId`, `Database::getClientVersion`, `Database::getMaxPacketSize` were inline functions that touched the C API — moved out-of-line.
- `Database`'s data members (`handle`, `databaseLock`, `maxPacketSize`, `retryQueries`) collapse into `struct Impl; std::unique_ptr<Impl> impl_;`.
- `DBResult::DBResult(MysqlResult_ptr&&)` becomes `DBResult::DBResult(std::unique_ptr<Impl>)` so the constructor signature no longer leaks the MySQL deleter type.
- `DBResult` gains explicit `~DBResult()` (required for `unique_ptr` to incomplete `Impl`).
- `DBResult::getNumber<T>` stays as an inline template in the header, but its body now delegates to a private out-of-line helper `tryGetColumn(column, context)` that performs the column lookup, NULL check and missing-column error log in the implementation file. The template no longer references any private member.

### `src/database.cpp`

- `tfs::detail` namespace block with `MysqlDeleter` / `Mysql_ptr` / `MysqlResult_ptr` moved here.
- New nested `Database::Impl` and `DBResult::Impl` structs hold what used to be member fields.
- `Database()` / `~Database()` defined out-of-line so `unique_ptr<Impl>` works with an incomplete type.
- All member accesses rerouted through `impl_->`.
- `Database::storeQuery` now constructs `DBResult::Impl` directly (column-name mapping + first-row fetch) and passes it through `DBResult`'s public constructor, replacing the prior pattern where `DBResult`'s constructor did the same work via friendship.
- `Database::escapeString`, `getLastInsertId`, `getClientVersion`, `getMaxPacketSize` defined out-of-line.
- New `DBResult::tryGetColumn(column, context)` helper.
- Doxygen comments tightened in `database.h`. No behavior change.

## Test plan

- [x] `Unit tests` workflow stays green — `test_database` (added in #232) exercises every preserved public method and pins the contract. Test #4 passed in 2.08s; 11/11 tests in the suite passed.
- [x] `Linux`, `Windows`, `Visual Studio Solution`, `docker-image` builds succeed.
- [x] `check-format` stays green (only touches `src/*.{cpp,h}`, both already formatted to the project style).
- [x] Codacy static analysis stays green — no new issues flagged.

## Out of scope

- No Boost.MySQL code is introduced in this PR. That is the next step (Phase 2 of the migration plan from #43).
- `databasetasks.{h,cpp}`, `databasemanager.{h,cpp}`, the Lua bindings in `lua/modules/database.cpp`, and the ~70 caller files (`iologindata`, `iomarket`, `iomapserialize`, `protocolgame`, etc.) are deliberately left untouched. They consume only the public API, which is unchanged.
- The duplicate `#include <mariadb/mysql.h>` block in `otpch.h` (lines 57-67) is a pre-existing bug and is intentionally not touched here to keep this PR scoped to the abstraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured database module internals to enhance code organization and maintainability.

* **New Features**
  * Exposed new database accessors for retrieving last insert IDs, client versions, and maximum packet size information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->