### PR TITLE
fix(player): defer zone change until after map description on login

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1024,7 +1024,13 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 
 		updateRegeneration();
 
-		onChangeZone(getZone());
+		if (getZone() == ZONE_PROTECTION) {
+			if (getAttackedCreature() && !hasFlag(PlayerFlag_IgnoreProtectionZone)) {
+				setAttackedCreature(nullptr);
+				sendCancelTarget();
+				sendTextMessage(MESSAGE_STATUS_SMALL, "Target lost.");
+			}
+		}
 
 		IOLoginData::updateOnlineStatus(guid, true);
 
@@ -1058,6 +1064,10 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 	sendPendingStateEntered();
 	sendEnterWorld();
 	sendMapDescription();
+
+	if (isLogin) {
+		g_game.updateCreatureWalkthrough(asPlayer());
+	}
 
 	if (magicEffect != CONST_ME_NONE) {
 		sendMagicEffect(magicEffect);


### PR DESCRIPTION
## Summary

Fixes #241

When a player logs in, the server sends a series of packets to the client in a specific order. One of those packets is the **map description** — it tells the client what the world looks like around the player (tiles, creatures, items, etc.).

There is also a **walkthrough update** (opcode `0x92`) — it tells the client whether it can walk through certain creatures (e.g., players in a protection zone become "walkable" so you don't get stuck).

### The problem

The walkthrough update was being sent **before** the map description. This is like telling someone "you can walk through that person over there" before they even know where "there" is. The client receives information about creatures it doesn't know about yet because the map hasn't loaded.

This happened because `onChangeZone()` (which triggers the walkthrough update) was called early in the login process, inside the login-specific setup block, **before** the login packet sequence that includes `sendMapDescription()`.

### The fix

Instead of moving the entire `onChangeZone()` call (which is designed for real zone transitions, not login initialization), the two independent concerns inside it are now handled separately at the right moment:

1. **Protection zone logic** (cancel attack target) — stays early in the `isLogin` block, before any packets are sent. This is state cleanup that doesn't require the map.
2. **`updateCreatureWalkthrough()`** — moved to right after `sendMapDescription()`, so the client already knows the map before receiving walkthrough updates.
3. **`sendIcons()`** — already called unconditionally later in the login packet sequence (no duplicate needed).

This avoids calling `onChangeZone()` during login entirely — no zone change actually happened, so firing that event was misleading.

### Before (incorrect order)
```
1. onChangeZone()
   ├── PZ cancel target
   ├── updateCreatureWalkthrough() (opcode 0x92)  ← too early!
   └── sendIcons() (duplicate)
2. sendMapDescription()  ← map arrives after walkthrough
3. sendIcons()
```

### After (correct order)
```
1. PZ cancel target (inline, early in isLogin block)
2. sendMapDescription()  ← map arrives first
3. updateCreatureWalkthrough() (opcode 0x92)  ← now safe
4. sendIcons()  ← single call, no duplicate
```

### Why this is safe

- **No dependency broken**: The operations between the old and new positions (`updateOnlineStatus`, guild membership, equipment decay, VIP notifications, `onLogin` event) are all independent of zone state.
- **No behavior change for non-login**: `onChangeZone()` is untouched for real zone transitions (e.g., walking into a PZ tile, handled in `Creature::onMoved`).
- **PZ logic preserved**: If the player logs into a protection zone with a stale attack target, it is still cleared — just handled inline instead of through `onChangeZone`.
- **No duplicate packets**: `sendIcons()` is called once (at the end of the login sequence) instead of twice.

## Test plan

- [ ] Log in with a character and verify the map loads correctly
- [ ] Log in inside a protection zone and verify the PZ icon appears
- [ ] Log in near other players and verify walkthrough states are correct
- [ ] Log in while having an attack target set (from previous session) in a PZ and verify it gets canceled
- [ ] Walk into/out of a protection zone normally (non-login) and verify walkthrough + icons still update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player state restoration during login to better handle zone synchronization.
  * Enhanced protection zone mechanics to properly manage target state when specific conditions are met.
  * Refined client notifications for target loss scenarios in protected areas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->