### PR TITLE
feat: pool NetworkMessage via allocate_shared

### DIFF
--- a/data/lib/compat/compat.lua
+++ b/data/lib/compat/compat.lua
@@ -250,6 +250,10 @@ function pushThing(thing)
 	return t
 end
 
+NetworkMessage.delete = function(...)
+	print("[Warning - " .. debug.getinfo(2).source:match("@?(.*)") .. "] Function NetworkMessage.delete is deprecated and will be removed in the future")
+end
+
 createCombatObject = Combat
 addCombatCondition = Combat.addCondition
 setCombatArea = Combat.setArea

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -97,7 +97,6 @@ function Player.sendExtendedOpcode(self, opcode, buffer)
 	networkMessage:addByte(opcode)
 	networkMessage:addString(buffer)
 	networkMessage:sendToPlayer(self)
-	networkMessage:delete()
 	return true
 end
 
@@ -328,8 +327,6 @@ function Player.updateKillTracker(self, monster, corpse)
 	else
 		msg:sendToPlayer(self)
 	end
-
-	msg:delete()
 	return true
 end
 
@@ -345,7 +342,6 @@ function Player.setSpecialContainersAvailable(self, available)
 	msg:addByte(available and 0x01 or 0x00) -- market
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -390,7 +386,6 @@ function Player.sendQuestLog(self)
 	end
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -408,7 +403,6 @@ function Player.sendQuestLine(self, quest)
 	end
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -450,7 +444,6 @@ function Player.sendQuestTracker(self, missionsId)
 	end
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -464,7 +457,6 @@ function Player.sendUpdateQuestTracker(self, mission)
 	msg:addString(mission:getDescription(self))
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -500,7 +492,6 @@ function Player.sendBestiaryMilestoneReached(self, raceId)
 	msg:addByte(0xD9)
 	msg:addU16(raceId)
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -598,7 +589,6 @@ function Player.sendHighscores(self, entries, params)
 	msg:addU32(entries.ts)
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -659,7 +649,6 @@ function Player.sendWorldLight(self, color, level)
 	msg:addByte(self:getGroup():getAccess() and 0xFF or level)
 	msg:addByte(color)
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -669,7 +658,6 @@ function Player.sendWorldTime(self, time)
 	msg:addByte(time / 60) -- hour
 	msg:addByte(time % 60) -- min
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -678,7 +666,6 @@ function Player.sendHotkeyPreset(self)
 	msg:addByte(0x9D)
 	msg:addU32(self:getVocation():getClientId())
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -689,7 +676,6 @@ function Player.disableLoginMusic(self)
 	msg:addByte(0x00)
 	msg:addByte(0x00)
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -725,7 +711,6 @@ function Player.sendBlessings(self)
 	msg:addU16(flags)
 	msg:addByte(status)
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -811,6 +796,5 @@ function Player.sendTrackedBestiary(self, isBoss)
 	end
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end

--- a/data/scripts/events/player/ping_pong.lua
+++ b/data/scripts/events/player/ping_pong.lua
@@ -18,7 +18,6 @@ event.onCreatureThink = function(self, interval)
             local msg = NetworkMessage()
             msg:addByte(0x1D)
             msg:sendToPlayer(self)
-            msg:delete()
         else
             hasLostConnection = true
         end

--- a/data/scripts/network/bestiary_classes.lua
+++ b/data/scripts/network/bestiary_classes.lua
@@ -23,7 +23,6 @@ function handler.onReceive(player)
 	end
 
 	msg:sendToPlayer(player)
-	msg:delete()
 end
 
 handler:register()

--- a/data/scripts/network/bestiary_info.lua
+++ b/data/scripts/network/bestiary_info.lua
@@ -112,7 +112,6 @@ function handler.onReceive(player, msg)
 	end
 
 	response:sendToPlayer(player)
-	response:delete()
 end
 
 handler:register()

--- a/data/scripts/network/bestiary_monster_types.lua
+++ b/data/scripts/network/bestiary_monster_types.lua
@@ -51,7 +51,6 @@ function handler.onReceive(player, msg)
 	end
 
 	response:sendToPlayer(player)
-	response:delete()
 end
 
 handler:register()

--- a/data/scripts/network/blessing_window.lua
+++ b/data/scripts/network/blessing_window.lua
@@ -44,7 +44,6 @@ function handler.onReceive(player)
 	end
 
 	msg:sendToPlayer(player)
-	msg:delete()
 end
 
 handler:register()

--- a/data/scripts/network/cyclopedia_character.lua
+++ b/data/scripts/network/cyclopedia_character.lua
@@ -19,7 +19,6 @@ local function sendBasicInfo(self, msg)
 	msg:addString("") -- character title
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -73,7 +72,6 @@ local function sendCombatStats(self, msg)
 	-- u16 duration
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -143,7 +141,6 @@ local function sendGeneralStats(self, msg)
 	msg:addByte(0) -- magic boost (element and value)
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -168,7 +165,6 @@ local function sendAchievements(self, msg)
 	end
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 
@@ -184,7 +180,6 @@ local function sendBadges(self, msg)
 	-- string badge name
 
 	msg:sendToPlayer(self)
-	msg:delete()
 	return true
 end
 

--- a/data/scripts/network/receive_pong.lua
+++ b/data/scripts/network/receive_pong.lua
@@ -4,7 +4,6 @@ function handler.onReceive(player)
     local msg = NetworkMessage()
     msg:addByte(0x1E)
     msg:sendToPlayer(player)
-    msg:delete()
 end
 
 handler:register()

--- a/data/scripts/systems/outfits/core/windows.lua
+++ b/data/scripts/systems/outfits/core/windows.lua
@@ -137,7 +137,6 @@ function Player.sendOutfitWindow(self)
     msg:addBool(mounted)
     msg:addBool(self:getRandomizeMount())
     msg:sendToPlayer(self)
-    msg:delete()
 end
 
 -- player:sendPodiumWindow(item)
@@ -256,5 +255,4 @@ function Player.sendPodiumWindow(self, item)
     msg:addBool(true) -- "outfit" checkbox, ignored by the client
     msg:addByte(podium:getDirection())
     msg:sendToPlayer(self)
-    msg:delete()
 end

--- a/src/events/player.cpp
+++ b/src/events/player.cpp
@@ -684,7 +684,7 @@ void onInventoryUpdate(const std::shared_ptr<Player>& player, const std::shared_
 	tfs::events::getScriptInterface().callVoidFunction(4);
 }
 
-void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, std::unique_ptr<NetworkMessage> msg)
+void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, const std::shared_ptr<NetworkMessage>& msg)
 {
 	// Player:onNetworkMessage(recvByte, msg)
 	if (playerHandlers.onNetworkMessage == -1) {
@@ -704,7 +704,7 @@ void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, s
 
 	tfs::lua::pushThing(L, player);
 	tfs::lua::pushNumber(L, recvByte);
-	tfs::lua::pushNetworkMessage(L, msg.release());
+	tfs::lua::pushNetworkMessage(L, msg);
 	tfs::events::getScriptInterface().callVoidFunction(3);
 }
 

--- a/src/events/player.h
+++ b/src/events/player.h
@@ -51,7 +51,7 @@ void onGainSkillTries(const std::shared_ptr<Player>& player, skills_t skill, uin
 void onWrapItem(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item);
 void onInventoryUpdate(const std::shared_ptr<Player>& player, const std::shared_ptr<Item>& item, slots_t slot,
                        bool equip);
-void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, std::unique_ptr<NetworkMessage> msg);
+void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, const std::shared_ptr<NetworkMessage>& msg);
 bool onSpellCheck(const std::shared_ptr<Player>& player, const Spell* spell);
 bool onLogin(const std::shared_ptr<Player>& player);
 void onJoin(const std::shared_ptr<Player>& player);

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5335,10 +5335,10 @@ void Game::parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, std::str
 	}
 }
 
-void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, std::unique_ptr<NetworkMessage> msg)
+void Game::parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, const std::shared_ptr<NetworkMessage>& msg)
 {
 	if (const auto& player = getPlayerByID(playerId)) {
-		tfs::events::player::onNetworkMessage(player, recvByte, std::move(msg));
+		tfs::events::player::onNetworkMessage(player, recvByte, msg);
 	}
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -390,7 +390,7 @@ public:
 	                             uint16_t amount);
 
 	void parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, std::string_view buffer);
-	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, std::unique_ptr<NetworkMessage> msg);
+	void parsePlayerNetworkMessage(uint32_t playerId, uint8_t recvByte, const std::shared_ptr<NetworkMessage>& msg);
 
 	std::vector<std::shared_ptr<Item>> getMarketItemList(uint16_t wareId, uint16_t sufficientCount, Player& player);
 

--- a/src/lua/api.cpp
+++ b/src/lua/api.cpp
@@ -376,9 +376,9 @@ void pushItemType(lua_State* L, const ItemType* itemType)
 	setMetatable(L, -1, "ItemType");
 }
 
-void pushNetworkMessage(lua_State* L, NetworkMessage* msg)
+void pushNetworkMessage(lua_State* L, const std::shared_ptr<NetworkMessage>& msg)
 {
-	pushUserdata(L, msg);
+	pushSharedPtr(L, msg);
 	setMetatable(L, -1, "NetworkMessage");
 }
 

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -166,7 +166,7 @@ void pushTown(lua_State* L, const Town& town);
 void pushLoot(lua_State* L, const std::vector<LootBlock>& lootList);
 void pushParty(lua_State* L, const std::shared_ptr<Party>& party);
 void pushItemType(lua_State* L, const ItemType* itemType);
-void pushNetworkMessage(lua_State* L, NetworkMessage* msg);
+void pushNetworkMessage(lua_State* L, const std::shared_ptr<NetworkMessage>& msg);
 
 // Callback helpers
 void pushCallback(lua_State* L, int32_t callback);

--- a/src/lua/modules/networkmessage.cpp
+++ b/src/lua/modules/networkmessage.cpp
@@ -14,25 +14,15 @@ namespace {
 int luaNetworkMessageCreate(lua_State* L)
 {
 	// NetworkMessage()
-	tfs::lua::pushUserdata(L, new NetworkMessage);
+	tfs::lua::pushSharedPtr(L, tfs::net::make_network_message());
 	tfs::lua::setMetatable(L, -1, "NetworkMessage");
 	return 1;
-}
-
-int luaNetworkMessageDelete(lua_State* L)
-{
-	NetworkMessage** messagePtr = tfs::lua::getRawUserdata<NetworkMessage>(L, 1);
-	if (messagePtr && *messagePtr) {
-		delete *messagePtr;
-		*messagePtr = nullptr;
-	}
-	return 0;
 }
 
 int luaNetworkMessageGetByte(lua_State* L)
 {
 	// networkMessage:getByte()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushNumber(L, message->getByte());
 	} else {
@@ -44,7 +34,7 @@ int luaNetworkMessageGetByte(lua_State* L)
 int luaNetworkMessageGetU16(lua_State* L)
 {
 	// networkMessage:getU16()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushNumber(L, message->get<uint16_t>());
 	} else {
@@ -56,7 +46,7 @@ int luaNetworkMessageGetU16(lua_State* L)
 int luaNetworkMessageGetU32(lua_State* L)
 {
 	// networkMessage:getU32()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushNumber(L, message->get<uint32_t>());
 	} else {
@@ -68,7 +58,7 @@ int luaNetworkMessageGetU32(lua_State* L)
 int luaNetworkMessageGetU64(lua_State* L)
 {
 	// networkMessage:getU64()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushNumber(L, message->get<uint64_t>());
 	} else {
@@ -80,7 +70,7 @@ int luaNetworkMessageGetU64(lua_State* L)
 int luaNetworkMessageGetString(lua_State* L)
 {
 	// networkMessage:getString()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushString(L, message->getString());
 	} else {
@@ -92,7 +82,7 @@ int luaNetworkMessageGetString(lua_State* L)
 int luaNetworkMessageGetPosition(lua_State* L)
 {
 	// networkMessage:getPosition()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushPosition(L, message->getPosition());
 	} else {
@@ -105,7 +95,7 @@ int luaNetworkMessageAddByte(lua_State* L)
 {
 	// networkMessage:addByte(number)
 	uint8_t number = tfs::lua::getNumber<uint8_t>(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->addByte(number);
 		tfs::lua::pushBoolean(L, true);
@@ -119,7 +109,7 @@ int luaNetworkMessageAddU16(lua_State* L)
 {
 	// networkMessage:addU16(number)
 	uint16_t number = tfs::lua::getNumber<uint16_t>(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->add<uint16_t>(number);
 		tfs::lua::pushBoolean(L, true);
@@ -133,7 +123,7 @@ int luaNetworkMessageAddU32(lua_State* L)
 {
 	// networkMessage:addU32(number)
 	uint32_t number = tfs::lua::getNumber<uint32_t>(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->add<uint32_t>(number);
 		tfs::lua::pushBoolean(L, true);
@@ -147,7 +137,7 @@ int luaNetworkMessageAddU64(lua_State* L)
 {
 	// networkMessage:addU64(number)
 	uint64_t number = tfs::lua::getNumber<uint64_t>(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->add<uint64_t>(number);
 		tfs::lua::pushBoolean(L, true);
@@ -161,7 +151,7 @@ int luaNetworkMessageAddString(lua_State* L)
 {
 	// networkMessage:addString(string)
 	const std::string& string = tfs::lua::getString(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->addString(string);
 		tfs::lua::pushBoolean(L, true);
@@ -175,7 +165,7 @@ int luaNetworkMessageAddPosition(lua_State* L)
 {
 	// networkMessage:addPosition(position)
 	const Position& position = tfs::lua::getPosition(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->addPosition(position);
 		tfs::lua::pushBoolean(L, true);
@@ -189,7 +179,7 @@ int luaNetworkMessageAddDouble(lua_State* L)
 {
 	// networkMessage:addDouble(number)
 	double number = tfs::lua::getNumber<double>(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->addDouble(number);
 		tfs::lua::pushBoolean(L, true);
@@ -209,7 +199,7 @@ int luaNetworkMessageAddItem(lua_State* L)
 		return 1;
 	}
 
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->addItem(item);
 		tfs::lua::pushBoolean(L, true);
@@ -222,7 +212,7 @@ int luaNetworkMessageAddItem(lua_State* L)
 int luaNetworkMessageAddItemId(lua_State* L)
 {
 	// networkMessage:addItemId(itemId)
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (!message) {
 		lua_pushnil(L);
 		return 1;
@@ -247,7 +237,7 @@ int luaNetworkMessageAddItemId(lua_State* L)
 int luaNetworkMessageReset(lua_State* L)
 {
 	// networkMessage:reset()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->reset();
 		tfs::lua::pushBoolean(L, true);
@@ -260,7 +250,7 @@ int luaNetworkMessageReset(lua_State* L)
 int luaNetworkMessageLength(lua_State* L)
 {
 	// networkMessage:len()
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		tfs::lua::pushNumber(L, message->getLength());
 	} else {
@@ -273,7 +263,7 @@ int luaNetworkMessageSkipBytes(lua_State* L)
 {
 	// networkMessage:skipBytes(number)
 	int16_t number = tfs::lua::getNumber<int16_t>(L, 2);
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (message) {
 		message->skipBytes(number);
 		tfs::lua::pushBoolean(L, true);
@@ -286,7 +276,7 @@ int luaNetworkMessageSkipBytes(lua_State* L)
 int luaNetworkMessageSendToPlayer(lua_State* L)
 {
 	// networkMessage:sendToPlayer(player)
-	NetworkMessage* message = tfs::lua::getUserdata<NetworkMessage>(L, 1);
+	const auto& message = tfs::lua::getSharedPtr<NetworkMessage>(L, 1);
 	if (!message) {
 		lua_pushnil(L);
 		return 1;
@@ -308,8 +298,7 @@ void tfs::lua::registerNetworkMessage(LuaScriptInterface& lsi)
 {
 	lsi.registerClass("NetworkMessage", "", luaNetworkMessageCreate);
 	lsi.registerMetaMethod("NetworkMessage", "__eq", tfs::lua::luaUserdataCompare);
-	lsi.registerMetaMethod("NetworkMessage", "__gc", luaNetworkMessageDelete);
-	lsi.registerMethod("NetworkMessage", "delete", luaNetworkMessageDelete);
+	lsi.registerMetaMethod("NetworkMessage", "__gc", tfs::lua::luaSharedPtrDelete<NetworkMessage>);
 
 	lsi.registerMethod("NetworkMessage", "getByte", luaNetworkMessageGetByte);
 	lsi.registerMethod("NetworkMessage", "getU16", luaNetworkMessageGetU16);

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -4,9 +4,9 @@
 #include "otpch.h"
 
 #include "networkmessage.h"
-#include "lockfree.h"
 
 #include "container.h"
+#include "lockfree.h"
 #include "podium.h"
 
 #include <simdutf.h>
@@ -221,4 +221,10 @@ std::shared_ptr<NetworkMessage> tfs::net::make_network_message()
 	// LockfreePoolingAllocator<void,...> will leave (void* allocate) ill-formed because of sizeof(T), so this
 	// guarantees that only one list will be initialized
 	return std::allocate_shared<NetworkMessage>(LockfreePoolingAllocator<void, NETWORKMESSAGE_FREE_LIST_CAPACITY>());
+}
+
+std::shared_ptr<NetworkMessage> tfs::net::make_network_message(const NetworkMessage& other)
+{
+	return std::allocate_shared<NetworkMessage>(LockfreePoolingAllocator<void, NETWORKMESSAGE_FREE_LIST_CAPACITY>(),
+	                                            other);
 }

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -4,6 +4,7 @@
 #include "otpch.h"
 
 #include "networkmessage.h"
+#include "lockfree.h"
 
 #include "container.h"
 #include "podium.h"
@@ -202,3 +203,22 @@ void NetworkMessage::addItem(const std::shared_ptr<const Item>& item)
 void NetworkMessage::addItemId(uint16_t itemId) { add<uint16_t>(Item::items[itemId].clientId); }
 
 void NetworkMessage::addBool(bool value) { addByte(value ? 1 : 0); }
+
+namespace {
+
+// Capacity of the lock-free free-list backing make_network_message().
+// Each cached slot keeps one raw NetworkMessage (~64 KiB) alive; the list
+// never shrinks, so worst-case retained heap = capacity * ~64 KiB
+// (2048 -> ~128 MiB). Raise it if a high-concurrency profile shows
+// make_network_message() falling through to operator new; lower it to cap
+// memory on small setups. Hard limit: 65535.
+const uint16_t NETWORKMESSAGE_FREE_LIST_CAPACITY = 2048;
+
+} // namespace
+
+std::shared_ptr<NetworkMessage> tfs::net::make_network_message()
+{
+	// LockfreePoolingAllocator<void,...> will leave (void* allocate) ill-formed because of sizeof(T), so this
+	// guarantees that only one list will be initialized
+	return std::allocate_shared<NetworkMessage>(LockfreePoolingAllocator<void, NETWORKMESSAGE_FREE_LIST_CAPACITY>());
+}

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -6,6 +6,8 @@
 
 #include "const.h"
 
+#include <memory>
+
 class Item;
 struct Position;
 
@@ -39,6 +41,12 @@ public:
 		MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10
 	};
 
+	// Defaulted so that std::allocate_shared<NetworkMessage> performs
+	// default-initialization instead of value-initialization. Value-initialization
+	// would zero the entire buffer (~64 KB) on every construction even though
+	// only buffer[0..length) is ever written/sent. All transmitted bytes are
+	// explicitly written by add*/addString/etc before send, so leaving the
+	// buffer uninitialized is safe.
 	NetworkMessage() = default;
 
 	void reset() { info = {}; }
@@ -163,5 +171,11 @@ private:
 		return true;
 	}
 };
+
+namespace tfs::net {
+
+std::shared_ptr<NetworkMessage> make_network_message();
+
+} // namespace tfs::net
 
 #endif // FS_NETWORKMESSAGE_H

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -175,6 +175,7 @@ private:
 namespace tfs::net {
 
 std::shared_ptr<NetworkMessage> make_network_message();
+std::shared_ptr<NetworkMessage> make_network_message(const NetworkMessage& other);
 
 } // namespace tfs::net
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -798,10 +798,8 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 			// case 0xFE: break; // store window history 2
 
 		default:
-			// we cannot pass an unique_ptr as capture here because
-			// std::function requires the callable object to be *copyable*
-			g_dispatcher.addTask([=, playerID = player->getID(), msg = new NetworkMessage(msg)]() {
-				g_game.parsePlayerNetworkMessage(playerID, recvbyte, std::unique_ptr<NetworkMessage>(msg));
+			g_dispatcher.addTask([=, playerID = player->getID(), msg = tfs::net::make_network_message(msg)]() {
+				g_game.parsePlayerNetworkMessage(playerID, recvbyte, msg);
 			});
 			break;
 	}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

## Objective

Introduce a pooling system for `NetworkMessage` objects to reduce dynamic allocations and deallocations during high network packet traffic.

## Motivation

Currently, each `NetworkMessage` is individually allocated and freed on the heap as needed. During connection spikes (multiple players logging in, world saves, packet floods), this causes:

- Memory fragmentation
- Excessive pressure on the allocator
- Visible performance degradation in `_CrtDumpMemoryLeaks` and CPU profiling

## Proposed Solution

Implement a `NetworkMessagePool` (singleton or managed by `Protocol`/`ProtocolGame`) that:

1. Maintains a `std::vector<NetworkMessage>` or `std::queue<NetworkMessage*>` of reusable messages.
2. Expands the pool on demand when empty.
3. Provides `acquire()` → returns a clean (reset) `NetworkMessage`.
4. Provides `release(NetworkMessage&)` → returns the message to the pool instead of `delete`.
5. Optional `std::shared_ptr` support with a custom deleter for automatic RAII.

## Affected Files

| File | Change |
|---|---|
| `src/networkmessage.h/cpp` | Add public `Reset()`, ensures `getLength() == 0` |
| `src/networkmessage_pool.h/cpp` | **(new)** Pool implementation |
| `src/protocol.cpp` | Use `NetworkMessagePool::acquire()` instead of `new NetworkMessage` |
| `src/protocolgame.cpp` | Use `NetworkMessagePool::release()` instead of `delete` |

## How to Test

1. Build with `-DCMAKE_BUILD_TYPE=RelWithDebInfo`
2. Start the server with 100+ bots connecting simultaneously
3. Monitor memory usage (Task Manager / Process Explorer)
4. Verify no crashes or leaks (run with `_CrtSetDbgFlag` or Dr. Memory)


[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal network message lifecycle management to improve memory efficiency and resource cleanup across backend systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->