### PR TITLE
fix(monster): drop follow target when victim enters protection zone

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -476,6 +476,7 @@ void Creature::onCreatureMove(const std::shared_ptr<Creature>& creature, const s
 				} else {
 					if (zone == ZONE_PROTECTION) {
 						setAttackedCreature(nullptr);
+						setFollowCreature(nullptr);
 
 						if (const auto& monster = asMonster()) {
 							monster->resetAttackTicks();


### PR DESCRIPTION
## Summary

Fixes #248 ("Monster keeps target after entering PZ").

When a monster had a target and that creature stepped into a protection zone while still visible to the monster on the same floor, `Creature::onCreatureMove` cleared only `attackedCreature` in the protection-zone branch. `followCreature` kept pointing at the victim, so the monster kept chasing it until the player moved far enough out of sight or relogged.

This adds a single `setFollowCreature(nullptr)` call in the existing monster protection-zone branch, mirroring what `Creature::onChangeZone` already does (it clears both `attackedCreature` and `followCreature`). The monster now drops the target immediately on PZ entry, regardless of distance from the PZ boundary.

## Root cause

`src/creature.cpp` — protection-zone handling inside `Creature::onCreatureMove` only reset `attackedCreature`; the `followCreature` block above it only releases on floor change or loss of sight, never on PZ entry. For monsters, `followCreature` independently drives the chase, so the monster kept following.

## Test plan

- [ ] Stand inside a PZ, leave it so a nearby monster targets you, then step back onto the first PZ tile ~1 sqm from the exit: monster must drop the target immediately.
- [ ] Verify the monster re-acquires the target normally once the player leaves the PZ again.
- [ ] Verify summons attacking a victim that enters a PZ stop attacking and resume following their master.
- [ ] Verify player "follow" behaviour is unchanged (this branch only affects the non-player path).