### PR TITLE
perf(otbm): zero-copy read on the map-loading hot path

### DIFF
--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -50,9 +50,38 @@ void skip(OTB::iterator& first, const OTB::iterator last, const size_t len);
 template <class T>
 [[nodiscard]] T read(OTB::iterator& first, const OTB::iterator last)
 {
+	static_assert(std::is_trivially_copyable_v<T>, "OTB::read requires a trivially copyable type");
+
 	T out;
-	auto buf = readBytes(first, last, sizeof(T));
-	std::memcpy(reinterpret_cast<char*>(&out), buf.data(), buf.size());
+	char* dst = reinterpret_cast<char*>(&out);
+
+	// Fast path: when none of the next sizeof(T) raw bytes is an escape marker we can copy the value
+	// straight out of the memory-mapped file in one shot, avoiding the per-read std::string allocation
+	// that readBytes() performs. Escape markers (0xFD) are rare in practice, so this is the common case
+	// for the millions of small reads issued while loading a map. The bounds check below guarantees the
+	// source range holds at least sizeof(T) bytes, and dst is exactly sizeof(T) bytes wide.
+	if (last - first >= static_cast<std::ptrdiff_t>(sizeof(T))) {
+		if (std::find(first, first + sizeof(T), Node::ESCAPE) == first + sizeof(T)) {
+			std::copy_n(first, sizeof(T), dst);
+			first += sizeof(T);
+			return out;
+		}
+	}
+
+	// Slow path: an escape marker is present (or we are near the end of the buffer). Unescape byte by
+	// byte directly into the output, still without allocating an intermediate buffer.
+	for (size_t i = 0; i < sizeof(T); ++i) {
+		if (first == last) [[unlikely]] {
+			throw std::invalid_argument("Not enough bytes to read.");
+		}
+
+		if (*first == Node::ESCAPE && ++first == last) [[unlikely]] {
+			throw std::invalid_argument("Not enough bytes to read.");
+		}
+
+		dst[i] = *first++;
+	}
+
 	return out;
 }
 


### PR DESCRIPTION
## In one sentence

Makes the server **load the map faster** by changing *how* it reads bytes from the `.otbm` file — without changing the map format or anything the user sees.

## Plain-language explanation

The game map is stored in an `.otbm` file. When the server starts, it has to read that whole file and build the world in memory: every floor tile, every item, every door.

To read the file, the server calls a function named `OTB::read` **millions of times** — once for each small piece of information (an item's number, a tile's coordinates, etc.).

The problem: as it was, **each of those reads created a temporary little "bag" of memory** (a `std::string`), copied the bytes into it one by one, and only then placed the value where it belonged. It's like, to read a single letter from a book, photocopying the page, cutting out the letter, and only then reading it — repeated millions of times. It works, but it wastes time and effort.

### What this PR changes

Now, in the overwhelming majority of cases, the server **reads the value straight from the file**, with no temporary bag and no byte-by-byte copying. A single copy and done.

There is a technical detail of the format: some special bytes need to be "unwrapped" (escaped). When — and only when — one of those bytes appears, the code falls back to the older, more careful path. But that case is **rare**, so almost every read goes through the new fast path.

## Benefits

- **Faster boot**: less memory allocation and fewer copies in the hottest part of map loading.
- **Less allocator pressure**: stops creating millions of temporary objects during boot.
- **Zero compatibility risk**: the `.otbm` format is unchanged. Maps from RME keep loading exactly the same.

## What does NOT change

- The map file format (`.otbm`).
- The public API (`readBytes` / `readString` still exist as a fallback).
- Any observable server behavior.

## Technical detail (for the curious)

`OTB::read<T>` delegated to `readBytes()`, which builds a temporary `std::string` and copies byte by byte before the final `memcpy`. This PR adds a fast path: if none of the next `sizeof(T)` bytes of the file (already memory-mapped via `mmap`) is the OTBM escape marker (`0xFD`), the value is copied straight out of the mapping with a single `memcpy`. The escape-aware path is preserved but now unescapes directly into the output buffer, with no intermediate `std::string`.

## How to test

1. Build it (already validated locally, clean build).
2. Start the server and watch the `> Map loading time: Xms` line in the boot log.
3. Compare it with the time before this PR — it should drop, and the map should load identically (same items, houses, towns, and waypoints).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation during data deserialization: malformed, truncated, or specially-escaped input is now detected and reported reliably, avoiding undefined behavior.

* **Refactor**
  * Faster binary reading with an optimized fast path for raw data and a safe slow path for escaped or partial input.
  * Stricter read-time type safety: only simple/trivially-copyable types are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->