### PR TITLE
fix(networkmessage): remove extra byte on add item for containers

### DIFF
--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -142,7 +142,6 @@ void NetworkMessage::addItem(const std::shared_ptr<const Item>& item)
 	} else if (it.isSplash() || it.isFluidContainer()) {
 		addByte(fluidMap[item->getFluidType() & 7]);
 	} else if (it.isContainer()) {
-		addByte(0x00); // assigned loot container icon
 		const auto& container = item->asContainer();
 		if (container && it.weaponType == WEAPON_QUIVER) {
 			addByte(0x01);

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -110,8 +110,12 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count)
 	} else if (it.isSplash() || it.isFluidContainer()) {
 		addByte(fluidMap[count & 7]);
 	} else if (it.isContainer()) {
-		addByte(0x00); // assigned loot container icon
-		addByte(0x00); // quiver ammo count
+		if (it.weaponType == WEAPON_QUIVER) {
+			addByte(0x01); // assigned loot container icon
+			add<uint32_t>(0); // quiver ammo count
+		} else {
+			addByte(0x00);
+		}
 	} else if (it.isPodium()) {
 		add<uint16_t>(0); // looktype
 		add<uint16_t>(0); // lookTypeEx

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -110,12 +110,7 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count)
 	} else if (it.isSplash() || it.isFluidContainer()) {
 		addByte(fluidMap[count & 7]);
 	} else if (it.isContainer()) {
-		if (it.weaponType == WEAPON_QUIVER) {
-			addByte(0x01); // assigned loot container icon
-			add<uint32_t>(0); // quiver ammo count
-		} else {
-			addByte(0x00);
-		}
+		addByte(0x00); // assigned loot container icon
 	} else if (it.isPodium()) {
 		add<uint16_t>(0); // looktype
 		add<uint16_t>(0); // lookTypeEx


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Containers crash the client by sending an extra null byte

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quiver container serialization so ammunition count is now transmitted correctly in network messages.
  * Corrected container icon handling to ensure quiver items display and sync consistently across clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->