### PR TITLE
feat(lua): migrate stages XML definition to Lua scripts

### DIFF
--- a/data/XML/stages.xml
+++ b/data/XML/stages.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<stages>
-	<config enabled="0" />
-	<stage minlevel="1" maxlevel="8" multiplier="7" />
-	<stage minlevel="9" maxlevel="20" multiplier="6" />
-	<stage minlevel="21" maxlevel="50" multiplier="5" />
-	<stage minlevel="51" maxlevel="100" multiplier="4" />
-	<stage minlevel="101" multiplier="5" />
-</stages>

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -113,44 +113,6 @@ ExperienceStages loadLuaStages(lua_State* L)
 	return stages;
 }
 
-ExperienceStages loadXMLStages()
-{
-	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file("data/XML/stages.xml");
-	if (!result) {
-		printXMLError("Error - loadXMLStages", "data/XML/stages.xml", result);
-		return {};
-	}
-
-	ExperienceStages stages;
-	for (auto stageNode : doc.child("stages").children()) {
-		if (boost::iequals(stageNode.name(), "config")) {
-			if (!stageNode.attribute("enabled").as_bool()) {
-				return {};
-			}
-		} else {
-			uint32_t minLevel = 1, maxLevel = std::numeric_limits<uint32_t>::max(), multiplier = 1;
-
-			if (auto minLevelAttribute = stageNode.attribute("minlevel")) {
-				minLevel = pugi::cast<uint32_t>(minLevelAttribute.value());
-			}
-
-			if (auto maxLevelAttribute = stageNode.attribute("maxlevel")) {
-				maxLevel = pugi::cast<uint32_t>(maxLevelAttribute.value());
-			}
-
-			if (auto multiplierAttribute = stageNode.attribute("multiplier")) {
-				multiplier = pugi::cast<uint32_t>(multiplierAttribute.value());
-			}
-
-			stages.emplace_back(minLevel, maxLevel, multiplier);
-		}
-	}
-
-	std::sort(stages.begin(), stages.end());
-	return stages;
-}
-
 } // namespace
 
 bool ConfigManager::load()
@@ -288,14 +250,7 @@ bool ConfigManager::load()
 	integer[PATHFINDING_INTERVAL] = getGlobalNumber(L, "pathfindingInterval", 200);
 	integer[PATHFINDING_DELAY] = getGlobalNumber(L, "pathfindingDelay", 300);
 
-	expStages = loadXMLStages();
-	if (expStages.empty()) {
-		expStages = loadLuaStages(L);
-	} else {
-		std::cout << "[Warning - ConfigManager::load] XML stages are deprecated, "
-		             "consider moving to config.lua."
-		          << std::endl;
-	}
+	expStages = loadLuaStages(L);
 	expStages.shrink_to_fit();
 
 	loaded = true;


### PR DESCRIPTION
## Summary

Closes #313 — removes the deprecated `data/XML/stages.xml` path. Experience stages are now defined solely in Lua via the `experienceStages` table in `config.lua`, parsed by the existing `loadLuaStages()` loader.

- Deleted `data/XML/stages.xml`
- Removed `loadXMLStages()` and the XML→Lua precedence/deprecation-warning logic in `src/configmanager.cpp`; `ConfigManager::load()` now calls `loadLuaStages(L)` directly

## Why this is behavior-safe

- `stages.xml` shipped disabled (`<config enabled="0" />`), so `loadXMLStages()` already returned empty and `loadLuaStages()` was already the **active path** on a default install. `config.lua.dist` already ships the `experienceStages` table.
- `ConfigManager::getExperienceStage()` and the `Game.getExperienceStage` Lua API are unchanged → `player.cpp` exp gain and all Lua consumers (`default_onGainExperience.lua`, `core/player.lua`, `compat.lua`, `server_info.lua`) are unaffected.
- Flat-rate fallback preserved: `experienceStages = nil` → `loadLuaStages` returns empty → `getExperienceStage` returns `RATE_EXPERIENCE`, exactly as documented in `config.lua.dist`.
- `stages.xml` / `loadXMLStages` were referenced **only** in `src/configmanager.cpp` — no CMake, docs, tests, packaging, or revscriptsys loader depended on them. `#include "pugicast.h"` is kept (still used by `getEnv`).
- The only removed behavior is the `enabled="1"` XML override — precisely the deprecated path this issue asks to remove, and off by default.

## Note

Pre-existing discrepancy: the deleted `stages.xml` had `multiplier=5` at `minlevel 101` while `config.lua.dist` has `multiplier=3`. Since the XML was disabled, `3` was already the effective default, so `config.lua.dist` was left unchanged to avoid altering shipped balance.

## Test plan

- [ ] Build server; start with default `config.lua` (`experienceStages` table present) — confirm staged exp rates apply per level bracket
- [ ] Set `experienceStages = nil` — confirm flat `rateExp` is used
- [ ] `!serverinfo` / exp gain reflects correct multiplier; no startup warnings about stages