### PR TITLE
fix(player): store levelPercent as basis points (0-10000) for protocol 15.24

### DIFF
--- a/data/scripts/network/cyclopedia_character.lua
+++ b/data/scripts/network/cyclopedia_character.lua
@@ -90,7 +90,7 @@ local clientSkillsId = {
 local function sendGeneralStats(self, msg)
 	msg:addU64(self:getExperience())
 	msg:addU16(self:getLevel())
-	msg:addByte(self:getLevelPercent())
+	msg:addU16(self:getLevelPercent())
 
 	msg:addU16(self:getClientExpDisplay())
 	msg:addU16(self:getClientLowLevelBonusDisplay())

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -177,8 +177,8 @@ bool IOLoginData::loadPlayer(const std::shared_ptr<Player>& player, std::shared_
 	player->experience = experience;
 
 	if (currExpCount < nextExpCount) {
-		player->levelPercent = static_cast<uint8_t>(
-		    Player::getBasisPointLevel(player->experience - currExpCount, nextExpCount - currExpCount) / 100);
+		player->levelPercent =
+		    Player::getBasisPointLevel(player->experience - currExpCount, nextExpCount - currExpCount);
 	} else {
 		player->levelPercent = 0;
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1708,7 +1708,7 @@ void Player::addExperience(const std::shared_ptr<Creature>& source, uint64_t exp
 	}
 
 	if (nextLevelExp > currLevelExp) {
-		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp) / 100;
+		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp);
 	} else {
 		levelPercent = 0;
 	}
@@ -1792,7 +1792,7 @@ void Player::removeExperience(uint64_t exp, bool sendText /* = false*/)
 
 	uint64_t nextLevelExp = Player::getExpForLevel(level + 1);
 	if (nextLevelExp > currLevelExp) {
-		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp) / 100;
+		levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp);
 	} else {
 		levelPercent = 0;
 	}
@@ -2039,7 +2039,7 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 			uint64_t currLevelExp = Player::getExpForLevel(level);
 			uint64_t nextLevelExp = Player::getExpForLevel(level + 1);
 			if (nextLevelExp > currLevelExp) {
-				levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp) / 100;
+				levelPercent = Player::getBasisPointLevel(experience - currLevelExp, nextLevelExp - currLevelExp);
 			} else {
 				levelPercent = 0;
 			}
@@ -3766,7 +3766,7 @@ double Player::getLossPercent() const
 
 	double lossPercent;
 	if (level >= 25) {
-		double tmpLevel = level + (levelPercent / 100.);
+		double tmpLevel = level + (levelPercent / 10000.);
 		lossPercent =
 		    static_cast<double>((tmpLevel + 50) * 50 * ((tmpLevel * tmpLevel) - (5 * tmpLevel) + 8)) / experience;
 	} else {

--- a/src/player.h
+++ b/src/player.h
@@ -277,7 +277,7 @@ public:
 	AccountType_t getAccountType() const { return accountType; }
 	void setAccountType(AccountType_t type) { accountType = type; }
 	uint32_t getLevel() const { return level; }
-	uint8_t getLevelPercent() const { return levelPercent; }
+	uint16_t getLevelPercent() const { return levelPercent; }
 	uint32_t getMagicLevel() const { return std::max<int32_t>(0, magLevel + varStats[STAT_MAGICPOINTS]); }
 	uint32_t getSpecialMagicLevel(CombatType_t type) const
 	{
@@ -1404,7 +1404,7 @@ private:
 
 	uint8_t soul = 0;
 	std::bitset<6> blessings;
-	uint8_t levelPercent = 0;
+	uint16_t levelPercent = 0;
 	uint16_t magLevelPercent = 0;
 
 	PlayerSex_t sex = PLAYERSEX_FEMALE;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3232,7 +3232,7 @@ void ProtocolGame::AddPlayerStats(NetworkMessage& msg)
 	msg.add<uint64_t>(player->getExperience());
 
 	msg.add<uint16_t>(player->getLevel());
-	msg.add<uint16_t>(static_cast<uint16_t>(player->getLevelPercent() * 100)); // 15.24: u16 (percent * 100), was u8
+	msg.add<uint16_t>(player->getLevelPercent());
 
 	msg.add<uint16_t>(player->getClientExpDisplay());
 	msg.add<uint16_t>(player->getClientLowLevelBonusDisplay());


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Converts levelPercent storage from uint8_t (0-100) to uint16_t (0-10000, basis points) as expected by protocol 15.24.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Changes**
  * Increased precision in level progress percentage tracking, now using 16-bit representation instead of 8-bit for enhanced accuracy.
  * Updated level progression calculations to provide more granular and detailed player advancement tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->