### PR TITLE
fix(http): add missing precompiled header include to HTTP source files

### DIFF
--- a/src/http/error.cpp
+++ b/src/http/error.cpp
@@ -1,3 +1,5 @@
+#include "../otpch.h"
+
 #include "error.h"
 
 std::pair<beast::http::status, json::value> tfs::http::make_error_response(detail::ErrorResponseParams params /*= {}*/)

--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -1,3 +1,5 @@
+#include "../otpch.h"
+
 #define BOOST_ASIO_NO_DEPRECATED
 
 #include "http.h"

--- a/src/http/listener.cpp
+++ b/src/http/listener.cpp
@@ -1,3 +1,5 @@
+#include "../otpch.h"
+
 #include "listener.h"
 
 #include "session.h"

--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -1,3 +1,5 @@
+#include "../otpch.h"
+
 #include "router.h"
 
 #include "cacheinfo.h"

--- a/src/http/session.cpp
+++ b/src/http/session.cpp
@@ -1,3 +1,5 @@
+#include "../otpch.h"
+
 #include "session.h"
 
 #include "router.h"


### PR DESCRIPTION
## Summary
- Five HTTP source files (`error.cpp`, `http.cpp`, `listener.cpp`, `router.cpp`, `session.cpp`) were missing `#include "../otpch.h"` as their first include
- The vcxproj enforces `<PrecompiledHeader>Use</PrecompiledHeader>` globally, so every `.cpp` must include the PCH — these five did not, causing **MSVC C1010** when compiled individually (i.e. with Unity Build disabled)
- The bug was latent because Unity Build merges translation units, so the PCH from adjacent files covered these — but it breaks on toolsets where Unity is disabled (e.g. v145)

## Test plan
- [ ] Build with MSVC (v145 toolset, Unity Build disabled) in both Debug and Release — no C1010 errors
- [ ] Build with CMake on Linux/GCC — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP server startup function with configurable port (default 8080) and adjustable worker thread count
  * IP address binding options supporting both specific IP addresses and all interfaces
  * Graceful server shutdown with proper cleanup and logging
  * Startup and shutdown status logging for monitoring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/239)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->