### PR TITLE
perf(net): avoid zero-initializing 64 KB OutputMessage buffer

### DIFF
--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -11,7 +11,13 @@
 class OutputMessage : public NetworkMessage
 {
 public:
-	OutputMessage() = default;
+	// User-provided (non-defaulted) so that std::allocate_shared<OutputMessage> performs
+	// default-initialization instead of value-initialization. Value-initialization would
+	// zero the entire NetworkMessage::buffer (~64 KB) on every construction even though
+	// only buffer[0..length) is ever written/sent. All transmitted bytes are explicitly
+	// written by add*/add_header/addPaddingBytes before send, so leaving the buffer
+	// uninitialized is safe (this already matches plain `NetworkMessage` usage).
+	OutputMessage() noexcept {}
 
 	// non-copyable
 	OutputMessage(const OutputMessage&) = delete;
@@ -66,7 +72,9 @@ private:
 	}
 
 	MsgSize_t outputBufferStart = INITIAL_BUFFER_POSITION;
-	uint32_t sequenceId;
+	// Was incidentally zeroed by value-initialization; keep an explicit default now that
+	// the object is no longer zero-initialized on construction.
+	uint32_t sequenceId = 0;
 };
 
 namespace tfs::net {


### PR DESCRIPTION
## Problem (atlas-kit/atlas#240, item 1)

`tfs::net::make_output_message()` uses `std::allocate_shared<OutputMessage>()`, which **value-initializes** the object. Because `OutputMessage`/`NetworkMessage` had non-user-provided defaulted constructors, value-initialization **zero-fills the whole object**, including `NetworkMessage::buffer` — a `std::array<uint8_t, NETWORKMESSAGE_MAXSIZE>` of ~64 KB — on **every** construction, even though only `buffer[0..length)` is ever written and sent. Under the 500-bot stress test this `memset` was a large part of the ~12% allocation cost.

## Change

- `src/outputmessage.h`: `OutputMessage()` is now **user-provided** (`OutputMessage() noexcept {}`) instead of `= default`. A user-provided default constructor makes `std::allocate_shared` perform **default-initialization** (no object-wide zeroing) instead of value-initialization.
- `sequenceId` gets an explicit `= 0` initializer (it was previously zeroed only as a side effect of value-init).

## Why this is 100% safe (no engine-mechanic impact)

- **The engine already runs with an uninitialized buffer.** Stack `NetworkMessage` instances and `new NetworkMessage` in the Lua module are default-initialized today (buffer not zeroed) and work correctly. This change only makes the `allocate_shared<OutputMessage>` path behave the same way.
- **Only `[0, length)` is ever transmitted**, and every byte in that range is explicitly written before send via `add*` / `add_header`.
- **XTEA padding is explicit**: `XTEA_encrypt` -> `addPaddingBytes` fills the pad with `0x33` (`std::fill_n`) and updates `length`; `xtea::encrypt` operates strictly on `[buffer, buffer+length)`. No reliance on a pre-zeroed buffer anywhere.
- **`sequenceId` correctness preserved**: it is always set by `setSequenceId` before `addCryptoHeader()`/`getSequenceId()` (both gated on `encryptionEnabled`, set precedes read in `Protocol::onSendMessage`). The explicit `= 0` keeps the exact prior value with zero cost, eliminating any theoretical uninitialized read.

## Why it fixes the problem

Removing the per-construction 64 KB zero-fill eliminates the dominant cost inside `make_output_message()` under load (15,000+ messages/s), while serialization output is byte-for-byte identical.

## Validation

- Reasoning-level: provably semantics-preserving (verified buffer is only ever read within the explicitly-written `[0,length)` window; padding/headers explicit; sequenceId set-before-read).
- Not stress-tested in this environment (no profiling harness). Behavior of generated packets is unchanged.