### PR TITLE
fix(tests): correct test suite bugs, style inconsistencies, and add missing test CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -135,6 +135,16 @@
       }
     },
     {
+      "name": "linux-debug-tests",
+      "inherits": "linux-debug",
+      "displayName": "Linux - Debug (with tests)",
+      "description": "Linux Debug build with unit tests enabled",
+      "cacheVariables": {
+        "BUILD_TESTING": "ON",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed/x64-linux-debug-tests"
+      }
+    },
+    {
       "name": "linux-debug-asan",
       "inherits": "linux-debug",
       "displayName": "Linux - Debug + ASAN",
@@ -194,6 +204,10 @@
       "configurePreset": "linux-release-tests"
     },
     {
+      "name": "linux-debug-tests",
+      "configurePreset": "linux-debug-tests"
+    },
+    {
       "name": "linux-debug-asan",
       "configurePreset": "linux-debug-asan"
     },
@@ -238,6 +252,11 @@
       "name": "windows-debug-asan",
       "inherits": "base",
       "configurePreset": "windows-debug-asan"
+    },
+    {
+      "name": "linux-debug-tests",
+      "inherits": "base",
+      "configurePreset": "linux-debug-tests"
     },
     {
       "name": "linux-debug-asan",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -73,6 +73,27 @@
       }
     },
     {
+      "name": "windows-debug-tests",
+      "inherits": "windows-debug",
+      "displayName": "Windows - Debug (with tests)",
+      "description": "Windows Debug build with unit tests enabled",
+      "cacheVariables": {
+        "BUILD_TESTING": "ON",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed/x64-windows-debug-tests"
+      }
+    },
+    {
+      "name": "windows-debug-asan",
+      "inherits": "windows-debug",
+      "displayName": "Windows - Debug + ASAN",
+      "description": "Windows Debug build with Address Sanitizer",
+      "cacheVariables": {
+        "ENABLE_ASAN": "ON",
+        "BUILD_TESTING": "ON",
+        "VCPKG_INSTALLED_DIR": "${sourceDir}/vcpkg_installed/x64-windows-debug-asan"
+      }
+    },
+    {
       "name": "linux-release",
       "inherits": "base",
       "displayName": "Linux - Release",
@@ -153,6 +174,14 @@
       "configurePreset": "windows-release-asan"
     },
     {
+      "name": "windows-debug-tests",
+      "configurePreset": "windows-debug-tests"
+    },
+    {
+      "name": "windows-debug-asan",
+      "configurePreset": "windows-debug-asan"
+    },
+    {
       "name": "linux-release",
       "configurePreset": "linux-release"
     },
@@ -199,6 +228,16 @@
       "name": "linux-release-tests",
       "inherits": "base",
       "configurePreset": "linux-release-tests"
+    },
+    {
+      "name": "windows-debug-tests",
+      "inherits": "base",
+      "configurePreset": "windows-debug-tests"
+    },
+    {
+      "name": "windows-debug-asan",
+      "inherits": "base",
+      "configurePreset": "windows-debug-asan"
     },
     {
       "name": "linux-debug-asan",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -225,7 +225,8 @@
       },
       "execution": {
         "noTestsAction": "error",
-        "timeout": 120
+        "timeout": 120,
+        "jobs": 2
       }
     },
     {

--- a/src/tests/test_base64.cpp
+++ b/src/tests/test_base64.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(test_base64_decode)
 {
 	for (auto&& [plain, encoded] : testVectors) {
 		std::string result = tfs::base64::decode(encoded);
-	BOOST_TEST(result == plain, "expected '" << plain << "', got '" << result << "'");
+		BOOST_TEST(result == plain, "expected '" << plain << "', got '" << result << "'");
+	}
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-}

--- a/src/tests/test_base64.cpp
+++ b/src/tests/test_base64.cpp
@@ -42,4 +42,53 @@ BOOST_AUTO_TEST_CASE(test_base64_decode)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(test_base64_roundtrip_binary)
+{
+	for (auto&& [plain, encoded] : testVectors) {
+		std::string encoded_result = tfs::base64::encode(plain);
+		BOOST_TEST(encoded_result == encoded, "encode: expected '" << encoded << "', got '" << encoded_result << "'");
+
+		std::string decoded_result = tfs::base64::decode(encoded);
+		BOOST_TEST(decoded_result == plain, "decode: expected '" << plain << "', got '" << decoded_result << "'");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(test_base64_roundtrip_arbitrary)
+{
+	// Round-trip encode/decode with various binary patterns
+	auto raw = std::vector<std::string>{
+	    std::string(1, '\0'),    std::string("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f", 16),
+	    std::string(1, '\xFF'),  "\xde\xad\xbe\xef",
+	    std::string(32, '\xFF'),
+	};
+
+	for (const auto& input : raw) {
+		auto encoded = tfs::base64::encode(input);
+		auto decoded = tfs::base64::decode(encoded);
+		BOOST_TEST(decoded == input, "round-trip failed for input of size " << input.size() << ": expected '" << input
+		                                                                    << "', got '" << decoded << "'");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(test_base64_decode_invalid_chars)
+{
+	// Invalid base64 characters — behavior depends on OpenSSL's BIO.
+	// At minimum the function should not crash and should return something.
+	auto result = tfs::base64::decode("!!!");
+	BOOST_TEST(result.empty(), "expected empty or error, got '" << result << "'");
+}
+
+BOOST_AUTO_TEST_CASE(test_base64_decode_malformed_padding)
+{
+	// Malformed padding — lengths not a multiple of 4
+	tfs::base64::decode("A"); // at least no crash
+	BOOST_TEST(true);
+}
+
+BOOST_AUTO_TEST_CASE(test_base64_decode_all_padding)
+{
+	auto result = tfs::base64::decode("====");
+	BOOST_TEST(result.empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_base64.cpp
+++ b/src/tests/test_base64.cpp
@@ -24,6 +24,8 @@ auto testVectors = std::vector<Basee64Fixture>{
 
 };
 
+BOOST_AUTO_TEST_SUITE(base64)
+
 BOOST_AUTO_TEST_CASE(test_base64_encode)
 {
 	for (auto&& [plain, encoded] : testVectors) {
@@ -36,6 +38,8 @@ BOOST_AUTO_TEST_CASE(test_base64_decode)
 {
 	for (auto&& [plain, encoded] : testVectors) {
 		std::string result = tfs::base64::decode(encoded);
-		BOOST_TEST(result == plain, "expected '" << plain << "', got '" << result << "'");
-	}
+	BOOST_TEST(result == plain, "expected '" << plain << "', got '" << result << "'");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 }

--- a/src/tests/test_database.cpp
+++ b/src/tests/test_database.cpp
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE(escape_blob_with_null_bytes_round_trips_via_player_items)
 	BOOST_REQUIRE(result);
 
 	auto stored = result->getString("attributes");
-	BOOST_REQUIRE_EQUAL(stored.size(), binaryLength);
+	BOOST_REQUIRE(stored.size() == binaryLength);
 	BOOST_TEST(stored == std::string_view(binary, binaryLength));
 }
 

--- a/src/tests/test_database.cpp
+++ b/src/tests/test_database.cpp
@@ -7,7 +7,6 @@
 
 // cppcheck-suppress missingIncludeSystem
 #include <boost/test/unit_test.hpp>
-
 #include <stdexcept>
 
 // Most tests use a top-level DBTransaction that is never committed, so its
@@ -160,11 +159,11 @@ BOOST_AUTO_TEST_CASE(missing_column_does_not_crash)
 
 BOOST_AUTO_TEST_CASE(next_iterates_multiple_rows)
 {
-	BOOST_TEST(db.executeQuery(
-	    "INSERT INTO `accounts` (`name`, `email`, `password`) VALUES "
-	    "('iter_a', 'iter_a@example.com', SHA1('x')),"
-	    "('iter_b', 'iter_b@example.com', SHA1('x')),"
-	    "('iter_c', 'iter_c@example.com', SHA1('x'))"));
+	BOOST_TEST(
+	    db.executeQuery("INSERT INTO `accounts` (`name`, `email`, `password`) VALUES "
+	                    "('iter_a', 'iter_a@example.com', SHA1('x')),"
+	                    "('iter_b', 'iter_b@example.com', SHA1('x')),"
+	                    "('iter_c', 'iter_c@example.com', SHA1('x'))"));
 
 	auto result = db.storeQuery("SELECT `name` FROM `accounts` WHERE `name` LIKE 'iter_%' ORDER BY `name`");
 	BOOST_REQUIRE(result);
@@ -187,9 +186,9 @@ BOOST_AUTO_TEST_CASE(escape_string_quotes_and_special_chars_round_trip)
 	// Strings with characters that would break a naive concatenation.
 	const std::string payload = R"(He said "hello" and used a \backslash plus an 'apostrophe'.)";
 
-	BOOST_TEST(db.executeQuery(std::format(
-	    "INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('escape_t', {:s}, SHA1('x'))",
-	    db.escapeString(payload))));
+	BOOST_TEST(db.executeQuery(
+	    std::format("INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('escape_t', {:s}, SHA1('x'))",
+	                db.escapeString(payload))));
 
 	auto result = db.storeQuery("SELECT `email` FROM `accounts` WHERE `name` = 'escape_t'");
 	BOOST_REQUIRE(result);
@@ -198,9 +197,9 @@ BOOST_AUTO_TEST_CASE(escape_string_quotes_and_special_chars_round_trip)
 
 BOOST_AUTO_TEST_CASE(escape_string_empty_round_trip)
 {
-	BOOST_TEST(db.executeQuery(std::format(
-	    "INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('escape_e', {:s}, SHA1('x'))",
-	    db.escapeString(""))));
+	BOOST_TEST(db.executeQuery(
+	    std::format("INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('escape_e', {:s}, SHA1('x'))",
+	                db.escapeString(""))));
 
 	auto result = db.storeQuery("SELECT `email` FROM `accounts` WHERE `name` = 'escape_e'");
 	BOOST_REQUIRE(result);
@@ -224,13 +223,13 @@ BOOST_AUTO_TEST_CASE(escape_blob_with_null_bytes_round_trips_via_player_items)
 	const char binary[] = {0x00, 0x01, 0x02, '\'', '\\', '\n', 0x00, 'z', 0x7f};
 	const uint32_t binaryLength = sizeof(binary);
 
-	BOOST_TEST(db.executeQuery(std::format(
-	    "INSERT INTO `player_items` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`)"
-	    " VALUES ({:d}, 0, 1, 100, 1, {:s})",
-	    playerId, db.escapeBlob(binary, binaryLength))));
+	BOOST_TEST(db.executeQuery(
+	    std::format("INSERT INTO `player_items` (`player_id`, `pid`, `sid`, `itemtype`, `count`, `attributes`)"
+	                " VALUES ({:d}, 0, 1, 100, 1, {:s})",
+	                playerId, db.escapeBlob(binary, binaryLength))));
 
-	auto result = db.storeQuery(
-	    std::format("SELECT `attributes` FROM `player_items` WHERE `player_id` = {:d}", playerId));
+	auto result =
+	    db.storeQuery(std::format("SELECT `attributes` FROM `player_items` WHERE `player_id` = {:d}", playerId));
 	BOOST_REQUIRE(result);
 
 	auto stored = result->getString("attributes");
@@ -306,14 +305,13 @@ BOOST_AUTO_TEST_CASE(transaction_commit_persists_changes)
 	{
 		DBTransaction tx;
 		BOOST_REQUIRE(tx.begin());
-		BOOST_TEST(db.executeQuery(
-		    "INSERT INTO `accounts` (`name`, `email`, `password`)"
-		    " VALUES ('__dbtest__commit', 'commit@example.com', SHA1('x'))"));
+		BOOST_TEST(
+		    db.executeQuery("INSERT INTO `accounts` (`name`, `email`, `password`)"
+		                    " VALUES ('__dbtest__commit', 'commit@example.com', SHA1('x'))"));
 		BOOST_REQUIRE(tx.commit());
 	}
 
-	auto result =
-	    db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__commit'");
+	auto result = db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__commit'");
 	BOOST_REQUIRE(result);
 	BOOST_TEST(result->getNumber<int>("n") == 1);
 }
@@ -323,14 +321,13 @@ BOOST_AUTO_TEST_CASE(transaction_destructor_rolls_back_without_commit)
 	{
 		DBTransaction tx;
 		BOOST_REQUIRE(tx.begin());
-		BOOST_TEST(db.executeQuery(
-		    "INSERT INTO `accounts` (`name`, `email`, `password`)"
-		    " VALUES ('__dbtest__rollback', 'rb@example.com', SHA1('x'))"));
+		BOOST_TEST(
+		    db.executeQuery("INSERT INTO `accounts` (`name`, `email`, `password`)"
+		                    " VALUES ('__dbtest__rollback', 'rb@example.com', SHA1('x'))"));
 		// tx goes out of scope without commit -- destructor must rollback.
 	}
 
-	auto result =
-	    db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__rollback'");
+	auto result = db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__rollback'");
 	BOOST_REQUIRE(result);
 	BOOST_TEST(result->getNumber<int>("n") == 0);
 }
@@ -344,19 +341,17 @@ BOOST_AUTO_TEST_CASE(transaction_commit_after_destruction_path_does_not_double_r
 	{
 		DBTransaction tx;
 		BOOST_REQUIRE(tx.begin());
-		BOOST_TEST(db.executeQuery(
-		    "INSERT INTO `accounts` (`name`, `email`, `password`)"
-		    " VALUES ('__dbtest__commit2', 'c2@example.com', SHA1('x'))"));
+		BOOST_TEST(
+		    db.executeQuery("INSERT INTO `accounts` (`name`, `email`, `password`)"
+		                    " VALUES ('__dbtest__commit2', 'c2@example.com', SHA1('x'))"));
 		BOOST_REQUIRE(tx.commit());
 
-		auto result =
-		    db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__commit2'");
+		auto result = db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__commit2'");
 		BOOST_REQUIRE(result);
 		BOOST_TEST(result->getNumber<int>("n") == 1);
 	}
 
-	auto result =
-	    db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__commit2'");
+	auto result = db.storeQuery("SELECT COUNT(*) AS `n` FROM `accounts` WHERE `name` = '__dbtest__commit2'");
 	BOOST_REQUIRE(result);
 	BOOST_TEST(result->getNumber<int>("n") == 1);
 }

--- a/src/tests/test_database.cpp
+++ b/src/tests/test_database.cpp
@@ -357,3 +357,77 @@ BOOST_AUTO_TEST_CASE(transaction_commit_after_destruction_path_does_not_double_r
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(database_escape_edge, DatabaseFixture)
+
+BOOST_AUTO_TEST_CASE(escape_blob_zero_length)
+{
+	BOOST_TEST(db.executeQuery(
+	    std::format("INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('blob_zero', {:s}, SHA1('x'))",
+	                db.escapeBlob(nullptr, 0))));
+
+	auto result = db.storeQuery("SELECT `email` FROM `accounts` WHERE `name` = 'blob_zero'");
+	BOOST_REQUIRE(result);
+	BOOST_TEST(result->getString("email").empty());
+}
+
+BOOST_AUTO_TEST_CASE(escape_blob_single_null_byte)
+{
+	const char binary[] = {0x00};
+	BOOST_TEST(db.executeQuery(
+	    std::format("INSERT INTO `accounts` (`name`, `email`, `password`) VALUES ('blob_one', {:s}, SHA1('x'))",
+	                db.escapeBlob(binary, sizeof(binary)))));
+
+	auto result = db.storeQuery("SELECT `email` FROM `accounts` WHERE `name` = 'blob_one'");
+	BOOST_REQUIRE(result);
+	auto stored = result->getString("email");
+	BOOST_REQUIRE(stored.size() == 1);
+	BOOST_TEST(static_cast<uint8_t>(stored[0]) == 0x00);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(database_column_types, DatabaseFixture)
+
+BOOST_AUTO_TEST_CASE(get_number_float)
+{
+	auto result = db.storeQuery("SELECT CAST(3.14159 AS DECIMAL(10,5)) AS `pi`");
+	BOOST_REQUIRE(result);
+
+	auto val = result->getNumber<float>("pi");
+	BOOST_TEST(val > 3.14f);
+	BOOST_TEST(val < 3.15f);
+}
+
+BOOST_AUTO_TEST_CASE(get_number_double)
+{
+	auto result = db.storeQuery("SELECT CAST(2.718281828459045 AS DECIMAL(16,15)) AS `e`");
+	BOOST_REQUIRE(result);
+
+	auto val = result->getNumber<double>("e");
+	BOOST_TEST(val > 2.71);
+	BOOST_TEST(val < 2.72);
+}
+
+BOOST_AUTO_TEST_CASE(get_datetime_returns_string)
+{
+	auto result = db.storeQuery("SELECT NOW() AS `now`");
+	BOOST_REQUIRE(result);
+
+	auto dt = result->getString("now");
+	BOOST_TEST(!dt.empty());
+	BOOST_TEST(dt.size() >= 19);
+}
+
+BOOST_AUTO_TEST_CASE(get_number_on_null_returns_zero_for_all_types)
+{
+	auto result = db.storeQuery("SELECT NULL AS `maybe`");
+	BOOST_REQUIRE(result);
+
+	BOOST_TEST(result->getNumber<float>("maybe") == 0.0f);
+	BOOST_TEST(result->getNumber<double>("maybe") == 0.0);
+	BOOST_TEST(result->getNumber<int16_t>("maybe") == 0);
+	BOOST_TEST(result->getNumber<uint8_t>("maybe") == 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_fileloader.cpp
+++ b/src/tests/test_fileloader.cpp
@@ -19,11 +19,13 @@ BOOST_AUTO_TEST_CASE(test_read_bytes)
 	auto bytes = OTB::readBytes(first, s.data() + s.size(), 8);
 	BOOST_TEST(bytes == "\x01\x02\x03\x04\x05\x06\x07\x08"sv,
 	           "expected '\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08', got '" << bytes << "'");
-	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2, "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2,
+	           "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
 
 	bytes = OTB::readBytes(first, s.data() + s.size(), 2);
 	BOOST_TEST(bytes == "\x09\x00"sv, "expected '\\x09\\x00', got '" << bytes << "'");
-	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(first == s.data() + s.size(),
+	           "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_bytes_escape)
@@ -35,11 +37,13 @@ BOOST_AUTO_TEST_CASE(test_read_bytes_escape)
 	auto bytes = OTB::readBytes(first, s.data() + s.size(), 8);
 	BOOST_TEST(bytes == "\x01\x02\x03\x04\x05\x06\x07\x08"sv,
 	           "expected '\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08', got '" << bytes << "'");
-	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2, "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2,
+	           "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
 
 	bytes = OTB::readBytes(first, s.data() + s.size(), 2);
 	BOOST_TEST(bytes == "\x09\x00"sv, "expected '\\x09\\x00', got '" << bytes << "'");
-	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(first == s.data() + s.size(),
+	           "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read)
@@ -52,12 +56,14 @@ BOOST_AUTO_TEST_CASE(test_read)
 	static_assert(std::is_same_v<decltype(u64), uint64_t>);
 	BOOST_TEST(u64 == 0x0807060504030201,
 	           "expected '0x" << std::hex << 0x0807060504030201 << "', got '0x" << u64 << "'");
-	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2, "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2,
+	           "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
 
 	auto u16 = OTB::read<uint16_t>(first, s.data() + s.size());
 	static_assert(std::is_same_v<decltype(u16), uint16_t>);
 	BOOST_TEST(u16 == 0x0009, "expected '0x" << std::hex << 0x0009 << "', got '0x" << u16 << "'");
-	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(first == s.data() + s.size(),
+	           "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_escape)
@@ -69,7 +75,8 @@ BOOST_AUTO_TEST_CASE(test_read_escape)
 	auto u64 = OTB::read<uint64_t>(first, s.data() + s.size());
 	BOOST_TEST(u64 == 0x0807060504030201,
 	           "expected '0x" << std::hex << 0x0807060504030201 << "', got '0x" << u64 << "'");
-	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(first == s.data() + s.size(),
+	           "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_not_enough_bytes)
@@ -102,11 +109,13 @@ BOOST_AUTO_TEST_CASE(test_read_string)
 
 	auto result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "atlas", "expected 'atlas', got '" << result << "'");
-	BOOST_TEST(std::distance(first, s.data() + s.size()) == 8, "expected 8 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 8,
+	           "expected 8 bytes left, got " << std::distance(first, s.data() + s.size()));
 
 	result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "server", "expected 'server', got '" << result << "'");
-	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(first == s.data() + s.size(),
+	           "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_string_escape)
@@ -122,11 +131,13 @@ BOOST_AUTO_TEST_CASE(test_read_string_escape)
 
 	auto result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "atlas", "expected 'atlas', got '" << result << "'");
-	BOOST_TEST(std::distance(first, s.data() + s.size()) == 10, "expected 10 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 10,
+	           "expected 10 bytes left, got " << std::distance(first, s.data() + s.size()));
 
 	result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "ser\xFDver", "expected 'ser\xFDver', got '" << result << "'");
-	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
+	BOOST_TEST(first == s.data() + s.size(),
+	           "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_string_not_enough_bytes)

--- a/src/tests/test_fileloader.cpp
+++ b/src/tests/test_fileloader.cpp
@@ -8,6 +8,8 @@
 
 using namespace std::string_view_literals;
 
+BOOST_AUTO_TEST_SUITE(fileloader)
+
 BOOST_AUTO_TEST_CASE(test_read_bytes)
 {
 	auto s = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x00"sv;
@@ -176,3 +178,5 @@ BOOST_AUTO_TEST_CASE(test_skip_escape_not_enough_bytes)
 	auto first = s.begin();
 	BOOST_CHECK_THROW(OTB::skip(first, s.end(), 5), std::invalid_argument);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_fileloader.cpp
+++ b/src/tests/test_fileloader.cpp
@@ -190,4 +190,276 @@ BOOST_AUTO_TEST_CASE(test_skip_escape_not_enough_bytes)
 	BOOST_CHECK_THROW(OTB::skip(first, s.data() + s.size(), 5), std::invalid_argument);
 }
 
+BOOST_AUTO_TEST_SUITE(propstream)
+
+BOOST_AUTO_TEST_CASE(test_propstream_init_and_size)
+{
+	PropStream stream;
+	BOOST_TEST(stream.size() == 0);
+
+	const char data[] = {0x01, 0x02, 0x03, 0x04};
+	stream.init(data, sizeof(data));
+	BOOST_TEST(stream.size() == 4);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_success)
+{
+	const char data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	uint16_t val;
+	BOOST_TEST(stream.read<uint16_t>(val));
+	BOOST_TEST(val == 0x0201);
+	BOOST_TEST(stream.size() == 4);
+
+	uint32_t val2;
+	BOOST_TEST(stream.read<uint32_t>(val2));
+	BOOST_TEST(val2 == 0x06050403);
+	BOOST_TEST(stream.size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_not_enough_bytes)
+{
+	const char data[] = {0x01, 0x02};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	uint32_t val;
+	BOOST_TEST(!stream.read<uint32_t>(val));
+	BOOST_TEST(stream.size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_string_success)
+{
+	const char data[] = {0x05, 0x00, 'a', 't', 'l', 'a', 's'};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	auto [result, ok] = stream.readString();
+	BOOST_TEST(ok);
+	BOOST_TEST(result == "atlas");
+	BOOST_TEST(stream.size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_string_empty)
+{
+	const char data[] = {0x00, 0x00};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	auto [result, ok] = stream.readString();
+	BOOST_TEST(ok);
+	BOOST_TEST(result.empty());
+	BOOST_TEST(stream.size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_string_not_enough_bytes)
+{
+	const char data[] = {0x05, 0x00, 'a', 't'};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	auto [result, ok] = stream.readString();
+	BOOST_TEST(!ok);
+	BOOST_TEST(result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_string_truncated_length)
+{
+	const char data[] = {0x01};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	auto [result, ok] = stream.readString();
+	BOOST_TEST(!ok);
+	BOOST_TEST(result.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_skip_success)
+{
+	const char data[] = {0x01, 0x02, 0x03, 0x04};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	BOOST_TEST(stream.skip(3));
+	BOOST_TEST(stream.size() == 1);
+
+	uint8_t val;
+	BOOST_TEST(stream.read<uint8_t>(val));
+	BOOST_TEST(val == 0x04);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_skip_zero)
+{
+	const char data[] = {0x01, 0x02, 0x03};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	BOOST_TEST(stream.skip(0));
+	BOOST_TEST(stream.size() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_skip_not_enough)
+{
+	const char data[] = {0x01, 0x02};
+	PropStream stream;
+	stream.init(data, sizeof(data));
+
+	BOOST_TEST(!stream.skip(5));
+	BOOST_TEST(stream.size() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_propstream_read_from_empty)
+{
+	PropStream stream;
+	stream.init(nullptr, 0);
+
+	uint8_t val;
+	BOOST_TEST(!stream.read<uint8_t>(val));
+
+	auto [result, ok] = stream.readString();
+	BOOST_TEST(!ok);
+	BOOST_TEST(result.empty());
+
+	BOOST_TEST(!stream.skip(1));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(propwritestream)
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_empty)
+{
+	PropWriteStream stream;
+	BOOST_TEST(stream.getStream().empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_uint8)
+{
+	PropWriteStream stream;
+	stream.write<uint8_t>(0x42);
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 1);
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x42);
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_uint16)
+{
+	PropWriteStream stream;
+	stream.write<uint16_t>(0x0102);
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 2);
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x02);
+	BOOST_TEST(static_cast<uint8_t>(sv[1]) == 0x01);
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_uint32)
+{
+	PropWriteStream stream;
+	stream.write<uint32_t>(0x01020304);
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 4);
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x04);
+	BOOST_TEST(static_cast<uint8_t>(sv[1]) == 0x03);
+	BOOST_TEST(static_cast<uint8_t>(sv[2]) == 0x02);
+	BOOST_TEST(static_cast<uint8_t>(sv[3]) == 0x01);
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_multiple)
+{
+	PropWriteStream stream;
+	stream.write<uint8_t>(0x11);
+	stream.write<uint16_t>(0x3344);
+	stream.write<uint32_t>(0x778899AA);
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 7);
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x11);
+	BOOST_TEST(static_cast<uint8_t>(sv[1]) == 0x44);
+	BOOST_TEST(static_cast<uint8_t>(sv[2]) == 0x33);
+	BOOST_TEST(static_cast<uint8_t>(sv[3]) == 0xAA);
+	BOOST_TEST(static_cast<uint8_t>(sv[4]) == 0x99);
+	BOOST_TEST(static_cast<uint8_t>(sv[5]) == 0x88);
+	BOOST_TEST(static_cast<uint8_t>(sv[6]) == 0x77);
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_string)
+{
+	PropWriteStream stream;
+	stream.writeString("atlas");
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 7); // 2 bytes length + 5 bytes data
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x05);
+	BOOST_TEST(static_cast<uint8_t>(sv[1]) == 0x00);
+	BOOST_TEST(std::string_view(sv.data() + 2, 5) == "atlas");
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_empty_string)
+{
+	PropWriteStream stream;
+	stream.writeString("");
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 2); // 2 bytes length only
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x00);
+	BOOST_TEST(static_cast<uint8_t>(sv[1]) == 0x00);
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_write_string_truncated)
+{
+	PropWriteStream stream;
+	// String longer than UINT16_MAX should write length 0 (existing behavior)
+	std::string huge(65536, 'x');
+	stream.writeString(huge);
+
+	auto sv = stream.getStream();
+	BOOST_TEST(sv.size() == 2); // only length 0 written
+	BOOST_TEST(static_cast<uint8_t>(sv[0]) == 0x00);
+	BOOST_TEST(static_cast<uint8_t>(sv[1]) == 0x00);
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_clear)
+{
+	PropWriteStream stream;
+	stream.write<uint32_t>(0xdeadbeef);
+	BOOST_TEST(!stream.getStream().empty());
+
+	stream.clear();
+	BOOST_TEST(stream.getStream().empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_propwritestream_roundtrip_via_propstream)
+{
+	PropWriteStream writer;
+	writer.write<uint8_t>(0x42);
+	writer.write<uint16_t>(0x0102);
+	writer.writeString("hello");
+
+	auto sv = writer.getStream();
+
+	PropStream reader;
+	reader.init(sv.data(), sv.size());
+
+	uint8_t u8;
+	BOOST_REQUIRE(reader.read<uint8_t>(u8));
+	BOOST_TEST(u8 == 0x42);
+
+	uint16_t u16;
+	BOOST_REQUIRE(reader.read<uint16_t>(u16));
+	BOOST_TEST(u16 == 0x0102);
+
+	auto [str, ok] = reader.readString();
+	BOOST_REQUIRE(ok);
+	BOOST_TEST(str == "hello");
+
+	BOOST_TEST(reader.size() == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_fileloader.cpp
+++ b/src/tests/test_fileloader.cpp
@@ -14,70 +14,70 @@ BOOST_AUTO_TEST_CASE(test_read_bytes)
 {
 	auto s = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x00"sv;
 
-	auto first = s.begin();
+	auto first = s.data();
 
-	auto bytes = OTB::readBytes(first, s.end(), 8);
+	auto bytes = OTB::readBytes(first, s.data() + s.size(), 8);
 	BOOST_TEST(bytes == "\x01\x02\x03\x04\x05\x06\x07\x08"sv,
 	           "expected '\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08', got '" << bytes << "'");
-	BOOST_TEST(std::distance(first, s.end()) == 2, "expected 2 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2, "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
 
-	bytes = OTB::readBytes(first, s.end(), 2);
+	bytes = OTB::readBytes(first, s.data() + s.size(), 2);
 	BOOST_TEST(bytes == "\x09\x00"sv, "expected '\\x09\\x00', got '" << bytes << "'");
-	BOOST_TEST(first == s.end(), "expected 0 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_bytes_escape)
 {
 	auto s = "\x01\x02\x03\x04\xFD\x05\x06\x07\x08\x09\x00"sv;
 
-	auto first = s.begin();
+	auto first = s.data();
 
-	auto bytes = OTB::readBytes(first, s.end(), 8);
+	auto bytes = OTB::readBytes(first, s.data() + s.size(), 8);
 	BOOST_TEST(bytes == "\x01\x02\x03\x04\x05\x06\x07\x08"sv,
 	           "expected '\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08', got '" << bytes << "'");
-	BOOST_TEST(std::distance(first, s.end()) == 2, "expected 2 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2, "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
 
-	bytes = OTB::readBytes(first, s.end(), 2);
+	bytes = OTB::readBytes(first, s.data() + s.size(), 2);
 	BOOST_TEST(bytes == "\x09\x00"sv, "expected '\\x09\\x00', got '" << bytes << "'");
-	BOOST_TEST(first == s.end(), "expected 0 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read)
 {
 	auto s = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x00"sv;
 
-	auto first = s.begin();
+	auto first = s.data();
 
-	auto u64 = OTB::read<uint64_t>(first, s.end());
+	auto u64 = OTB::read<uint64_t>(first, s.data() + s.size());
 	static_assert(std::is_same_v<decltype(u64), uint64_t>);
 	BOOST_TEST(u64 == 0x0807060504030201,
 	           "expected '0x" << std::hex << 0x0807060504030201 << "', got '0x" << u64 << "'");
-	BOOST_TEST(std::distance(first, s.end()) == 2, "expected 2 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 2, "expected 2 bytes left, got " << std::distance(first, s.data() + s.size()));
 
-	auto u16 = OTB::read<uint16_t>(first, s.end());
+	auto u16 = OTB::read<uint16_t>(first, s.data() + s.size());
 	static_assert(std::is_same_v<decltype(u16), uint16_t>);
 	BOOST_TEST(u16 == 0x0009, "expected '0x" << std::hex << 0x0009 << "', got '0x" << u16 << "'");
-	BOOST_TEST(first == s.end(), "expected 0 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_escape)
 {
 	auto s = "\x01\x02\x03\x04\xFD\x05\x06\x07\x08"sv;
 
-	auto first = s.begin();
+	auto first = s.data();
 
-	auto u64 = OTB::read<uint64_t>(first, s.end());
+	auto u64 = OTB::read<uint64_t>(first, s.data() + s.size());
 	BOOST_TEST(u64 == 0x0807060504030201,
 	           "expected '0x" << std::hex << 0x0807060504030201 << "', got '0x" << u64 << "'");
-	BOOST_TEST(first == s.end(), "expected 0 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_not_enough_bytes)
 {
 	auto s = "\x01\x02\x03\x04\x05\x06\x07"sv;
 
-	auto first = s.begin();
-	BOOST_CHECK_THROW(std::ignore = OTB::read<uint64_t>(first, s.end()), std::invalid_argument);
+	auto first = s.data();
+	BOOST_CHECK_THROW(std::ignore = OTB::read<uint64_t>(first, s.data() + s.size()), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_read_escape_not_enough_bytes)
@@ -85,8 +85,8 @@ BOOST_AUTO_TEST_CASE(test_read_escape_not_enough_bytes)
 	auto s = "\x01\x02\x03\x04\xFD\x05\x06\x07"sv; // 8 bytes, but with escape it should be 7 actual bytes, not enough
 	                                               // for length 8
 
-	auto first = s.begin();
-	BOOST_CHECK_THROW(std::ignore = OTB::read<uint64_t>(first, s.end()), std::invalid_argument);
+	auto first = s.data();
+	BOOST_CHECK_THROW(std::ignore = OTB::read<uint64_t>(first, s.data() + s.size()), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_read_string)
@@ -98,15 +98,15 @@ BOOST_AUTO_TEST_CASE(test_read_string)
 	    "server"sv;
 	BOOST_TEST(s.size() == 15, "expected 15 bytes, got " << s.size());
 
-	auto first = s.begin();
+	auto first = s.data();
 
-	auto result = OTB::readString(first, s.end());
+	auto result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "atlas", "expected 'atlas', got '" << result << "'");
-	BOOST_TEST(std::distance(first, s.end()) == 8, "expected 8 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 8, "expected 8 bytes left, got " << std::distance(first, s.data() + s.size()));
 
-	result = OTB::readString(first, s.end());
+	result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "server", "expected 'server', got '" << result << "'");
-	BOOST_TEST(first == s.end(), "expected 0 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_string_escape)
@@ -118,65 +118,65 @@ BOOST_AUTO_TEST_CASE(test_read_string_escape)
 	    "ser\xFD\xFDver"sv;
 	BOOST_TEST(s.size() == 18, "expected 18 bytes, got " << s.size());
 
-	auto first = s.begin();
+	auto first = s.data();
 
-	auto result = OTB::readString(first, s.end());
+	auto result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "atlas", "expected 'atlas', got '" << result << "'");
-	BOOST_TEST(std::distance(first, s.end()) == 10, "expected 10 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(std::distance(first, s.data() + s.size()) == 10, "expected 10 bytes left, got " << std::distance(first, s.data() + s.size()));
 
-	result = OTB::readString(first, s.end());
+	result = OTB::readString(first, s.data() + s.size());
 	BOOST_TEST(result == "ser\xFDver", "expected 'ser\xFDver', got '" << result << "'");
-	BOOST_TEST(first == s.end(), "expected 0 bytes left, got " << std::distance(first, s.end()));
+	BOOST_TEST(first == s.data() + s.size(), "expected 0 bytes left, got " << std::distance(first, s.data() + s.size()));
 }
 
 BOOST_AUTO_TEST_CASE(test_read_string_not_enough_bytes)
 {
 	auto s = "\x09\x00"sv;
 
-	auto first = s.begin();
-	BOOST_CHECK_THROW(std::ignore = OTB::readString(first, s.end()), std::invalid_argument);
+	auto first = s.data();
+	BOOST_CHECK_THROW(std::ignore = OTB::readString(first, s.data() + s.size()), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_read_string_escape_not_enough_bytes)
 {
 	auto s = "\x05\x00gh\xFDij"sv; // 5 bytes, but with escape it should be 4 actual bytes, not enough for length 5
 
-	auto first = s.begin();
-	BOOST_CHECK_THROW(std::ignore = OTB::readString(first, s.end()), std::invalid_argument);
+	auto first = s.data();
+	BOOST_CHECK_THROW(std::ignore = OTB::readString(first, s.data() + s.size()), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_skip)
 {
 	auto s = "\x01\x02\x03\x04\x05\x06"sv;
 
-	auto first = s.begin();
-	OTB::skip(first, s.end(), 4);
-	BOOST_TEST(first == s.begin() + 4, "expected 4 bytes skipped, got " << first - s.begin());
+	auto first = s.data();
+	OTB::skip(first, s.data() + s.size(), 4);
+	BOOST_TEST(first == s.data() + 4, "expected 4 bytes skipped, got " << first - s.data());
 }
 
 BOOST_AUTO_TEST_CASE(test_skip_escape)
 {
 	auto s = "\x01\x02\xFD\x03\x04\x05\x06"sv;
 
-	auto first = s.begin();
-	OTB::skip(first, s.end(), 4);
-	BOOST_TEST(first == s.begin() + 5, "expected 5 bytes skipped, got " << first - s.begin());
+	auto first = s.data();
+	OTB::skip(first, s.data() + s.size(), 4);
+	BOOST_TEST(first == s.data() + 5, "expected 5 bytes skipped, got " << first - s.data());
 }
 
 BOOST_AUTO_TEST_CASE(test_skip_not_enough_bytes)
 {
 	auto s = "\x01\x02\x03"sv;
 
-	auto first = s.begin();
-	BOOST_CHECK_THROW(OTB::skip(first, s.end(), 4), std::invalid_argument);
+	auto first = s.data();
+	BOOST_CHECK_THROW(OTB::skip(first, s.data() + s.size(), 4), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(test_skip_escape_not_enough_bytes)
 {
 	auto s = "gh\xFDij"sv; // 5 bytes, but with escape it should be 4 actual bytes, not enough for length 5
 
-	auto first = s.begin();
-	BOOST_CHECK_THROW(OTB::skip(first, s.end(), 5), std::invalid_argument);
+	auto first = s.data();
+	BOOST_CHECK_THROW(OTB::skip(first, s.data() + s.size(), 5), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_generate_token.cpp
+++ b/src/tests/test_generate_token.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE rsa
+#define BOOST_TEST_MODULE generate_token
 
 #include "../otpch.h"
 

--- a/src/tests/test_generate_token.cpp
+++ b/src/tests/test_generate_token.cpp
@@ -15,37 +15,37 @@ struct HmacSHA1Fixture
 
 BOOST_AUTO_TEST_SUITE(generate_token)
 
+using namespace std::string_view_literals;
+
+// test vectors from https://www.rfc-editor.org/rfc/rfc2202.html#section-2
+auto hmacTestVectors = std::vector<HmacSHA1Fixture>{
+    {.key = std::string(20, '\x0b'),
+     .message = "Hi There",
+     .expected = "\xb6\x17\x31\x86\x55\x05\x72\x64\xe2\x8b\xc0\xb6\xfb\x37\x8c\x8e\xf1\x46\xbe\x00"sv},
+    {.key = "Jefe",
+     .message = "what do ya want for nothing?",
+     .expected = "\xef\xfc\xdf\x6a\xe5\xeb\x2f\xa2\xd2\x74\x16\xd5\xf1\x84\xdf\x9c\x25\x9a\x7c\x79"sv},
+    {.key = std::string(20, '\xaa'),
+     .message = std::string(50, '\xdd'),
+     .expected = "\x12\x5d\x73\x42\xb9\xac\x11\xcd\x91\xa3\x9a\xf4\x8a\xa1\x7b\x4f\x63\xf1\x75\xd3"sv},
+    {.key = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19",
+     .message = std::string(50, '\xcd'),
+     .expected = "\x4c\x90\x07\xf4\x02\x62\x50\xc6\xbc\x84\x14\xf9\xbf\x50\xc8\x6c\x2d\x72\x35\xda"sv},
+    {.key = std::string(20, '\x0c'),
+     .message = "Test With Truncation",
+     // note: we test the full digest rather than the truncated one in this test
+     .expected = "\x4c\x1a\x03\x42\x4b\x55\xe0\x7f\xe7\xf2\x7b\xe1\xd5\x8b\xb9\x32\x4a\x9a\x5a\x04"sv},
+    {.key = std::string(80, '\xaa'),
+     .message = "Test Using Larger Than Block-Size Key - Hash Key First",
+     .expected = "\xaa\x4a\xe5\xe1\x52\x72\xd0\x0e\x95\x70\x56\x37\xce\x8a\x3b\x55\xed\x40\x21\x12"sv},
+    {.key = std::string(80, '\xaa'),
+     .message = "Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data",
+     .expected = "\xe8\xe9\x9d\x0f\x45\x23\x7d\x78\x6d\x6b\xba\xa7\x96\x5c\x78\x08\xbb\xff\x1a\x91"sv},
+};
+
 BOOST_AUTO_TEST_CASE(test_hmac_sha1)
 {
-	using namespace std::string_view_literals;
-
-	// test vectors from https://www.rfc-editor.org/rfc/rfc2202.html#section-2
-	auto testVectors = std::vector<HmacSHA1Fixture>{
-	    {.key = std::string(20, '\x0b'),
-	     .message = "Hi There",
-	     .expected = "\xb6\x17\x31\x86\x55\x05\x72\x64\xe2\x8b\xc0\xb6\xfb\x37\x8c\x8e\xf1\x46\xbe\x00"sv},
-	    {.key = "Jefe",
-	     .message = "what do ya want for nothing?",
-	     .expected = "\xef\xfc\xdf\x6a\xe5\xeb\x2f\xa2\xd2\x74\x16\xd5\xf1\x84\xdf\x9c\x25\x9a\x7c\x79"sv},
-	    {.key = std::string(20, '\xaa'),
-	     .message = std::string(50, '\xdd'),
-	     .expected = "\x12\x5d\x73\x42\xb9\xac\x11\xcd\x91\xa3\x9a\xf4\x8a\xa1\x7b\x4f\x63\xf1\x75\xd3"sv},
-	    {.key = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19",
-	     .message = std::string(50, '\xcd'),
-	     .expected = "\x4c\x90\x07\xf4\x02\x62\x50\xc6\xbc\x84\x14\xf9\xbf\x50\xc8\x6c\x2d\x72\x35\xda"sv},
-	    {.key = std::string(20, '\x0c'),
-	     .message = "Test With Truncation",
-	     // note: we test the full digest rather than the truncated one in this test
-	     .expected = "\x4c\x1a\x03\x42\x4b\x55\xe0\x7f\xe7\xf2\x7b\xe1\xd5\x8b\xb9\x32\x4a\x9a\x5a\x04"sv},
-	    {.key = std::string(80, '\xaa'),
-	     .message = "Test Using Larger Than Block-Size Key - Hash Key First",
-	     .expected = "\xaa\x4a\xe5\xe1\x52\x72\xd0\x0e\x95\x70\x56\x37\xce\x8a\x3b\x55\xed\x40\x21\x12"sv},
-	    {.key = std::string(80, '\xaa'),
-	     .message = "Test Using Larger Than Block-Size Key and Larger Than One Block-Size Data",
-	     .expected = "\xe8\xe9\x9d\x0f\x45\x23\x7d\x78\x6d\x6b\xba\xa7\x96\x5c\x78\x08\xbb\xff\x1a\x91"sv},
-	};
-
-	for (auto&& [key, message, expected] : testVectors) {
+	for (auto&& [key, message, expected] : hmacTestVectors) {
 		auto actual = hmac("SHA1", key, message);
 		BOOST_TEST(actual == expected, "expected " << expected << ", got: " << actual << "");
 	}
@@ -57,16 +57,16 @@ struct TotpFixture
 	std::string_view expected;
 };
 
+// test vectors from https://www.rfc-editor.org/rfc/rfc6238#appendix-B
+auto totpTestVectors = std::vector<TotpFixture>{
+    {.time = 59, .expected = "94287082"},         {.time = 1111111109, .expected = "07081804"},
+    {.time = 1111111111, .expected = "14050471"}, {.time = 1234567890, .expected = "89005924"},
+    {.time = 2000000000, .expected = "69279037"}, {.time = 20000000000, .expected = "65353130"},
+};
+
 BOOST_AUTO_TEST_CASE(test_totp)
 {
-	// test vectors from https://www.rfc-editor.org/rfc/rfc6238#appendix-B
-	auto testVectors = std::vector<TotpFixture>{
-	    {.time = 59, .expected = "94287082"},         {.time = 1111111109, .expected = "07081804"},
-	    {.time = 1111111111, .expected = "14050471"}, {.time = 1234567890, .expected = "89005924"},
-	    {.time = 2000000000, .expected = "69279037"}, {.time = 20000000000, .expected = "65353130"},
-	};
-
-	for (auto&& [time, expected] : testVectors) {
+	for (auto&& [time, expected] : totpTestVectors) {
 		auto actual = generateToken("12345678901234567890", time / 30u, 8);
 		BOOST_TEST(actual == expected, "expected: " << expected << ", got: " << actual);
 	}

--- a/src/tests/test_generate_token.cpp
+++ b/src/tests/test_generate_token.cpp
@@ -13,6 +13,8 @@ struct HmacSHA1Fixture
 	std::string_view expected;
 };
 
+BOOST_AUTO_TEST_SUITE(generate_token)
+
 BOOST_AUTO_TEST_CASE(test_hmac_sha1)
 {
 	using namespace std::string_view_literals;
@@ -69,3 +71,5 @@ BOOST_AUTO_TEST_CASE(test_totp)
 		BOOST_TEST(actual == expected, "expected: " << expected << ", got: " << actual);
 	}
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_generate_token.cpp
+++ b/src/tests/test_generate_token.cpp
@@ -72,4 +72,48 @@ BOOST_AUTO_TEST_CASE(test_totp)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(test_hmac_sha1_empty_key)
+{
+	auto result = hmac("SHA1", "", "Hi There");
+	BOOST_TEST(result.size() == 20);
+}
+
+BOOST_AUTO_TEST_CASE(test_hmac_sha1_empty_message)
+{
+	auto result = hmac("SHA1", std::string(20, '\x0b'), "");
+	BOOST_TEST(result.size() == 20);
+}
+
+BOOST_AUTO_TEST_CASE(test_hmac_sha1_both_empty)
+{
+	auto result = hmac("SHA1", "", "");
+	BOOST_TEST(result.size() == 20);
+}
+
+BOOST_AUTO_TEST_CASE(test_hmac_unknown_algorithm)
+{
+	// Non-existent algorithm digest must throw
+	BOOST_CHECK_THROW(hmac("BOGUS", "key", "message"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_totp_counter_zero)
+{
+	auto result = generateToken("12345678901234567890", 0, 8);
+	BOOST_TEST(result.size() == 8);
+}
+
+BOOST_AUTO_TEST_CASE(test_totp_empty_key)
+{
+	auto result = generateToken("", 1, 8);
+	BOOST_TEST(result.size() == 8);
+}
+
+BOOST_AUTO_TEST_CASE(test_totp_different_lengths)
+{
+	for (size_t len : {6, 7, 8}) {
+		auto result = generateToken("12345678901234567890", 1, len);
+		BOOST_TEST(result.size() == len, "expected length " << len << ", got " << result.size());
+	}
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_matrixarea.cpp
+++ b/src/tests/test_matrixarea.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(test_MatrixArea_rotate180)
 	BOOST_TEST(m(2, 0));
 	BOOST_TEST(m(2, 1));
 	BOOST_TEST(m(2, 2));
-	BOOST_TEST(m(2, 2));
+	BOOST_TEST(m(2, 3));
 }
 
 BOOST_AUTO_TEST_CASE(test_MatrixArea_rotate270)

--- a/src/tests/test_matrixarea.cpp
+++ b/src/tests/test_matrixarea.cpp
@@ -149,4 +149,93 @@ BOOST_AUTO_TEST_CASE(test_MatrixArea_rotate270)
 	BOOST_TEST(!m(3, 2));
 }
 
+BOOST_AUTO_TEST_CASE(test_createArea_empty)
+{
+	auto m = createArea({}, 0);
+	BOOST_TEST(m.getCols() == 0);
+	BOOST_TEST(m.getRows() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_createArea_1xN)
+{
+	auto m = createArea({1, 2, 0, 0, 1, 0}, 1);
+	BOOST_TEST(m.getCols() == 6);
+	BOOST_TEST(m.getRows() == 1);
+	BOOST_TEST(m(0, 0));
+	BOOST_TEST(m(0, 1));
+	BOOST_TEST(!m(0, 2));
+	BOOST_TEST(!m(0, 3));
+	BOOST_TEST(m(0, 4));
+	BOOST_TEST(!m(0, 5));
+}
+
+BOOST_AUTO_TEST_CASE(test_createArea_Nx1)
+{
+	// clang-format off
+	auto m = createArea({
+	    1,
+	    0,
+	    1,
+	}, 3);
+	// clang-format on
+	BOOST_TEST(m.getCols() == 1);
+	BOOST_TEST(m.getRows() == 3);
+	BOOST_TEST(m(0, 0));
+	BOOST_TEST(!m(1, 0));
+	BOOST_TEST(m(2, 0));
+}
+
+BOOST_AUTO_TEST_CASE(test_createArea_all_zeros)
+{
+	auto m = createArea({0, 0, 0, 0}, 2);
+	BOOST_TEST(m.getRows() == 2);
+	BOOST_TEST(m.getCols() == 2);
+	BOOST_TEST(!m(0, 0));
+	BOOST_TEST(!m(0, 1));
+	BOOST_TEST(!m(1, 0));
+	BOOST_TEST(!m(1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_createArea_all_ones)
+{
+	auto m = createArea({1, 1, 1, 1}, 2);
+	BOOST_TEST(m.getRows() == 2);
+	BOOST_TEST(m.getCols() == 2);
+	BOOST_TEST(m(0, 0));
+	BOOST_TEST(m(0, 1));
+	BOOST_TEST(m(1, 0));
+	BOOST_TEST(m(1, 1));
+}
+
+BOOST_AUTO_TEST_CASE(test_createArea_no_center_marker)
+{
+	// No value 2 or 3 — center stays at (0,0)
+	auto m = createArea({1, 0, 0, 1}, 2);
+	auto&& [centerX, centerY] = m.getCenter();
+	BOOST_TEST(centerX == 0);
+	BOOST_TEST(centerY == 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_rotate90_1x1)
+{
+	auto m = createArea({1}, 1).rotate90();
+	BOOST_TEST(m.getRows() == 1);
+	BOOST_TEST(m.getCols() == 1);
+	BOOST_TEST(m(0, 0));
+}
+
+BOOST_AUTO_TEST_CASE(test_rotate180_1xN)
+{
+	// clang-format off
+	auto m = createArea({
+	    1, 0, 1,
+	}, 1).rotate180();
+	// clang-format on
+	BOOST_TEST(m.getRows() == 1);
+	BOOST_TEST(m.getCols() == 3);
+	BOOST_TEST(m(0, 0));
+	BOOST_TEST(!m(0, 1));
+	BOOST_TEST(m(0, 2));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_matrixarea.cpp
+++ b/src/tests/test_matrixarea.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+BOOST_AUTO_TEST_SUITE(matrixarea)
+
 BOOST_AUTO_TEST_CASE(test_createArea)
 {
 	// clang-format off
@@ -146,3 +148,5 @@ BOOST_AUTO_TEST_CASE(test_MatrixArea_rotate270)
 	BOOST_TEST(!m(3, 1));
 	BOOST_TEST(!m(3, 2));
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -8,6 +8,8 @@
 #include <openssl/core_names.h>
 #include <openssl/evp.h>
 
+BOOST_AUTO_TEST_SUITE(rsa)
+
 struct PrivateKeyFixture
 {
 	// contains the private key from key.pem in the root of the repository
@@ -132,3 +134,5 @@ BOOST_FIXTURE_TEST_CASE(test_rsa_decrypt, PrivateKeyFixture)
 	tfs::rsa::decrypt(reinterpret_cast<uint8_t*>(encrypted.data()), encrypted.size());
 	BOOST_TEST(encrypted == plaintext, "expected '" << plaintext << "', got '" << encrypted << "'");
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -135,4 +135,40 @@ BOOST_FIXTURE_TEST_CASE(test_rsa_decrypt, PrivateKeyFixture)
 	BOOST_TEST(encrypted == plaintext, "expected '" << plaintext << "', got '" << encrypted << "'");
 }
 
+BOOST_AUTO_TEST_CASE(test_rsa_load_pem_invalid)
+{
+	BOOST_CHECK_THROW(tfs::rsa::loadPEM("this is not a PEM"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_rsa_load_pem_empty) { BOOST_CHECK_THROW(tfs::rsa::loadPEM(""), std::runtime_error); }
+
+BOOST_AUTO_TEST_CASE(test_rsa_load_pem_truncated)
+{
+	BOOST_CHECK_THROW(tfs::rsa::loadPEM("-----BEGIN RSA PRIVATE KEY-----\n"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_rsa_load_pem_public_key)
+{
+	// Public key PEM (extracted from the same 1024-bit key) should fail since
+	// PEM_read_bio_PrivateKey expects a private key.
+	auto publicKey =
+	    "-----BEGIN PUBLIC KEY-----\n"
+	    "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCbZGkDtFsHrJVlaNhzU71xZROd15QHA7A+bdB5\n"
+	    "OZZhtKg3qmBWHXzLlFL6AIBZSQmIKrW8pYoaGzX4sQWbcrEhJhHGFSrT27PPvuetwUKnXT11lxUJ\n"
+	    "wyHFwkpb1R/UYPAbThW+sN4ZMFKKXT8VwePL9cQB1nd+EKyqsz2+jVt/9QIDAQAB\n"
+	    "-----END PUBLIC KEY-----\n";
+	BOOST_CHECK_THROW(tfs::rsa::loadPEM(publicKey), std::runtime_error);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_rsa_decrypt_wrong_size, PrivateKeyFixture)
+{
+	tfs::rsa::loadPEM(privateKey);
+
+	// Buffer smaller than 128 bytes (RSA 1024 block size) — the function
+	// delegates to OpenSSL which may pad/truncate silently. Just verify no crash.
+	std::string shortBuf(64, 'x');
+	tfs::rsa::decrypt(reinterpret_cast<uint8_t*>(shortBuf.data()), shortBuf.size());
+	BOOST_TEST(true);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_scope_exit.cpp
+++ b/src/tests/test_scope_exit.cpp
@@ -124,7 +124,6 @@ BOOST_AUTO_TEST_CASE(test_scope_exit_move_only_callable)
 BOOST_AUTO_TEST_CASE(test_scope_exit_function_pointer)
 {
 	bool ran = false;
-	auto cleanup = [&] { ran = true; };
 
 	auto fp = +[](void* arg) { // function pointer
 		(*static_cast<bool*>(arg)) = true;

--- a/src/tests/test_scope_exit.cpp
+++ b/src/tests/test_scope_exit.cpp
@@ -8,6 +8,8 @@
 
 // Test that the scope_exit destructor executes the cleanup function
 // when the scope is exited normally.
+BOOST_AUTO_TEST_SUITE(scope_exit)
+
 BOOST_AUTO_TEST_CASE(test_scope_exit_runs_on_destruction)
 {
 	bool ran = false;
@@ -62,3 +64,5 @@ BOOST_AUTO_TEST_CASE(test_scope_exit_on_exception)
 		BOOST_TEST(std::string(e.what()) == "boom");
 	}
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_scope_exit.cpp
+++ b/src/tests/test_scope_exit.cpp
@@ -65,4 +65,77 @@ BOOST_AUTO_TEST_CASE(test_scope_exit_on_exception)
 	}
 }
 
+BOOST_AUTO_TEST_CASE(test_scope_exit_no_op)
+{
+	bool ran = false;
+	{
+		tfs::scope_exit se{[] {}};
+		BOOST_TEST(!ran);
+	}
+	BOOST_TEST(!ran); // no-op lambda doesn't modify ran
+}
+
+BOOST_AUTO_TEST_CASE(test_scope_exit_multiple_reverse_order)
+{
+	std::vector<int> order;
+	{
+		tfs::scope_exit se1{[&] { order.push_back(1); }};
+		tfs::scope_exit se2{[&] { order.push_back(2); }};
+		tfs::scope_exit se3{[&] { order.push_back(3); }};
+		BOOST_TEST(order.empty());
+	}
+	// Destructors run in reverse order of construction
+	BOOST_REQUIRE(order.size() == 3);
+	BOOST_TEST(order[0] == 3);
+	BOOST_TEST(order[1] == 2);
+	BOOST_TEST(order[2] == 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_scope_exit_nested)
+{
+	bool outerRan = false;
+	bool innerRan = false;
+	{
+		tfs::scope_exit outer{[&] { outerRan = true; }};
+		{
+			tfs::scope_exit inner{[&] { innerRan = true; }};
+			BOOST_TEST(!innerRan);
+			BOOST_TEST(!outerRan);
+		}
+		// inner destroyed when its scope exits
+		BOOST_TEST(innerRan);
+		BOOST_TEST(!outerRan);
+	}
+	BOOST_TEST(outerRan);
+}
+
+BOOST_AUTO_TEST_CASE(test_scope_exit_move_only_callable)
+{
+	auto ptr = std::make_unique<int>(42);
+	{
+		tfs::scope_exit se{[ptr = std::move(ptr)] {
+			// ptr is moved into the lambda and destroyed with se
+		}};
+		BOOST_TEST(!ptr); // ptr was moved
+	}
+	// se was destroyed, lambda ran
+}
+
+BOOST_AUTO_TEST_CASE(test_scope_exit_function_pointer)
+{
+	bool ran = false;
+	auto cleanup = [&] { ran = true; };
+
+	auto fp = +[](void* arg) { // function pointer
+		(*static_cast<bool*>(arg)) = true;
+	};
+
+	{
+		// Use a lambda that wraps the function pointer
+		tfs::scope_exit se{[&] { fp(&ran); }};
+		BOOST_TEST(!ran);
+	}
+	BOOST_TEST(ran);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_sha1.cpp
+++ b/src/tests/test_sha1.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE rsa
+#define BOOST_TEST_MODULE sha1
 
 #include "../otpch.h"
 

--- a/src/tests/test_sha1.cpp
+++ b/src/tests/test_sha1.cpp
@@ -16,7 +16,7 @@ struct SHA1Fixture
 
 // test vectors from https://csrc.nist.gov/projects/cryptographic-algorithm-validation-program/secure-hashing
 // up to 64 bytes in input length
-auto testVectors = std::vector<SHA1Fixture>{
+auto shortVectors = std::vector<SHA1Fixture>{
     {.input = "", .expected = "\xda\x39\xa3\xee\x5e\x6b\x4b\x0d\x32\x55\xbf\xef\x95\x60\x18\x90\xaf\xd8\x07\x09"sv},
     {.input = "\x36", .expected = "\xc1\xdf\xd9\x6e\xea\x8c\xc2\xb6\x27\x85\x27\x5b\xca\x38\xac\x26\x12\x56\xe2\x78"sv},
     {.input = "\x19\x5a",
@@ -36,10 +36,74 @@ auto testVectors = std::vector<SHA1Fixture>{
 
 };
 
-BOOST_AUTO_TEST_CASE(test_sha1)
+// FIPS 180-4 known answer tests for block-boundary coverage
+auto blockBoundaryVectors = std::vector<SHA1Fixture>{
+    // http://www.nsrl.nist.gov/testdata/ - SHA1
+    // 56 bytes (forces second block due to SHA1 padding)
+    {.input = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+     .expected = "\x84\x98\x3e\x44\x1c\x3b\xd2\x6e\xba\xae\x4a\xa1\xf9\x51\x29\xe5\xe5\x46\x70\xf1"sv},
+    // 112 bytes (multiple blocks, from FIPS 180-4)
+    {.input =
+         "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+     .expected = "\xa4\x9b\x24\x46\xa0\x2c\x64\x5b\xf4\x19\xf9\x95\xb6\x70\x91\x25\x3a\x04\xa2\x59"sv},
+};
+
+BOOST_AUTO_TEST_SUITE(sha1)
+
+BOOST_AUTO_TEST_CASE(test_sha1_short_vectors)
 {
-	for (auto&& [input, expected] : testVectors) {
+	for (auto&& [input, expected] : shortVectors) {
 		std::string result = transformToSHA1(input);
 		BOOST_TEST(result == expected, "expected '" << expected << "', got '" << result << "'");
 	}
 }
+
+BOOST_AUTO_TEST_CASE(test_sha1_block_boundary_vectors)
+{
+	for (auto&& [input, expected] : blockBoundaryVectors) {
+		std::string result = transformToSHA1(input);
+		BOOST_TEST(result == expected, "expected '" << expected << "', got '" << result << "'");
+	}
+}
+
+BOOST_AUTO_TEST_CASE(test_sha1_output_length)
+{
+	// SHA1 always produces 20-byte output regardless of input size
+	for (size_t len : {0, 1, 55, 56, 64, 65, 128, 1024}) {
+		std::string input(len, 'a');
+		std::string result = transformToSHA1(input);
+		BOOST_TEST(result.size() == 20, "expected 20 bytes for input length " << len << ", got " << result.size());
+	}
+}
+
+BOOST_AUTO_TEST_CASE(test_sha1_deterministic)
+{
+	auto a = transformToSHA1("The quick brown fox jumps over the lazy dog");
+	auto b = transformToSHA1("The quick brown fox jumps over the lazy dog");
+	BOOST_TEST(a == b);
+}
+
+BOOST_AUTO_TEST_CASE(test_sha1_binary_data_with_nulls)
+{
+	std::string input(64, '\0');
+	input[0] = 'a';
+	input[63] = 'z';
+	auto result = transformToSHA1(input);
+	BOOST_TEST(result.size() == 20);
+}
+
+BOOST_AUTO_TEST_CASE(test_sha1_all_zeros)
+{
+	std::string input(64, '\0');
+	auto result = transformToSHA1(input);
+	BOOST_TEST(result.size() == 20);
+}
+
+BOOST_AUTO_TEST_CASE(test_sha1_all_ff)
+{
+	std::string input(64, '\xFF');
+	auto result = transformToSHA1(input);
+	BOOST_TEST(result.size() == 20);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_xtea.cpp
+++ b/src/tests/test_xtea.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+BOOST_AUTO_TEST_SUITE(xtea)
+
 BOOST_AUTO_TEST_CASE(test_xtea_expand_key)
 {
 	auto expected = xtea::round_keys{
@@ -42,3 +44,5 @@ BOOST_AUTO_TEST_CASE(test_xtea_decrypt)
 
 	BOOST_TEST(data == expected);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tests/test_xtea.cpp
+++ b/src/tests/test_xtea.cpp
@@ -45,4 +45,121 @@ BOOST_AUTO_TEST_CASE(test_xtea_decrypt)
 	BOOST_TEST(data == expected);
 }
 
+BOOST_AUTO_TEST_CASE(test_xtea_encrypt_empty_data)
+{
+	auto data = std::vector<uint8_t>{};
+	xtea::encrypt(data.data(), data.size(), xtea::expand_key({0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef}));
+	BOOST_TEST(data.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_decrypt_empty_data)
+{
+	auto data = std::vector<uint8_t>{};
+	xtea::decrypt(data.data(), data.size(), xtea::expand_key({0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef}));
+	BOOST_TEST(data.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_roundtrip_single_block)
+{
+	auto original = std::vector<uint8_t>{0xef, 0xbe, 0xad, 0xde, 0xef, 0xbe, 0xad, 0xde};
+	auto data = original;
+	auto keys = xtea::expand_key({0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef});
+
+	xtea::encrypt(data.data(), data.size(), keys);
+	xtea::decrypt(data.data(), data.size(), keys);
+
+	BOOST_TEST(data == original);
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_roundtrip_multi_block)
+{
+	auto original = std::vector<uint8_t>(32, 0);
+	for (size_t i = 0; i < original.size(); ++i) {
+		original[i] = static_cast<uint8_t>(i * 17 + 13);
+	}
+
+	auto data = original;
+	auto keys = xtea::expand_key({0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef});
+
+	xtea::encrypt(data.data(), data.size(), keys);
+	xtea::decrypt(data.data(), data.size(), keys);
+
+	BOOST_TEST(data == original);
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_roundtrip_all_zeros_key)
+{
+	auto original = std::vector<uint8_t>(24, 0);
+	for (size_t i = 0; i < original.size(); ++i) {
+		original[i] = static_cast<uint8_t>(i * 7 + 3);
+	}
+
+	auto data = original;
+	auto keys = xtea::expand_key({0, 0, 0, 0});
+
+	xtea::encrypt(data.data(), data.size(), keys);
+	xtea::decrypt(data.data(), data.size(), keys);
+
+	BOOST_TEST(data == original);
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_roundtrip_all_ones_key)
+{
+	auto original = std::vector<uint8_t>(24, 0);
+	for (size_t i = 0; i < original.size(); ++i) {
+		original[i] = static_cast<uint8_t>(i * 11 + 7);
+	}
+
+	auto data = original;
+	auto keys = xtea::expand_key({0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF});
+
+	xtea::encrypt(data.data(), data.size(), keys);
+	xtea::decrypt(data.data(), data.size(), keys);
+
+	BOOST_TEST(data == original);
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_expand_key_all_zeros)
+{
+	auto actual = xtea::expand_key({0, 0, 0, 0});
+
+	BOOST_TEST(actual.size() == 64);
+	BOOST_TEST(actual[0] == 0);
+	BOOST_TEST(actual[1] == 0x9e3779b9);
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_encrypt_all_zeros_plaintext)
+{
+	auto data = std::vector<uint8_t>(8, 0);
+	xtea::encrypt(data.data(), data.size(), xtea::expand_key({0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef}));
+
+	auto nonZero = false;
+	for (auto b : data) {
+		if (b != 0) {
+			nonZero = true;
+			break;
+		}
+	}
+	BOOST_TEST(nonZero);
+}
+
+BOOST_AUTO_TEST_CASE(test_xtea_encrypt_all_ones_plaintext)
+{
+	auto data = std::vector<uint8_t>(8, 0xFF);
+	xtea::encrypt(data.data(), data.size(), xtea::expand_key({0xdeadbeef, 0xdeadbeef, 0xdeadbeef, 0xdeadbeef}));
+
+	auto changed = false;
+	auto allNonFF = true;
+	for (auto b : data) {
+		if (b != 0xFF) {
+			changed = true;
+		}
+		if (b == 0xFF) {
+			allNonFF = false;
+		}
+	}
+	BOOST_TEST(changed);
+	BOOST_TEST(allNonFF);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Consolidates several fixes and improvements to the test suite, addressing inconsistencies introduced during initial development and adding missing build presets for testing and ASAN builds on Windows and Linux.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized unit tests into named suites and added many new test cases (base64, database, file loader, token generation, matrix area, RSA, scope-exit, SHA-1, XTEA) to improve coverage and consistency.
  * Updated test module identifiers and increased test runner defaults (longer timeout, parallel jobs).

* **Chores**
  * Added new CMake presets for Windows/Linux debug builds with testing and AddressSanitizer-enabled variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->