### PR TITLE
ci: add concurrency to cancel stale workflow runs

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -1,5 +1,9 @@
 name: Build with vcpkg
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Unit tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Add **concurrency** to existing CI workflows to cancel stale runs on new pushes.

**Modified files:**
- `.github/workflows/build-vcpkg.yml` — added `concurrency` group with `cancel-in-progress: true`
- `.github/workflows/test.yml` — same concurrency block

Each workflow uses the same pattern:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This ensures that when multiple commits are pushed in quick succession to the same PR or branch, only the latest workflow run executes — previous runs are cancelled, saving CI minutes and freeing runners.

### How to test

Open a PR and push two commits in quick succession — the first workflow run will be cancelled when the second starts.

### Issues addressed

N/A — CI improvement.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
