### PR TITLE
fix(database): count row bytes after flush in DBInsert::addRow

### DIFF
--- a/src/database.cpp
+++ b/src/database.cpp
@@ -297,10 +297,14 @@ bool DBInsert::addRow(const std::string& row)
 {
 	// adds new row to buffer
 	const size_t rowLength = row.length();
-	length += rowLength;
-	if (length > Database::getInstance().getMaxPacketSize() && !execute()) {
+	// Flush the buffer before adding this row if it would push the statement past the packet
+	// limit. execute() resets length to query.length(), so the current row must be accounted for
+	// *after* the potential flush; incrementing before the check loses this row's bytes from the
+	// running total whenever a flush happens, letting later checks undercount.
+	if (length + rowLength > Database::getInstance().getMaxPacketSize() && !execute()) {
 		return false;
 	}
+	length += rowLength;
 
 	if (values.empty()) {
 		values.reserve(rowLength + 2);


### PR DESCRIPTION
## Summary

`DBInsert::addRow` increments `length` by the new row's size **before** the packet-limit check:

```cpp
const size_t rowLength = row.length();
length += rowLength;
if (length > Database::getInstance().getMaxPacketSize() && !execute()) {
    return false;
}
```

When the check triggers a flush, `execute()` does `values.clear(); length = query.length();`. The current row is then appended to the freshly emptied buffer, but its bytes were just discarded from `length` by the reset. So **every flush loses one row's worth from the running total**, and subsequent `addRow` checks undercount — the accumulated statement can grow past `max_allowed_packet` and the eventual `executeQuery` may be rejected by the server.

## Fix

Move the increment to **after** the check (and base the check on `length + rowLength`):

```cpp
const size_t rowLength = row.length();
if (length + rowLength > Database::getInstance().getMaxPacketSize() && !execute()) {
    return false;
}
length += rowLength;
```

Pure correctness fix. No API change. For the common no-flush path the behavior is identical. The increment is now always applied to the correct (post-flush) base.

> Note: `length` still excludes the per-row `(`, `)` and `,` punctuation, exactly as before — that is a separate, long-standing approximation and is intentionally left unchanged here to keep the fix minimal.

## Context

Spotted by CodeRabbit during review of #244 (the Boost.MySQL backend, which copies this backend-agnostic `DBInsert` verbatim). Fixing it here, in the canonical `database.cpp`, keeps both current and future backends consistent; #244 will pick this up on rebase.

## Test plan

- [ ] `Unit tests` — `test_database` exercises this path via `dbinsert_auto_flushes_when_exceeding_max_packet_size` (added in #232); it must stay green.
- [ ] `Linux` / `Windows` / `Visual Studio Solution` / `docker-image` build green.
- [ ] `check-format` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a row insertion issue where data could be lost when exceeding maximum packet size limits. The size validation check now executes in the correct order, ensuring accurate tracking of data during database flush operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->