### PR TITLE
cleanup(creature): remove stale follower when clearing follow target

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -840,6 +840,10 @@ void Creature::getPathSearchParams(const std::shared_ptr<const Creature>&, FindP
 void Creature::setFollowCreature(const std::shared_ptr<Creature>& creature)
 {
 	if (!creature) {
+		if (const auto& oldFollow = getFollowCreature()) {
+			oldFollow->removeFollower(asCreature());
+		}
+
 		followCreature.reset();
 
 		hasFollowPath = false;


### PR DESCRIPTION
## Summary
- Remove the creature from the old target's `followers` set when `setFollowCreature(nullptr)` is called
- Matches the existing cleanup behavior already used in the non-null assignment path (line 873)
- Prevents stale `weak_ptr` entries from accumulating in long-lived creatures' `followers` sets

Closes #258