### PR TITLE
feat(lua): migrate game state management to Lua

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -84,7 +84,22 @@ configManager = {}
 ---@field createTile fun(position: Position): Tile
 ---@field createMonsterType fun(name: string): MonsterType
 ---@field getClientVersion fun(): string
+---@field saveMap fun(): boolean
 ---@field reload fun(reloadType: number): boolean
+---@field reloadActions fun(): boolean
+---@field reloadAll fun(): boolean
+---@field reloadChat fun(): boolean
+---@field reloadConfig fun(): boolean
+---@field reloadEvents fun(): boolean
+---@field reloadGlobal fun(): boolean, boolean
+---@field reloadItems fun(): boolean
+---@field reloadMonsters fun(): boolean
+---@field reloadMovements fun(): boolean
+---@field reloadNpcs fun(): boolean
+---@field reloadScripts fun(): boolean
+---@field reloadSpells fun(): boolean
+---@field reloadTalkActions fun(): boolean
+---@field reloadWeapons fun(): boolean
 ---@field getPlayerRecord fun(): integer
 ---@field setPlayerRecord fun(record: integer): boolean
 Game = {}

--- a/data/scripts/systems/game_state.lua
+++ b/data/scripts/systems/game_state.lua
@@ -13,14 +13,17 @@
 --     Monsters, MoveEvents, Npcs, Spells, TalkActions, Weapons, Scripts) —
 --     exposed as Game.reload<Subsystem>() so this file can compose them.
 
+-- math.huge as triggerIndex forces these hooks to sort last in the
+-- onGameSave/onGameShutdown chains. The previous C++ implementation ran the
+-- full event chain and *then* kicked, so any third-party callback (no matter
+-- its triggerIndex) used to run before the kick. Using math.huge preserves
+-- that contract: every other subscriber finishes first.
+local KICK_TRIGGER_INDEX = math.huge
+
 do
 	-- Server closed: kick everyone without the always-login flag.
 	-- onSave also fires on shutdown and on manual saves (SIGUSR1, saveServer),
 	-- so the state gate isolates the close transition exactly like the engine did.
-	-- triggerIndex 1 forces this to run after the default (index 0) save
-	-- subscribers (e.g. account storage persistence), preserving the exact
-	-- ordering the engine used before this logic moved to Lua:
-	--   onSave subscribers -> kick -> C++ saveGameState
 	local event = Event()
 
 	event.onGameSave = function()
@@ -35,7 +38,7 @@ do
 		end
 	end
 
-	event:register(1)
+	event:register(KICK_TRIGGER_INDEX)
 end
 
 do
@@ -48,7 +51,7 @@ do
 		end
 	end
 
-	event:register(1)
+	event:register(KICK_TRIGGER_INDEX)
 end
 
 do

--- a/data/scripts/systems/game_state.lua
+++ b/data/scripts/systems/game_state.lua
@@ -1,16 +1,26 @@
--- Player-kicking on server close/shutdown. The C++ engine still drives the
--- state machine, thread lifecycle and saveGameState; only the player-facing
--- logic lives here.
+-- Game-state plumbing previously living inside Game::setGameState() and
+-- Game::reload() in src/game.cpp.
 --
--- triggerIndex 1 forces these to run after the default (index 0) save
--- subscribers (e.g. account storage persistence), preserving the exact
--- ordering the engine used before this logic moved to Lua:
---   onSave subscribers -> kick -> C++ saveGameState
+-- What stays in C++:
+--   * The state-machine guard inside Game::setGameState (gameState transitions,
+--     dispatcher/scheduler shutdown, saveGameState bookkeeping).
+--   * The INIT bootstrap (Groups::load, Chat::load, Map::spawns::startup) — these
+--     load native XML/spawn structures and have no Lua API; the onStartup event
+--     fires *after* them so scripts already have the canonical hook point.
+--   * Game::cleanup() — internal decay-wheel maintenance run from checkDecay()
+--     and from shutdown(); not safe to drive from Lua.
+--   * The subsystem reload entry points themselves (Actions, Chat, Items,
+--     Monsters, MoveEvents, Npcs, Spells, TalkActions, Weapons, Scripts) —
+--     exposed as Game.reload<Subsystem>() so this file can compose them.
 
 do
 	-- Server closed: kick everyone without the always-login flag.
 	-- onSave also fires on shutdown and on manual saves (SIGUSR1, saveServer),
 	-- so the state gate isolates the close transition exactly like the engine did.
+	-- triggerIndex 1 forces this to run after the default (index 0) save
+	-- subscribers (e.g. account storage persistence), preserving the exact
+	-- ordering the engine used before this logic moved to Lua:
+	--   onSave subscribers -> kick -> C++ saveGameState
 	local event = Event()
 
 	event.onGameSave = function()
@@ -39,4 +49,34 @@ do
 	end
 
 	event:register(1)
+end
+
+do
+	-- Reload routing: maps each RELOAD_TYPE_X to the C++ subsystem binding that
+	-- knows how to rebuild it. Mirrors the switch that used to live inside
+	-- Game::reload(); RELOAD_TYPE_ALL (and any unknown type) falls back to
+	-- Game.reloadAll(), which preserves the original default sweep order.
+	local handlers = {
+		[RELOAD_TYPE_ACTIONS] = Game.reloadActions,
+		[RELOAD_TYPE_CHAT] = Game.reloadChat,
+		[RELOAD_TYPE_CONFIG] = Game.reloadConfig,
+		[RELOAD_TYPE_EVENTS] = Game.reloadEvents,
+		[RELOAD_TYPE_GLOBAL] = Game.reloadGlobal,
+		[RELOAD_TYPE_ITEMS] = Game.reloadItems,
+		[RELOAD_TYPE_MONSTERS] = Game.reloadMonsters,
+		[RELOAD_TYPE_MOVEMENTS] = Game.reloadMovements,
+		[RELOAD_TYPE_NPCS] = Game.reloadNpcs,
+		[RELOAD_TYPE_SCRIPTS] = Game.reloadScripts,
+		[RELOAD_TYPE_SPELLS] = Game.reloadSpells,
+		[RELOAD_TYPE_TALKACTIONS] = Game.reloadTalkActions,
+		[RELOAD_TYPE_WEAPONS] = Game.reloadWeapons,
+	}
+
+	function Game.reload(reloadType)
+		local handler = handlers[reloadType]
+		if handler then
+			return handler()
+		end
+		return Game.reloadAll()
+	end
 end

--- a/data/scripts/systems/game_state.lua
+++ b/data/scripts/systems/game_state.lua
@@ -1,0 +1,42 @@
+-- Player-kicking on server close/shutdown. The C++ engine still drives the
+-- state machine, thread lifecycle and saveGameState; only the player-facing
+-- logic lives here.
+--
+-- triggerIndex 1 forces these to run after the default (index 0) save
+-- subscribers (e.g. account storage persistence), preserving the exact
+-- ordering the engine used before this logic moved to Lua:
+--   onSave subscribers -> kick -> C++ saveGameState
+
+do
+	-- Server closed: kick everyone without the always-login flag.
+	-- onSave also fires on shutdown and on manual saves (SIGUSR1, saveServer),
+	-- so the state gate isolates the close transition exactly like the engine did.
+	local event = Event()
+
+	event.onGameSave = function()
+		if Game.getGameState() ~= GAME_STATE_CLOSED then
+			return
+		end
+
+		for _, player in ipairs(Game.getPlayers()) do
+			if not player:hasFlag(PlayerFlag_CanAlwaysLogin) then
+				player:remove()
+			end
+		end
+	end
+
+	event:register(1)
+end
+
+do
+	-- Server shutdown: kick every online player before the state is saved.
+	local event = Event()
+
+	event.onGameShutdown = function()
+		for _, player in ipairs(Game.getPlayers()) do
+			player:remove()
+		end
+	end
+
+	event:register(1)
+end

--- a/data/scripts/systems/game_state.lua
+++ b/data/scripts/systems/game_state.lua
@@ -54,8 +54,11 @@ end
 do
 	-- Reload routing: maps each RELOAD_TYPE_X to the C++ subsystem binding that
 	-- knows how to rebuild it. Mirrors the switch that used to live inside
-	-- Game::reload(); RELOAD_TYPE_ALL (and any unknown type) falls back to
-	-- Game.reloadAll(), which preserves the original default sweep order.
+	-- Game::reload(); RELOAD_TYPE_ALL and RELOAD_TYPE_QUESTS (and any unknown
+	-- type) intentionally fall through to Game.reloadAll(), which preserves the
+	-- original default-branch sweep order. The previous C++ switch had no case
+	-- for QUESTS either, so /reload quests has always meant "do a full sweep";
+	-- the per-type quest clear is handled by the /reload talkaction itself.
 	local handlers = {
 		[RELOAD_TYPE_ACTIONS] = Game.reloadActions,
 		[RELOAD_TYPE_CHAT] = Game.reloadChat,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -90,11 +90,6 @@ void Game::setGameState(GameState_t newState)
 			tfs::events::game::onSave();
 			tfs::events::game::onShutdown();
 
-			// kick all players that are still online
-			for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>()) {
-				player->kickPlayer(true);
-			}
-
 			saveGameState();
 
 			g_dispatcher.addTask([this]() { shutdown(); });
@@ -110,13 +105,6 @@ void Game::setGameState(GameState_t newState)
 
 		case GAME_STATE_CLOSED: {
 			tfs::events::game::onSave();
-
-			/* kick all players without the CanAlwaysLogin flag */
-			for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs | std::ranges::to<std::vector>()) {
-				if (!player->hasFlag(PlayerFlag_CanAlwaysLogin)) {
-					player->kickPlayer(true);
-				}
-			}
 
 			saveGameState();
 			break;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4699,14 +4699,6 @@ void Game::cleanup(std::chrono::steady_clock::time_point virtualNow)
 	}
 }
 
-void Game::broadcastMessage(const std::string& text, MessageClasses type) const
-{
-	std::cout << "> Broadcasted message: \"" << text << "\"." << std::endl;
-	for (const auto& player : getPlayers() | tfs::views::lock_weak_ptrs) {
-		player->sendTextMessage(type, text);
-	}
-}
-
 void Game::updateCreatureWalkthrough(const std::shared_ptr<const Creature>& creature)
 {
 	// send to clients
@@ -5472,98 +5464,6 @@ bool Game::addUniqueItem(uint16_t uniqueId, std::shared_ptr<Item> item)
 		std::cout << "Duplicate unique id: " << uniqueId << std::endl;
 	}
 	return result.second;
-}
-
-bool Game::reload(ReloadTypes_t reloadType)
-{
-	switch (reloadType) {
-		case RELOAD_TYPE_ACTIONS:
-			return g_actions->reload();
-		case RELOAD_TYPE_CHAT:
-			return g_chat.load();
-		case RELOAD_TYPE_CONFIG:
-			return ConfigManager::load();
-		case RELOAD_TYPE_EVENTS:
-			tfs::events::reload();
-			return true;
-		case RELOAD_TYPE_ITEMS:
-			return Item::items.reload();
-		case RELOAD_TYPE_MONSTERS:
-			return g_monsters.reload();
-		case RELOAD_TYPE_MOVEMENTS:
-			return g_moveEvents->reload();
-		case RELOAD_TYPE_NPCS: {
-			Npcs::reload();
-			return true;
-		}
-
-		case RELOAD_TYPE_SPELLS: {
-			if (!g_spells->reload()) {
-				std::cout << "[Error - Game::reload] Failed to reload spells." << std::endl;
-				std::terminate();
-			} else if (!g_monsters.reload()) {
-				std::cout << "[Error - Game::reload] Failed to reload monsters." << std::endl;
-				std::terminate();
-			}
-			return true;
-		}
-
-		case RELOAD_TYPE_TALKACTIONS:
-			return g_talkActions->reload();
-
-		case RELOAD_TYPE_WEAPONS: {
-			g_weapons->loadDefaults();
-			return true;
-		}
-
-		case RELOAD_TYPE_SCRIPTS: {
-			// commented out stuff is TODO, once we approach further in revscriptsys
-			g_actions->clear(true);
-			g_moveEvents->clear(true);
-			g_talkActions->clear(true);
-			g_weapons->clear(true);
-			g_weapons->loadDefaults();
-			g_spells->clear(true);
-			g_scripts->loadScripts("scripts", false, true);
-			/*
-			Npcs::reload();
-			Item::items.reload();
-			ConfigManager::reload();
-			tfs::events::load();
-			g_chat.load();
-			*/
-			return true;
-		}
-
-		default: {
-			if (!g_spells->reload()) {
-				std::cout << "[Error - Game::reload] Failed to reload spells." << std::endl;
-				std::terminate();
-			} else if (!g_monsters.reload()) {
-				std::cout << "[Error - Game::reload] Failed to reload monsters." << std::endl;
-				std::terminate();
-			}
-
-			g_actions->reload();
-			ConfigManager::load();
-			g_monsters.reload();
-			g_moveEvents->reload();
-			Npcs::reload();
-			g_talkActions->reload();
-			Item::items.reload();
-			g_weapons->clear(true);
-			g_weapons->loadDefaults();
-			tfs::events::reload();
-			g_chat.load();
-			g_actions->clear(true);
-			g_moveEvents->clear(true);
-			g_talkActions->clear(true);
-			g_spells->clear(true);
-			g_scripts->loadScripts("scripts", false, true);
-			return true;
-		}
-	}
-	return true;
 }
 
 std::shared_ptr<House> Game::addHouse(uint32_t id)

--- a/src/game.h
+++ b/src/game.h
@@ -306,7 +306,6 @@ public:
 	                        const std::shared_ptr<Item>& tradeItem);
 	void internalCloseTrade(const std::shared_ptr<Player>& player, bool sendCancel = true);
 	bool playerBroadcastMessage(const std::shared_ptr<Player>& player, const std::string& text) const;
-	void broadcastMessage(const std::string& text, MessageClasses type) const;
 
 	// Implementation of player invoked events
 	void playerMoveThing(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
@@ -462,8 +461,6 @@ public:
 	std::shared_ptr<Item> getUniqueItem(uint16_t uniqueId);
 	bool addUniqueItem(uint16_t uniqueId, std::shared_ptr<Item> item);
 	void removeUniqueItem(uint16_t uniqueId) { uniqueItems.erase(uniqueId); }
-
-	bool reload(ReloadTypes_t reloadType);
 
 	Groups groups;
 	Map map;

--- a/src/lua/modules/game.cpp
+++ b/src/lua/modules/game.cpp
@@ -578,6 +578,12 @@ int luaGameGetClientVersion(lua_State* L)
 	return 1;
 }
 
+// Mirrors the trailing `lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0)`
+// that the previous luaGameReload(type) ran after every reload type. Reloading
+// XML/Lua data on subsystems can leave many short-lived objects on the main
+// interface; the original collected them eagerly and we preserve that exactly.
+void gcMainInterfaceAfterReload() { lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0); }
+
 int luaGameSaveMap(lua_State* L)
 {
 	// Game.saveMap()
@@ -588,21 +594,27 @@ int luaGameSaveMap(lua_State* L)
 int luaGameReloadActions(lua_State* L)
 {
 	// Game.reloadActions()
-	tfs::lua::pushBoolean(L, g_actions->reload());
+	const bool ok = g_actions->reload();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
 int luaGameReloadChat(lua_State* L)
 {
 	// Game.reloadChat()
-	tfs::lua::pushBoolean(L, g_chat.load());
+	const bool ok = g_chat.load();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
 int luaGameReloadConfig(lua_State* L)
 {
 	// Game.reloadConfig()
-	tfs::lua::pushBoolean(L, ConfigManager::load());
+	const bool ok = ConfigManager::load();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
@@ -610,6 +622,7 @@ int luaGameReloadEvents(lua_State* L)
 {
 	// Game.reloadEvents()
 	tfs::events::reload();
+	gcMainInterfaceAfterReload();
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
@@ -617,21 +630,27 @@ int luaGameReloadEvents(lua_State* L)
 int luaGameReloadItems(lua_State* L)
 {
 	// Game.reloadItems()
-	tfs::lua::pushBoolean(L, Item::items.reload());
+	const bool ok = Item::items.reload();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
 int luaGameReloadMonsters(lua_State* L)
 {
 	// Game.reloadMonsters()
-	tfs::lua::pushBoolean(L, g_monsters.reload());
+	const bool ok = g_monsters.reload();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
 int luaGameReloadMovements(lua_State* L)
 {
 	// Game.reloadMovements()
-	tfs::lua::pushBoolean(L, g_moveEvents->reload());
+	const bool ok = g_moveEvents->reload();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
@@ -639,6 +658,7 @@ int luaGameReloadNpcs(lua_State* L)
 {
 	// Game.reloadNpcs()
 	Npcs::reload();
+	gcMainInterfaceAfterReload();
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
@@ -657,6 +677,7 @@ int luaGameReloadSpells(lua_State* L)
 		std::cout << "[Error - Game.reloadSpells] Failed to reload monsters." << std::endl;
 		std::terminate();
 	}
+	gcMainInterfaceAfterReload();
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
@@ -664,7 +685,9 @@ int luaGameReloadSpells(lua_State* L)
 int luaGameReloadTalkActions(lua_State* L)
 {
 	// Game.reloadTalkActions()
-	tfs::lua::pushBoolean(L, g_talkActions->reload());
+	const bool ok = g_talkActions->reload();
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
@@ -676,6 +699,7 @@ int luaGameReloadWeapons(lua_State* L)
 	// present in `weapons`. The full clear+rebuild happens in reloadScripts()
 	// and reloadAll(), as in the original switch.
 	g_weapons->loadDefaults();
+	gcMainInterfaceAfterReload();
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
@@ -689,8 +713,9 @@ int luaGameReloadScripts(lua_State* L)
 	g_weapons->clear(true);
 	g_weapons->loadDefaults();
 	g_spells->clear(true);
-	tfs::lua::pushBoolean(L, g_scripts->loadScripts("scripts", false, true));
-	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	const bool ok = g_scripts->loadScripts("scripts", false, true);
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, ok);
 	return 1;
 }
 
@@ -701,9 +726,11 @@ int luaGameReloadGlobal(lua_State* L)
 	// the multi-return contract of the previous luaGameReload(RELOAD_TYPE_GLOBAL)
 	// path. The Lua dispatcher forwards both values, so Game.reload(GLOBAL)
 	// keeps the same return shape it had before this migration.
-	tfs::lua::pushBoolean(L, g_luaEnvironment.loadFile("data/global.lua") == 0);
-	tfs::lua::pushBoolean(L, g_scripts->loadScripts("scripts/lib", true, true));
-	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	const bool globalLoaded = g_luaEnvironment.loadFile("data/global.lua") == 0;
+	const bool libsLoaded = g_scripts->loadScripts("scripts/lib", true, true);
+	gcMainInterfaceAfterReload();
+	tfs::lua::pushBoolean(L, globalLoaded);
+	tfs::lua::pushBoolean(L, libsLoaded);
 	return 2;
 }
 
@@ -738,7 +765,7 @@ int luaGameReloadAll(lua_State* L)
 	g_talkActions->clear(true);
 	g_spells->clear(true);
 	g_scripts->loadScripts("scripts", false, true);
-	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	gcMainInterfaceAfterReload();
 	tfs::lua::pushBoolean(L, true);
 	return 1;
 }

--- a/src/lua/modules/game.cpp
+++ b/src/lua/modules/game.cpp
@@ -2,26 +2,37 @@
 
 #include "../../game.h"
 
+#include "../../actions.h"
+#include "../../chat.h"
 #include "../../configmanager.h"
+#include "../../events/events.h"
 #include "../../events/monster.h"
 #include "../../monster.h"
+#include "../../movement.h"
 #include "../../npc.h"
 #include "../../script.h"
 #include "../../spells.h"
+#include "../../talkaction.h"
 #include "../../tasks.h"
+#include "../../weapons.h"
 #include "../api.h"
 #include "../env.h"
 #include "../meta.h"
 #include "../register.h"
 #include "../script.h"
 
+extern Actions* g_actions;
+extern Chat g_chat;
 extern Game g_game;
 extern LuaEnvironment g_luaEnvironment;
+extern MoveEvents* g_moveEvents;
 extern Spells* g_spells;
 extern Monsters g_monsters;
 extern Scripts* g_scripts;
 extern Dispatcher g_dispatcher;
+extern TalkActions* g_talkActions;
 extern Vocations g_vocations;
+extern std::unique_ptr<Weapons> g_weapons;
 
 namespace {
 
@@ -567,19 +578,160 @@ int luaGameGetClientVersion(lua_State* L)
 	return 1;
 }
 
-int luaGameReload(lua_State* L)
+int luaGameSaveMap(lua_State* L)
 {
-	// Game.reload(reloadType)
-	ReloadTypes_t reloadType = tfs::lua::getNumber<ReloadTypes_t>(L, 1);
-	if (reloadType == RELOAD_TYPE_GLOBAL) {
-		tfs::lua::pushBoolean(L, g_luaEnvironment.loadFile("data/global.lua") == 0);
-		tfs::lua::pushBoolean(L, g_scripts->loadScripts("scripts/lib", true, true));
-		lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
-		return 2;
+	// Game.saveMap()
+	tfs::lua::pushBoolean(L, Map::save());
+	return 1;
+}
+
+int luaGameReloadActions(lua_State* L)
+{
+	// Game.reloadActions()
+	tfs::lua::pushBoolean(L, g_actions->reload());
+	return 1;
+}
+
+int luaGameReloadChat(lua_State* L)
+{
+	// Game.reloadChat()
+	tfs::lua::pushBoolean(L, g_chat.load());
+	return 1;
+}
+
+int luaGameReloadConfig(lua_State* L)
+{
+	// Game.reloadConfig()
+	tfs::lua::pushBoolean(L, ConfigManager::load());
+	return 1;
+}
+
+int luaGameReloadEvents(lua_State* L)
+{
+	// Game.reloadEvents()
+	tfs::events::reload();
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
+int luaGameReloadItems(lua_State* L)
+{
+	// Game.reloadItems()
+	tfs::lua::pushBoolean(L, Item::items.reload());
+	return 1;
+}
+
+int luaGameReloadMonsters(lua_State* L)
+{
+	// Game.reloadMonsters()
+	tfs::lua::pushBoolean(L, g_monsters.reload());
+	return 1;
+}
+
+int luaGameReloadMovements(lua_State* L)
+{
+	// Game.reloadMovements()
+	tfs::lua::pushBoolean(L, g_moveEvents->reload());
+	return 1;
+}
+
+int luaGameReloadNpcs(lua_State* L)
+{
+	// Game.reloadNpcs()
+	Npcs::reload();
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
+int luaGameReloadSpells(lua_State* L)
+{
+	// Game.reloadSpells()
+	// Matches the previous RELOAD_TYPE_SPELLS path: also reloads monsters, and
+	// terminates on failure because partial spell/monster data would leave the
+	// game in an inconsistent state.
+	if (!g_spells->reload()) {
+		std::cout << "[Error - Game.reloadSpells] Failed to reload spells." << std::endl;
+		std::terminate();
+	}
+	if (!g_monsters.reload()) {
+		std::cout << "[Error - Game.reloadSpells] Failed to reload monsters." << std::endl;
+		std::terminate();
+	}
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
+int luaGameReloadTalkActions(lua_State* L)
+{
+	// Game.reloadTalkActions()
+	tfs::lua::pushBoolean(L, g_talkActions->reload());
+	return 1;
+}
+
+int luaGameReloadWeapons(lua_State* L)
+{
+	// Game.reloadWeapons()
+	g_weapons->loadDefaults();
+	tfs::lua::pushBoolean(L, true);
+	return 1;
+}
+
+int luaGameReloadScripts(lua_State* L)
+{
+	// Game.reloadScripts()
+	g_actions->clear(true);
+	g_moveEvents->clear(true);
+	g_talkActions->clear(true);
+	g_weapons->clear(true);
+	g_weapons->loadDefaults();
+	g_spells->clear(true);
+	tfs::lua::pushBoolean(L, g_scripts->loadScripts("scripts", false, true));
+	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	return 1;
+}
+
+int luaGameReloadGlobal(lua_State* L)
+{
+	// Game.reloadGlobal()
+	tfs::lua::pushBoolean(L, g_luaEnvironment.loadFile("data/global.lua") == 0);
+	tfs::lua::pushBoolean(L, g_scripts->loadScripts("scripts/lib", true, true));
+	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	return 2;
+}
+
+int luaGameReloadAll(lua_State* L)
+{
+	// Game.reloadAll()
+	// Matches the previous default branch of Game::reload(): mirrors the exact
+	// order of subsystem reloads, including the duplicate spell/monster passes
+	// that the original sweep performed.
+	if (!g_spells->reload()) {
+		std::cout << "[Error - Game.reloadAll] Failed to reload spells." << std::endl;
+		std::terminate();
+	}
+	if (!g_monsters.reload()) {
+		std::cout << "[Error - Game.reloadAll] Failed to reload monsters." << std::endl;
+		std::terminate();
 	}
 
-	tfs::lua::pushBoolean(L, g_game.reload(reloadType));
+	g_actions->reload();
+	ConfigManager::load();
+	g_monsters.reload();
+	g_moveEvents->reload();
+	Npcs::reload();
+	g_talkActions->reload();
+	Item::items.reload();
+	g_weapons->clear(true);
+	g_weapons->loadDefaults();
+	tfs::events::reload();
+	g_chat.load();
+	g_actions->clear(true);
+	g_moveEvents->clear(true);
+	g_talkActions->clear(true);
+	g_spells->clear(true);
+	g_scripts->loadScripts("scripts", false, true);
 	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
+	tfs::lua::pushBoolean(L, true);
 	return 1;
 }
 
@@ -662,7 +814,24 @@ void tfs::lua::registerGame(LuaScriptInterface& lsi)
 
 	lsi.registerMethod("Game", "getClientVersion", luaGameGetClientVersion);
 
-	lsi.registerMethod("Game", "reload", luaGameReload);
+	lsi.registerMethod("Game", "saveMap", luaGameSaveMap);
+
+	// Per-subsystem reload bindings. Game.reload(type) lives in Lua
+	// (data/scripts/systems/game_state.lua) and dispatches through these.
+	lsi.registerMethod("Game", "reloadActions", luaGameReloadActions);
+	lsi.registerMethod("Game", "reloadChat", luaGameReloadChat);
+	lsi.registerMethod("Game", "reloadConfig", luaGameReloadConfig);
+	lsi.registerMethod("Game", "reloadEvents", luaGameReloadEvents);
+	lsi.registerMethod("Game", "reloadGlobal", luaGameReloadGlobal);
+	lsi.registerMethod("Game", "reloadItems", luaGameReloadItems);
+	lsi.registerMethod("Game", "reloadMonsters", luaGameReloadMonsters);
+	lsi.registerMethod("Game", "reloadMovements", luaGameReloadMovements);
+	lsi.registerMethod("Game", "reloadNpcs", luaGameReloadNpcs);
+	lsi.registerMethod("Game", "reloadScripts", luaGameReloadScripts);
+	lsi.registerMethod("Game", "reloadSpells", luaGameReloadSpells);
+	lsi.registerMethod("Game", "reloadTalkActions", luaGameReloadTalkActions);
+	lsi.registerMethod("Game", "reloadWeapons", luaGameReloadWeapons);
+	lsi.registerMethod("Game", "reloadAll", luaGameReloadAll);
 
 	lsi.registerMethod("Game", "getPlayerRecord", luaGameGetPlayerRecord);
 	lsi.registerMethod("Game", "setPlayerRecord", luaGameSetPlayerRecord);

--- a/src/lua/modules/game.cpp
+++ b/src/lua/modules/game.cpp
@@ -671,6 +671,10 @@ int luaGameReloadTalkActions(lua_State* L)
 int luaGameReloadWeapons(lua_State* L)
 {
 	// Game.reloadWeapons()
+	// Matches the previous RELOAD_TYPE_WEAPONS path: loadDefaults() only. Repeat
+	// calls are idempotent because Weapons::loadDefaults skips entries already
+	// present in `weapons`. The full clear+rebuild happens in reloadScripts()
+	// and reloadAll(), as in the original switch.
 	g_weapons->loadDefaults();
 	tfs::lua::pushBoolean(L, true);
 	return 1;
@@ -693,6 +697,10 @@ int luaGameReloadScripts(lua_State* L)
 int luaGameReloadGlobal(lua_State* L)
 {
 	// Game.reloadGlobal()
+	// Returns two booleans (global.lua loaded, scripts/lib loaded) to preserve
+	// the multi-return contract of the previous luaGameReload(RELOAD_TYPE_GLOBAL)
+	// path. The Lua dispatcher forwards both values, so Game.reload(GLOBAL)
+	// keeps the same return shape it had before this migration.
 	tfs::lua::pushBoolean(L, g_luaEnvironment.loadFile("data/global.lua") == 0);
 	tfs::lua::pushBoolean(L, g_scripts->loadScripts("scripts/lib", true, true));
 	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);


### PR DESCRIPTION
Refs #301

## The short version

When the server **closes** or **shuts down**, it has to kick the players who are still online. When an admin types **`/reload <something>`**, the server has to know which subsystem to refresh. When a script wants to **save the map** or **send a broadcast message**, it needs a way to do that.

Today most of that logic is hard-coded in C++ — changing any of it requires recompiling the whole server. This PR moves the user-facing parts into Lua scripts so server owners can read them, audit them, and tweak them without touching C++.

Everything that has to stay native (threads, the engine state machine, internal decay queues, XML loading) **stays in C++**, with comments explaining why.

## What this means in practice

Nothing changes for players. The server behaves exactly like before:

- **Closing the server** still kicks regular players and lets admins/GMs stay (the "always login" flag).
- **Shutting down the server** still kicks everyone, saves the world, flushes the database, and stops the engine cleanly — in that order.
- **Manual saves** (`/save`, SIGUSR1) still don't kick anyone.
- **`/reload spells`**, **`/reload monsters`**, **`/reload scripts`**, **`/reload all`** etc. still do the same thing they did before.
- **`Game.broadcastMessage("...")`** in scripts still sends a message to every online player.

What's new is that the *logic* behind all of that is now visible and editable in two places:

- `data/scripts/systems/game_state.lua` — the kick rules and the reload dispatcher
- `src/lua/modules/game.cpp` — the small C++ bindings the Lua side calls into

## What moved into Lua

Everything is in **`data/scripts/systems/game_state.lua`**.

**Kicking on close.** When the server enters the CLOSED state, the script kicks every player who doesn't have the "can always login" flag. Hooked to `onGameSave`, gated on the state so it doesn't accidentally fire on a regular save.

**Kicking on shutdown.** When the server is shutting down, the script kicks everyone. Hooked to `onGameShutdown`.

Both kicks register at `triggerIndex = math.huge`, which means: if any other script also hooks `onGameSave` or `onGameShutdown`, it will run *before* the kick. That matches what C++ did before — it always let every callback finish, *then* kicked.

**Reload routing.** A Lua table maps each reload type (`RELOAD_TYPE_ACTIONS`, `RELOAD_TYPE_MONSTERS`, `RELOAD_TYPE_SPELLS`, etc.) to the small C++ binding that knows how to rebuild that subsystem. `RELOAD_TYPE_ALL` and `RELOAD_TYPE_QUESTS` fall through to a full sweep — same as the original C++ switch, which didn't have explicit cases for them either.

## New tools available to scripts

The reload migration needed one C++ binding per subsystem. They're all on the `Game` table:

```
Game.reloadActions()     Game.reloadGlobal()       Game.reloadSpells()
Game.reloadChat()        Game.reloadItems()        Game.reloadTalkActions()
Game.reloadConfig()      Game.reloadMonsters()     Game.reloadWeapons()
Game.reloadEvents()      Game.reloadMovements()    Game.reloadAll()
                         Game.reloadNpcs()         Game.reloadScripts()
```

Each one is a 1:1 wrapper around the same code the old C++ switch ran, including the same hard-fail on spell/monster reload errors and the same Lua garbage-collect pass on the main interface after every reload. So behaviour is byte-for-byte identical to before.

Plus the binding the issue specifically requested:

- **`Game.saveMap()`** — saves the map exactly like the engine does internally.

## What was removed

Two pieces of C++ code that weren't doing anything useful:

- `Game::reload(ReloadTypes_t)` — the switch is now in Lua, and its only caller (`luaGameReload`) is gone.
- `Game::broadcastMessage(text, type)` — was never called from C++ or exposed to Lua. Scripts have always used the pure-Lua `Game.broadcastMessage` defined in `data/lib/core/game/lib.lua`.

## What stays in C++ — and why

These were on the issue's wish list but don't move safely:

| Thing | Why it stays native |
|---|---|
| `Game::setGameState` state machine | Coordinates the engine's threads and re-entrancy. Driving it from Lua would race against the very threads that run Lua. |
| `Game::saveGameState` | Internal save coordinator. The map-save step is now exposed as `Game.saveMap()`, but the full sequence needs engine locks. |
| `Game::shutdown` | Stops the scheduler, dispatcher and database tasks. Pure engine teardown. |
| INIT bootstrap (`Groups::load`, `Chat::load`, `Map::spawns.startup`) | They read XML/native data with no Lua API. The `onGameStartup` event already fires right after them, so scripts already have the canonical hook point. |
| `Game::cleanup()` | Drains the item decay queue every tick. The issue itself notes that "scheduling infrastructure can stay C++". |
| `addCreatureCheck` / `removeCreatureCheck` / `checkCreatures` | Same — the issue explicitly marks them as stay-in-C++. |

The same list is at the top of `data/scripts/systems/game_state.lua`, so future readers see it's a deliberate boundary, not an oversight.

## Issue coverage

The issue's **migration strategy** lists two concrete moves:

1. Move player-kicking on shutdown to Lua ✅ done (also covers the CLOSED branch)
2. Move reload routing to Lua ✅ done

The required binding (`Map:save()`) was added as `Game.saveMap()` ✅.
The dead `Game::broadcastMessage` C++ code was removed ✅.

The issue's broader **what to move** list also mentions the rest of `setGameState`, `cleanup()` and the INIT bootstrap. Those stay in C++ for the reasons in the table above — which mirrors the issue's own note that *"this is low priority since game state management is mostly infrastructure"*.

This PR intentionally uses `Refs #301` (not `Closes`) so the issue stays open. A literal port of every line in the issue's "What to Move" section - specifically the INIT bootstrap (`Groups::load`, `Chat::load`, `Map::spawns.startup`), the internal `saveGameState` coordinator, and `cleanup()` - would need their own Lua APIs and is a natural follow-up PR. Maintainers can close the issue manually once they're happy with the split, or leave it open to track the remaining items.

## Why it is safe

- `Game.reload(type)` keeps the same signature; `Game.reload(RELOAD_TYPE_GLOBAL)` still returns two booleans like before.
- Reload subsystem bindings preserve the original behaviour exactly, including the hard-fail on spell/monster reload errors and the GC pass after every reload.
- Kicks happen at `math.huge` triggerIndex, so any third-party `onGameSave` / `onGameShutdown` hook still runs first — same as the engine's previous "callbacks finish → then kick" ordering.
- Reloading scripts (`/reload scripts`) re-runs `game_state.lua` and rebuilds the dispatcher table from the same C++ bindings, so it's idempotent.
- The `/reload` talkaction wasn't touched and uses the new dispatcher transparently.

## Files touched

- `src/game.h`, `src/game.cpp` — removed `Game::reload` and `Game::broadcastMessage`.
- `src/lua/modules/game.cpp` — replaced `luaGameReload` with per-subsystem bindings and `Game.saveMap`; added a shared `gcMainInterfaceAfterReload()` helper.
- `data/scripts/systems/game_state.lua` — close/shutdown kicks, reload dispatcher, and a top-of-file note about what stays in C++.
- `data/cpplinter.lua` — type hints for the new `Game.*` bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular reload system allowing specialized reloads of individual subsystems (actions, chat, config, events, items, monsters, NPCs, spells, and more) instead of full server reloads.
  * Added map save functionality.

* **Improvements**
  * Enhanced creature pathfinding behavior during follow mechanics.
  * Refined game shutdown and save state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

