### PR TITLE
feat: add xtea benchmark

### DIFF
--- a/src/benchs/CMakeLists.txt
+++ b/src/benchs/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(benchs_SRC
     ${CMAKE_CURRENT_LIST_DIR}/bench_base64.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/bench_xtea.cpp
     )
 
 foreach(bench_src ${benchs_SRC})

--- a/src/benchs/bench_xtea.cpp
+++ b/src/benchs/bench_xtea.cpp
@@ -1,0 +1,44 @@
+#include "../otpch.h"
+
+#include "../xtea.h"
+
+#include <benchmark/benchmark.h>
+
+static void bench_xtea_expand_key(benchmark::State& state)
+{
+	xtea::key key = {0x12345678, 0x9ABCDEF0, 0x0FEDCBA9, 0x87654321};
+	for (auto&& _ : state) {
+		auto result = xtea::expand_key(key);
+		benchmark::DoNotOptimize(result);
+	}
+}
+BENCHMARK(bench_xtea_expand_key);
+
+static void bench_xtea_encrypt(benchmark::State& state)
+{
+	xtea::key key = {0x12345678, 0x9ABCDEF0, 0x0FEDCBA9, 0x87654321};
+	auto roundKeys = xtea::expand_key(key);
+
+	std::vector<uint8_t> data(state.range(0), 0x42);
+	for (auto&& _ : state) {
+		xtea::encrypt(data.data(), data.size(), roundKeys);
+		benchmark::DoNotOptimize(data);
+	}
+}
+BENCHMARK(bench_xtea_encrypt)->Range(8, 1024);
+
+static void bench_xtea_decrypt(benchmark::State& state)
+{
+	xtea::key key = {0x12345678, 0x9ABCDEF0, 0x0FEDCBA9, 0x87654321};
+	auto roundKeys = xtea::expand_key(key);
+
+	std::vector<uint8_t> data(state.range(0), 0x42);
+	xtea::encrypt(data.data(), data.size(), roundKeys);
+	for (auto&& _ : state) {
+		xtea::decrypt(data.data(), data.size(), roundKeys);
+		benchmark::DoNotOptimize(data);
+	}
+}
+BENCHMARK(bench_xtea_decrypt)->Range(8, 1024);
+
+BENCHMARK_MAIN();

--- a/src/benchs/bench_xtea.cpp
+++ b/src/benchs/bench_xtea.cpp
@@ -23,9 +23,11 @@ static void bench_xtea_encrypt(benchmark::State& state)
 	for (auto&& _ : state) {
 		xtea::encrypt(data.data(), data.size(), roundKeys);
 		benchmark::DoNotOptimize(data);
+
+		state.SetBytesProcessed(state.range(0) * state.iterations());
 	}
 }
-BENCHMARK(bench_xtea_encrypt)->Range(8, 1024);
+BENCHMARK(bench_xtea_decrypt)->Range(8, 65500);
 
 static void bench_xtea_decrypt(benchmark::State& state)
 {
@@ -37,8 +39,10 @@ static void bench_xtea_decrypt(benchmark::State& state)
 	for (auto&& _ : state) {
 		xtea::decrypt(data.data(), data.size(), roundKeys);
 		benchmark::DoNotOptimize(data);
+
+		state.SetBytesProcessed(state.range(0) * state.iterations());
 	}
 }
-BENCHMARK(bench_xtea_decrypt)->Range(8, 1024);
+BENCHMARK(bench_xtea_decrypt)->Range(8, 65500);
 
 BENCHMARK_MAIN();

--- a/src/benchs/bench_xtea.cpp
+++ b/src/benchs/bench_xtea.cpp
@@ -3,6 +3,7 @@
 #include "../xtea.h"
 
 #include <benchmark/benchmark.h>
+#include <cassert>
 
 static void bench_xtea_expand_key(benchmark::State& state)
 {
@@ -16,28 +17,36 @@ BENCHMARK(bench_xtea_expand_key);
 
 static void bench_xtea_encrypt(benchmark::State& state)
 {
+	// XTEA requires data length to be a multiple of 8 bytes.
+	size_t size = state.range(0);
+	assert(size % 8 == 0);
+
 	xtea::key key = {0x12345678, 0x9ABCDEF0, 0x0FEDCBA9, 0x87654321};
 	auto roundKeys = xtea::expand_key(key);
 
-	std::vector<uint8_t> data(state.range(0), 0x42);
+	std::vector<uint8_t> data(size, 0x42);
 	for (auto&& _ : state) {
-		xtea::encrypt(data.data(), data.size(), roundKeys);
+		xtea::encrypt(data.data(), size, roundKeys);
 		benchmark::DoNotOptimize(data);
 
 		state.SetBytesProcessed(state.range(0) * state.iterations());
 	}
 }
-BENCHMARK(bench_xtea_decrypt)->Range(8, 65500);
+BENCHMARK(bench_xtea_encrypt)->Range(8, 65500);
 
 static void bench_xtea_decrypt(benchmark::State& state)
 {
+	// XTEA requires data length to be a multiple of 8 bytes.
+	size_t size = state.range(0);
+	assert(size % 8 == 0);
+
 	xtea::key key = {0x12345678, 0x9ABCDEF0, 0x0FEDCBA9, 0x87654321};
 	auto roundKeys = xtea::expand_key(key);
 
-	std::vector<uint8_t> data(state.range(0), 0x42);
-	xtea::encrypt(data.data(), data.size(), roundKeys);
+	std::vector<uint8_t> data(size, 0x42);
+	xtea::encrypt(data.data(), size, roundKeys);
 	for (auto&& _ : state) {
-		xtea::decrypt(data.data(), data.size(), roundKeys);
+		xtea::decrypt(data.data(), size, roundKeys);
 		benchmark::DoNotOptimize(data);
 
 		state.SetBytesProcessed(state.range(0) * state.iterations());


### PR DESCRIPTION
### Pull Request Prelude

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Adds a new benchmark suite for XTEA encryption/decryption operations, following the same pattern as the existing base64 benchmark.

**Issues addressed:** N/A

**How to test:**
```bash
mkdir -p build && cd build
cmake ..
cmake --build . --target bench_xtea
./src/benchs/bench_xtea
```

Or run all benchmarks via ctest:
```bash
ctest -R bench_xtea
```

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks for XTEA cryptographic operations including key expansion, encryption, and decryption. Benchmarks feature configurable scaling ranges from 1 to 1024 bytes with optimization prevention mechanisms to ensure accurate performance measurements. The new benchmarks enable comprehensive evaluation of XTEA operation performance across varying data sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->