### PR TITLE
fix(protocol): write outer message length AFTER addCryptoHeader

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -72,11 +72,6 @@ void Protocol::onSendMessage(const std::shared_ptr<OutputMessage>& msg)
 			msg->addCryptoHeader();
 		}
 
-		// writeMessageLength prepends the OUTER u16 block-count that
-		// `Connection::parseHeader` reads via `msg.getLengthHeader() * 8 + CHECKSUM_LENGTH`.
-		// Must run AFTER `addCryptoHeader` so the u16 lands at the very start of the
-		// frame (outside the XTEA payload) and the formula sees the full length
-		// including the 4-byte crypto header.
 		msg->writeMessageLength();
 	}
 }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -66,13 +66,18 @@ void Protocol::onSendMessage(const std::shared_ptr<OutputMessage>& msg)
 			msg->setSequenceId(compressionChecksum | getNextSequenceId());
 		}
 
-		msg->writeMessageLength();
-
 		if (encryptionEnabled) {
 			msg->writePaddingLength();
 			XTEA_encrypt(*msg, key);
 			msg->addCryptoHeader();
 		}
+
+		// writeMessageLength prepends the OUTER u16 block-count that
+		// `Connection::parseHeader` reads via `msg.getLengthHeader() * 8 + CHECKSUM_LENGTH`.
+		// Must run AFTER `addCryptoHeader` so the u16 lands at the very start of the
+		// frame (outside the XTEA payload) and the formula sees the full length
+		// including the 4-byte crypto header.
+		msg->writeMessageLength();
 	}
 }
 


### PR DESCRIPTION
## Summary

`Connection::parseHeader` reads the first `u16` of every TCP frame as a block-count via `msg.getLengthHeader() * 8 + CHECKSUM_LENGTH`. Since #129 the encrypted send path called `writeMessageLength()` **before** `writePaddingLength()` / `XTEA_encrypt` / `addCryptoHeader`. Because `add_header` *prepends*, that u16 ended up inside the XTEA payload instead of at the very start of the frame.

Effective wire layout before this PR (encrypted):

\`\`\`
[u32 seqid][XTEA( u16 block-count | u8 pad | payload | trailing pad )]
\`\`\`

What the receive side and real 15.x clients expect:

\`\`\`
[u16 block-count][u32 seqid][XTEA( u8 pad | payload | trailing pad )]
\`\`\`

So the first 2 bytes peers read are the low half of the seqid (treated as a bogus block-count) and the real \`writeMessageLength\` u16 stays encrypted until it's too late.

## Fix

Move \`msg->writeMessageLength()\` to run **after** \`addCryptoHeader\` so the u16 lands at the outermost position of the frame:

\`\`\`cpp
if (encryptionEnabled) {
    msg->writePaddingLength();
    XTEA_encrypt(*msg, key);
    msg->addCryptoHeader();
}

// writeMessageLength prepends the OUTER u16 block-count that
// Connection::parseHeader reads via getLengthHeader() * 8 + CHECKSUM_LENGTH.
// Must run AFTER addCryptoHeader so the u16 lands at the very start of the
// frame (outside the XTEA payload) and the formula sees the full length
// including the 4-byte crypto header.
msg->writeMessageLength();
\`\`\`

The unencrypted challenge path (\`onConnect\`) is unaffected: with \`encryptionEnabled = false\` the \`if\` block is skipped and \`writeMessageLength\` runs as the only header prepend, exactly as before.

## How to test

Reproduce against any 15.x client (or a MITM like [TibiaTrace](https://github.com/luanluciano93/TibiaTrace)):

- **Before:** client gets through HTTP login, sees the character list, selects a character, connects to the game port, and crashes immediately with \`Unknown Gameserver Message: 0\` followed by a buffer of zero bytes in the crash dump. A sniffer with the correct XTEA keys cannot decrypt the first post-handshake server packet (\`Invalid padding amount: 238 (decrypted size: 8)\`).
- **After:** the same sniffer decrypts every server packet cleanly. The first byte of the decrypted payload is the expected padding amount (0-7).

## Test plan

- [ ] Connect a real 15.24 client to the game port and confirm it reads past the handshake without "Unknown Gameserver Message: 0" (will still hit downstream protobuf-payload mismatches that are out of scope for this PR).
- [ ] Run a MITM proxy with the OpenTibia RSA key against this server and confirm post-XTEA decryption succeeds (`u8 paddingAmount` is in 0..7).

Co-authored-with: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of operations in encrypted message handling to ensure messages are properly encrypted and transmitted with correct length validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/atlas-kit/atlas/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->