### PR TITLE
fix(build): repair FindMySQL.cmake and document Ubuntu 24.04 noble quirks

### DIFF
--- a/cmake/modules/FindMySQL.cmake
+++ b/cmake/modules/FindMySQL.cmake
@@ -29,20 +29,26 @@
 
 
 #-------------- FIND MYSQL_INCLUDE_DIR ------------------
-FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
-		$ENV{MYSQL_INCLUDE_DIR}
-		$ENV{MYSQL_DIR}/include
-		/usr/include/mysql
-		/usr/local/include/mysql
-		/opt/mysql/mysql/include
-		/opt/mysql/mysql/include/mysql
-		/opt/mysql/include
-		/opt/local/include/mysql5
-		/usr/local/mysql/include
-		/usr/local/mysql/include/mysql
-		$ENV{ProgramFiles}/MySQL/*/include
-		$ENV{SystemDrive}/MySQL/*/include
-		PATH_SUFFIXES mysql)
+FIND_PATH(MYSQL_INCLUDE_DIR
+		NAMES mysql.h
+		HINTS
+			$ENV{MYSQL_INCLUDE_DIR}
+			$ENV{MYSQL_DIR}/include
+		PATHS
+			/usr/include/mariadb
+			/usr/local/include/mariadb
+			/usr/include/mysql
+			/usr/local/include/mysql
+			/opt/mysql/mysql/include
+			/opt/mysql/mysql/include/mysql
+			/opt/mysql/include
+			/opt/local/include/mysql5
+			/usr/local/mysql/include
+			/usr/local/mysql/include/mysql
+			$ENV{ProgramFiles}/MySQL/*/include
+			$ENV{SystemDrive}/MySQL/*/include
+		PATH_SUFFIXES mariadb mysql
+		NO_SYSTEM_ENVIRONMENT_PATH)
 
 #----------------- FIND MYSQL_LIB_DIR -------------------
 IF (WIN32)
@@ -73,7 +79,9 @@ ELSE (WIN32)
 				 $ENV{MYSQL_DIR}/libmysql/.libs
 				 $ENV{MYSQL_DIR}/lib
 				 $ENV{MYSQL_DIR}/lib/mysql
+				 /usr/lib/mariadb
 				 /usr/lib/mysql
+				 /usr/local/lib/mariadb
 				 /usr/local/lib/mysql
 				 /usr/local/mysql/lib
 				 /usr/local/mysql/lib/mysql

--- a/compiling/linux.md
+++ b/compiling/linux.md
@@ -1,6 +1,11 @@
 # Compiling on Linux
 
-Atlas builds on any modern Linux distribution with a C++23-capable compiler (GCC 14+ or Clang 17+).
+Atlas builds on any modern Linux distribution with a C++23-capable compiler. You need either:
+
+- **GCC 14+** (provides the C++23 `<print>` header in libstdc++), or
+- **Clang 17+** paired with libstdc++ from GCC 14+ (install `g++-14` alongside) or with `libc++` (`-stdlib=libc++`, requires `libc++-18-dev` or newer).
+
+A bare Clang 18 on Ubuntu 24.04 will fail with `fatal error: 'print' file not found` because the default libstdc++ ships with GCC 13.
 
 You can pick between two paths:
 
@@ -21,6 +26,22 @@ sudo apt install -y \
 ```
 
 > `libboost-dev` is required when `ENABLE_HTTP=ON` (the default) because Boost.Beast is header-only and ships only with that package on Debian/Ubuntu.
+
+> **Ubuntu 24.04 (noble)** does not ship `libsimdutf-dev`. Either upgrade to 24.10+/Debian 13+, or build simdutf from source:
+>
+> ```bash
+> git clone --depth 1 --branch v5.7.2 https://github.com/simdutf/simdutf.git /tmp/simdutf
+> cmake -G Ninja -S /tmp/simdutf -B /tmp/simdutf/build \
+>   -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DSIMDUTF_TOOLS=OFF -DSIMDUTF_BENCHMARKS=OFF
+> cmake --build /tmp/simdutf/build && sudo cmake --install /tmp/simdutf/build
+> ```
+
+> **GCC 13 (Ubuntu 24.04 default)** is too old for `<print>`. Install GCC 14 and use it explicitly:
+>
+> ```bash
+> sudo apt install -y g++-14
+> export CC=gcc-14 CXX=g++-14
+> ```
 
 Configure and build:
 
@@ -91,5 +112,5 @@ After building, copy `config.lua.dist` to `config.lua`, edit it, then run from t
 ## Troubleshooting
 
 - **"Boost not found" / version too old** — Atlas requires Boost 1.71+ (1.75+ when HTTP is enabled). Install a newer Boost from your distro's backports or use the vcpkg path.
-- **GCC version error** — you need GCC 14+ for the C++23 features used by Atlas (`std::move_only_function`, `std::views::as_const`).
+- **GCC version error / `'print' file not found`** — you need GCC 14+ for the C++23 features used by Atlas (`<print>`, `std::move_only_function`, `std::views::as_const`). On Ubuntu 24.04: `sudo apt install g++-14` and `export CC=gcc-14 CXX=g++-14`.
 - **vcpkg builds slow on first run** — vcpkg compiles every dependency from source on the first invocation. Subsequent builds reuse the binary cache.


### PR DESCRIPTION
## Summary

Two independent issues that bite anyone trying to build Atlas from system packages on a fresh Ubuntu 24.04 noble box.

### 1. \`cmake/modules/FindMySQL.cmake\`

\`find_path(<VAR> mysql.h <path1> <path2> ... PATH_SUFFIXES mysql)\` is the legacy short form. Modern CMake parses every positional argument before the first keyword as a NAME, so the hint paths were being treated as additional file names and silently ignored. Combined with the default \`CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH = 1\`, CMake then walked the user's \`PATH\` env (which on WSL inherits Windows) and reported nonsense like:

\`\`\`
-- MySQL Include dir: /mnt/c/Users/.../AppData/Local/Programs/Python/Python313
\`\`\`

because \`Python313\include\` happens to exist and \`find_path\` could not constrain its search.

**Fix:** use the explicit \`NAMES\` / \`HINTS\` / \`PATHS\` / \`PATH_SUFFIXES\` form, add \`/usr/include/mariadb\` (the actual Debian/Ubuntu layout since the libmariadb-dev split) plus the matching lib paths, add \`mariadb\` to \`PATH_SUFFIXES\`, and pass \`NO_SYSTEM_ENVIRONMENT_PATH\` so the \`PATH\` walk is no longer consulted.

After the fix:

\`\`\`
-- MySQL Include dir: /usr/include/mariadb  library dir: /usr/lib/x86_64-linux-gnu
\`\`\`

### 2. \`compiling/linux.md\`

Ubuntu 24.04 (noble) ships \`libsimdutf-dev\` only from 24.10 onwards and GCC 13 by default. Two failures users hit on a fresh checkout:

- \`E: Unable to locate package libsimdutf-dev\` — the package only exists in 24.10+ / Debian forky-trixie. Documented the source build of simdutf 5.7.2 into \`/usr/local\` as the workaround.
- \`fatal error: 'print' file not found\` when compiling with the default toolchain. C++23's \`<print>\` lives in libstdc++ starting with GCC 14; Clang alone (even Clang 18 on 24.04) sees the system libstdc++ from GCC 13 and fails. Documented \`apt install g++-14\` + \`CC=gcc-14 CXX=g++-14\` as the standard fix, and qualified the existing "GCC 14+ or Clang 17+" line with what Clang actually needs to pair with on Ubuntu 24.04.

Both pieces are independent of any 15.x protocol work and unblock fresh builds on the most popular dev distro today.

## Test plan

- [ ] On Ubuntu 24.04 noble: \`apt install\` the documented packages + \`g++-14\`, build simdutf from source per the README block, run \`CC=gcc-14 CXX=g++-14 cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build build\` and confirm the binary builds without intervention.
- [ ] Confirm CMake reports \`MySQL Include dir: /usr/include/mariadb\` (not a path walked from \`\$PATH\`).
- [ ] Confirm Debian (\`forky\`) and other Ubuntu releases (\`oracular\`/24.10+) still find the system \`libsimdutf-dev\` and don't regress.

Co-authored-with: Claude Opus 4.7 (1M context)