### PR TITLE
perf(tile): add non-owning getGroundRef() for serialization hot path

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -814,7 +814,7 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 void ProtocolGame::GetTileDescription(const std::shared_ptr<const Tile>& tile, NetworkMessage& msg)
 {
 	int32_t count;
-	if (const auto& ground = tile->getGround()) {
+	if (const auto& ground = tile->getGroundRef()) {
 		msg.addItem(ground);
 		count = 1;
 	} else {

--- a/src/tile.h
+++ b/src/tile.h
@@ -248,6 +248,10 @@ public:
 	std::shared_ptr<Item> getUseItem(int32_t index) const;
 
 	std::shared_ptr<Item> getGround() const { return ground; }
+	// Non-owning view of the ground item, for transient reads in hot paths (e.g. tile
+	// serialization) where no ownership is taken and the tile outlives the access.
+	// Avoids the atomic shared_ptr copy that getGround() performs on every call.
+	const std::shared_ptr<Item>& getGroundRef() const { return ground; }
 	void setGround(std::shared_ptr<Item> item) { ground = std::move(item); }
 
 private:


### PR DESCRIPTION
## Problem (atlas-kit/atlas#240, item 7)

`ProtocolGame::GetTileDescription` runs for every tile of every spectator's visible map area on each move (~1.9% self CPU in the 500-bot profile). It called `Tile::getGround()`, which **returns `std::shared_ptr<Item>` by value**, copying the ground pointer (atomic ref-count inc + dec) for every ground tile serialized.

## Change

- Add `Tile::getGroundRef()` returning `const std::shared_ptr<Item>&` (a const reference to the `ground` member — no copy).
- Use it at the **single** hot site, `GetTileDescription` (`src/protocolgame.cpp`).
- `getGround()` and the **other 16 callers are left untouched**.

> Note: this delivers item 7 only. Item 4 (`Map::getTile` returning `shared_ptr` by value) is **not** included here — see the caveat below.

## Why this is 100% safe (no engine-mechanic impact)

- **Pure addition** for the API: `getGround()` keeps its exact value-returning signature, so none of the other 16 call sites change behavior.
- **The migrated site is a provably-safe transient read**: `GetTileDescription` receives the tile as `const std::shared_ptr<const Tile>&`, so the caller keeps the `Tile` alive for the entire call. The ground is only *read* (`msg.addItem`) and is never reassigned within `GetTileDescription`, so the returned reference cannot dangle.
- **Identical output**: `msg.addItem` still receives the same `shared_ptr<const Item>` (same implicit conversion as before). The only thing removed is the redundant copy that the value-returning `getGround()` forced on the return.

## Why it fixes the problem

It removes one atomic ref-count pair per ground tile per serialized tile in the hottest serialization loop, which is exactly the cost item 7 flagged, while producing byte-identical packets.

## Caveat on item 4 (`Map::getTile` by value) — intentionally excluded

`getTile()` returning `std::shared_ptr<Tile>` by value has ~hundreds of callers, and the hot consumers (`GetFloorDescription` -> `GetTileDescription`) pass the tile onward as `const std::shared_ptr<const Tile>&`. Capturing the gain requires either changing `getTile`'s return type (lifetime-sensitive across `setTile`/`removeTile`, not auditable to a 100% guarantee here) or widening `GetTileDescription`'s signature. Neither meets the "100% cannot break engine mechanics" bar without a stress-test harness, so it is deliberately left out rather than shipped as a risky change.

## Validation

- Reasoning-level: additive API; single migrated site proven non-dangling and output-identical.
- Not stress-tested here (no profiling harness).