### PR TITLE
ci: add ccache to Linux build for faster rebuilds

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -116,6 +116,28 @@ jobs:
           restore-keys: |
             vcpkg-windows-
 
+      - name: Cache sccache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ runner.temp }}/sccache
+          key: sccache-windows-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+          restore-keys: |
+            sccache-windows-
+
+      - name: Install sccache
+        shell: pwsh
+        run: |
+          $dir = "${{ runner.temp }}\sccache"
+          if (-not (Test-Path "$dir\sccache.exe")) {
+            New-Item -ItemType Directory -Force -Path $dir
+            $tmp = "$dir\sccache.tar.gz"
+            Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-pc-windows-msvc.tar.gz" -OutFile $tmp
+            tar -xzf $tmp -C $dir
+            Move-Item "$dir\sccache-v0.10.0-x86_64-pc-windows-msvc\sccache.exe" $dir\
+          }
+          "SCCACHE_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "$dir" | Out-File -FilePath $env:GITHUB_PATH -Append
+
       - name: Run vcpkg
         uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
@@ -123,6 +145,7 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -111,7 +111,7 @@ jobs:
         uses: lukka/get-cmake@f57d5c55bca331a49bdc52a6069f211f1363a275 # v4.3.2
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: windows-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
           restore-keys: |

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -61,7 +61,7 @@ jobs:
             vcpkg-linux-
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
 
@@ -116,13 +116,34 @@ jobs:
           restore-keys: |
             vcpkg-windows-
 
+      - name: Cache sccache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ runner.temp }}/sccache
+          key: sccache-windows-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+          restore-keys: |
+            sccache-windows-
+
+      - name: Install sccache
+        run: |
+          $env:SCCACHE_DIR = "${{ runner.temp }}\sccache"
+          if (-not (Test-Path "$env:SCCACHE_DIR\sccache.exe")) {
+            New-Item -ItemType Directory -Force -Path $env:SCCACHE_DIR
+            Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-pc-windows-msvc.tar.gz" -OutFile "$env:SCCACHE_DIR\sccache.tar.gz"
+            tar -xzf "$env:SCCACHE_DIR\sccache.tar.gz" -C $env:SCCACHE_DIR
+            Move-Item "$env:SCCACHE_DIR\sccache-v0.10.0-x86_64-pc-windows-msvc\sccache.exe" $env:SCCACHE_DIR\
+          }
+          echo "SCCACHE_DIR=$env:SCCACHE_DIR" >> $env:GITHUB_ENV
+          echo "$env:SCCACHE_DIR" >> $env:GITHUB_PATH
+
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25c3b022a9a03bd7a427fb6a2 # v11.6
 
       - name: Build with CMake
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -64,9 +64,11 @@ jobs:
         uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
         with:
           key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
 
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
+        uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
       - name: Build with CMake
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -110,6 +110,13 @@ jobs:
       - name: Get latest CMake
         uses: lukka/get-cmake@f57d5c55bca331a49bdc52a6069f211f1363a275 # v4.3.2
 
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+        with:
+          key: windows-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+          restore-keys: |
+            windows-ccache-
+
       - name: Cache vcpkg binary packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -118,28 +125,6 @@ jobs:
           restore-keys: |
             vcpkg-windows-
 
-      - name: Cache sccache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ runner.temp }}/sccache
-          key: sccache-windows-${{ hashFiles('src/**', 'CMakeLists.txt') }}
-          restore-keys: |
-            sccache-windows-
-
-      - name: Install sccache
-        shell: pwsh
-        run: |
-          $dir = "${{ runner.temp }}\sccache"
-          if (-not (Test-Path "$dir\sccache.exe")) {
-            New-Item -ItemType Directory -Force -Path $dir
-            $tmp = "$dir\sccache.tar.gz"
-            Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-pc-windows-msvc.tar.gz" -OutFile $tmp
-            tar -xzf $tmp -C $dir
-            Move-Item "$dir\sccache-v0.10.0-x86_64-pc-windows-msvc\sccache.exe" $dir\
-          }
-          "SCCACHE_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "$dir" | Out-File -FilePath $env:GITHUB_PATH -Append
-
       - name: Run vcpkg
         uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
@@ -147,7 +132,6 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
-          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache','-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -126,7 +126,7 @@ jobs:
             vcpkg-windows-
 
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
 
       - name: Build with CMake
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -61,7 +61,7 @@ jobs:
             vcpkg-linux-
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
           key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
           restore-keys: |

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -68,7 +68,7 @@ jobs:
             ${{ runner.os }}-ccache-
 
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
 
       - name: Build with CMake
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -116,26 +116,6 @@ jobs:
           restore-keys: |
             vcpkg-windows-
 
-      - name: Cache sccache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ runner.temp }}/sccache
-          key: sccache-windows-${{ hashFiles('src/**', 'CMakeLists.txt') }}
-          restore-keys: |
-            sccache-windows-
-
-      - name: Install sccache
-        run: |
-          $env:SCCACHE_DIR = "${{ runner.temp }}\sccache"
-          if (-not (Test-Path "$env:SCCACHE_DIR\sccache.exe")) {
-            New-Item -ItemType Directory -Force -Path $env:SCCACHE_DIR
-            Invoke-WebRequest -Uri "https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-x86_64-pc-windows-msvc.tar.gz" -OutFile "$env:SCCACHE_DIR\sccache.tar.gz"
-            tar -xzf "$env:SCCACHE_DIR\sccache.tar.gz" -C $env:SCCACHE_DIR
-            Move-Item "$env:SCCACHE_DIR\sccache-v0.10.0-x86_64-pc-windows-msvc\sccache.exe" $env:SCCACHE_DIR\
-          }
-          echo "SCCACHE_DIR=$env:SCCACHE_DIR" >> $env:GITHUB_ENV
-          echo "$env:SCCACHE_DIR" >> $env:GITHUB_PATH
-
       - name: Run vcpkg
         uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
@@ -143,7 +123,6 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
-          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -113,7 +113,7 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
-          key: windows-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+          key: windows-ccache-${{ hashFiles('src/**', 'CMakeLists.txt', 'vcpkg.json') }}
           restore-keys: |
             windows-ccache-
 

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -137,7 +137,7 @@ jobs:
           echo "$env:SCCACHE_DIR" >> $env:GITHUB_PATH
 
       - name: Run vcpkg
-        uses: lukka/run-vcpkg@b1a0dd252f06b9e25c3b022a9a03bd7a427fb6a2 # v11.6
+        uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
       - name: Build with CMake
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -119,7 +119,6 @@ jobs:
             vcpkg-windows-
 
       - name: Cache sccache
-        if: github.ref_type != 'tag'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ runner.temp }}/sccache
@@ -128,7 +127,6 @@ jobs:
             sccache-windows-
 
       - name: Install sccache
-        if: github.ref_type != 'tag'
         shell: pwsh
         run: |
           $dir = "${{ runner.temp }}\sccache"
@@ -145,18 +143,12 @@ jobs:
       - name: Run vcpkg
         uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
-      - name: Configure CMake (Windows)
-        shell: pwsh
-        run: |
-          $args = @()
-          if (Get-Command sccache -ErrorAction SilentlyContinue) {
-            $args += '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
-            $args += '-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded'
-          }
-          cmake --preset windows-release $args
-
       - name: Build with CMake
-        run: cmake --build --preset windows-release
+        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
+        with:
+          configurePreset: windows-release
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache','-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded']"
+          buildPreset: windows-release
 
       - name: Upload build logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -147,7 +147,7 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
-          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache']"
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache','-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -63,7 +63,7 @@ jobs:
       - name: CCache
         uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
         with:
-          key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+          key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt', 'vcpkg.json') }}
           restore-keys: |
             ${{ runner.os }}-ccache-
 

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -60,6 +60,11 @@ jobs:
           restore-keys: |
             vcpkg-linux-
 
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt') }}
+
       - name: Run vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
 
@@ -67,6 +72,7 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: linux-release
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
           buildPreset: linux-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -132,6 +132,7 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
+          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -119,6 +119,7 @@ jobs:
             vcpkg-windows-
 
       - name: Cache sccache
+        if: github.ref_type != 'tag'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ runner.temp }}/sccache
@@ -127,6 +128,7 @@ jobs:
             sccache-windows-
 
       - name: Install sccache
+        if: github.ref_type != 'tag'
         shell: pwsh
         run: |
           $dir = "${{ runner.temp }}\sccache"
@@ -143,12 +145,18 @@ jobs:
       - name: Run vcpkg
         uses: lukka/run-vcpkg@305c06bd4dee21e23dcf142c85c657a993f7aa1a # v11.6
 
+      - name: Configure CMake (Windows)
+        shell: pwsh
+        run: |
+          $args = @()
+          if (Get-Command sccache -ErrorAction SilentlyContinue) {
+            $args += '-DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
+            $args += '-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded'
+          }
+          cmake --preset windows-release $args
+
       - name: Build with CMake
-        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
-        with:
-          configurePreset: windows-release
-          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=sccache','-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded']"
-          buildPreset: windows-release
+        run: cmake --build --preset windows-release
 
       - name: Upload build logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,8 +30,7 @@
         "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed/x64-windows-static-release",
         "VCPKG_BUILD_TYPE": "release",
         "CMAKE_C_COMPILER": "cl.exe",
-        "CMAKE_CXX_COMPILER": "cl.exe",
-        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
+        "CMAKE_CXX_COMPILER": "cl.exe"
       },
       "architecture": {
         "value": "x64",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,8 @@
         "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed/x64-windows-static-release",
         "VCPKG_BUILD_TYPE": "release",
         "CMAKE_C_COMPILER": "cl.exe",
-        "CMAKE_CXX_COMPILER": "cl.exe"
+        "CMAKE_CXX_COMPILER": "cl.exe",
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded"
       },
       "architecture": {
         "value": "x64",


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adds ccache to the Linux GitHub Actions build pipeline. ccache caches compiled object files and reuses them when source files haven't changed, dramatically reducing rebuild times.

| Before | After |
|---|---|
| Every push recompiles all ~20 unity files from scratch (~2-3 min) | Only recompiles files that actually changed (~30-60s) |

**Changes:**

- Added `hendrikmuhs/ccache-action@v1.2` to the Linux build job
- Cache keyed by hash of `src/**` + `CMakeLists.txt`
- Added `-DCMAKE_CXX_COMPILER_LAUNCHER=ccache` to CMake configure step
- Windows build unchanged (ccache doesn't support MSVC)

**Expected gain:** ~50-70% faster rebuilds on consecutive pushes.


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux build workflow with enhanced compilation caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->