### PR TITLE
perf: replace linear searches with hash maps for O(1) lookups

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1231,28 +1231,33 @@ Condition* Creature::getCondition(ConditionType_t type, ConditionId_t conditionI
 
 void Creature::executeConditions(std::chrono::milliseconds interval)
 {
-	std::vector<Condition*> tempConditions;
-	tempConditions.reserve(conditions.size());
+	std::vector<Condition*> snapshot;
+	snapshot.reserve(conditions.size());
 	for (const auto& condition : conditions) {
-		tempConditions.push_back(condition.get());
+		snapshot.push_back(condition.get());
 	}
 
-	for (Condition* condition : tempConditions) {
-		auto it = std::find_if(conditions.begin(), conditions.end(),
-		                       [condition](const std::unique_ptr<Condition>& c) { return c.get() == condition; });
+	auto findOwning = [this](Condition* c) {
+		return std::ranges::find_if(conditions, [c](const std::unique_ptr<Condition>& p) { return p.get() == c; });
+	};
+
+	for (Condition* condition : snapshot) {
+		if (findOwning(condition) == conditions.end()) {
+			continue;
+		}
+
+		if (condition->executeCondition(asCreature(), interval)) {
+			continue;
+		}
+
+		auto it = findOwning(condition);
 		if (it == conditions.end()) {
 			continue;
 		}
 
-		if (!condition->executeCondition(asCreature(), interval)) {
-			it = std::find_if(conditions.begin(), conditions.end(),
-			                  [condition](const std::unique_ptr<Condition>& c) { return c.get() == condition; });
-			if (it != conditions.end()) {
-				condition->endCondition(asCreature());
-				onEndCondition(condition->getType());
-				conditions.erase(it);
-			}
-		}
+		condition->endCondition(asCreature());
+		onEndCondition(condition->getType());
+		conditions.erase(it);
 	}
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -427,8 +427,8 @@ private:
 
 	std::vector<std::weak_ptr<Creature>> summons;
 
-	std::map<uint32_t, CountBlock_t> damageMap;
-	std::map<uint32_t, int32_t> storageMap;
+	std::unordered_map<uint32_t, CountBlock_t> damageMap;
+	std::unordered_map<uint32_t, int32_t> storageMap;
 
 	Position position;
 	Position lastPosition;

--- a/src/game.h
+++ b/src/game.h
@@ -519,11 +519,11 @@ private:
 
 	boost::container::flat_map<uint32_t, std::shared_ptr<House>> houses;
 
-	std::map<uint32_t, std::weak_ptr<Npc>> npcs;
-	std::map<uint32_t, std::weak_ptr<Monster>> monsters;
+	std::unordered_map<uint32_t, std::weak_ptr<Npc>> npcs;
+	std::unordered_map<uint32_t, std::weak_ptr<Monster>> monsters;
 
 	// list of items that are in trading state, mapped to the player holding them
-	std::map<std::shared_ptr<Item>, uint32_t> tradeItems;
+	std::unordered_map<std::shared_ptr<Item>, uint32_t> tradeItems;
 
 	std::unordered_set<std::shared_ptr<Tile>> tilesToClean;
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -113,4 +113,26 @@ private:
 
 } // namespace tfs
 
+struct CaseInsensitiveStringHash
+{
+	using is_transparent = void;
+
+	size_t operator()(std::string_view sv) const noexcept
+	{
+		size_t h = 0xcbf29ce484222325ULL;
+		for (unsigned char c : sv) {
+			h ^= static_cast<size_t>(std::tolower(c));
+			h *= 0x100000001b3ULL;
+		}
+		return h;
+	}
+};
+
+struct CaseInsensitiveStringEqual
+{
+	using is_transparent = void;
+
+	bool operator()(std::string_view a, std::string_view b) const noexcept { return boost::iequals(a, b); }
+};
+
 #endif // FS_TOOLS_H

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -111,7 +111,22 @@ bool Vocations::loadFromXml(std::istream& is, std::string_view filename)
 			}
 		}
 	}
+	buildIndices();
 	return true;
+}
+
+void Vocations::buildIndices()
+{
+	vocationByName.clear();
+	promotedVocations.clear();
+	vocationByName.reserve(vocationsMap.size());
+	promotedVocations.reserve(vocationsMap.size());
+	for (const auto& [id, voc] : vocationsMap) {
+		vocationByName[voc.name] = id;
+		if (voc.fromVocation != VOCATION_NONE && voc.fromVocation != id) {
+			promotedVocations[voc.fromVocation] = id;
+		}
+	}
 }
 
 Vocation* Vocations::getVocation(uint16_t id)
@@ -126,16 +141,14 @@ Vocation* Vocations::getVocation(uint16_t id)
 
 int32_t Vocations::getVocationId(std::string_view name) const
 {
-	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(),
-	                       [=](auto it) { return boost::iequals(name, it.second.name); });
-	return it != vocationsMap.end() ? it->first : -1;
+	auto it = vocationByName.find(name);
+	return it != vocationByName.end() ? it->second : -1;
 }
 
 uint16_t Vocations::getPromotedVocation(uint16_t id) const
 {
-	auto it = std::find_if(vocationsMap.begin(), vocationsMap.end(),
-	                       [id](auto it) { return it.second.fromVocation == id && it.first != id; });
-	return it != vocationsMap.end() ? it->first : VOCATION_NONE;
+	auto it = promotedVocations.find(id);
+	return it != promotedVocations.end() ? it->second : VOCATION_NONE;
 }
 
 static const uint32_t skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -6,6 +6,7 @@
 
 #include "configmanager.h"
 #include "enums.h"
+#include "tools.h"
 
 class Vocation
 {
@@ -87,7 +88,7 @@ private:
 	bool magicShield = false;
 };
 
-using VocationMap = std::map<uint16_t, Vocation>;
+using VocationMap = std::unordered_map<uint16_t, Vocation>;
 
 class Vocations
 {
@@ -100,7 +101,11 @@ public:
 	const VocationMap& getVocations() const { return vocationsMap; }
 
 private:
+	void buildIndices();
+
 	VocationMap vocationsMap;
+	std::unordered_map<std::string, uint16_t, CaseInsensitiveStringHash, CaseInsensitiveStringEqual> vocationByName;
+	std::unordered_map<uint16_t, uint16_t> promotedVocations;
 };
 
 #endif // FS_VOCATION_H


### PR DESCRIPTION
Replace std::map with std::unordered_map for damageMap, storageMap, npcs, monsters, tradeItems, and VocationMap. Add index hash maps for vocation name/promotion lookups (O(n) -> O(1)). Add transparent CaseInsensitiveStringHash for allocation-free string_view queries. Refactor executeConditions to use a findOwning lambda eliminating duplicate find_if calls. Mounts optimization removed as mounts were migrated to Lua in #114.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
