### PR TITLE
refactor(connection): overhaul Connection and Protocol with tests and benches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ endif ()
 # Compiler Options
 # *****************************************************************************
 if (MSVC)
-    add_compile_options(/bigobj /utf-8 /MP)
+    add_compile_options(/bigobj /utf-8 /MP /EHsc)
 else ()
     add_compile_options(-Wall -Wextra -Wnon-virtual-dtor -Wno-error=old-style-cast -pedantic -Werror -pipe -fvisibility=hidden)
 endif ()

--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -53,7 +53,7 @@ const std::optional<BanInfo> getAccountBanInfo(uint32_t accountId)
 	return banInfo;
 }
 
-const std::optional<BanInfo> getIpBanInfo(const Connection::Address& clientIP)
+const std::optional<BanInfo> getIpBanInfo(const boost::asio::ip::address& clientIP)
 {
 	if (clientIP.is_unspecified()) {
 		return std::nullopt;

--- a/src/ban.h
+++ b/src/ban.h
@@ -16,7 +16,7 @@ struct BanInfo
 };
 
 const std::optional<BanInfo> getAccountBanInfo(uint32_t accountId);
-const std::optional<BanInfo> getIpBanInfo(const Connection::Address& clientIP);
+const std::optional<BanInfo> getIpBanInfo(const boost::asio::ip::address& clientIP);
 bool isPlayerNamelocked(uint32_t playerId);
 
 }; // namespace IOBan

--- a/src/benchs/CMakeLists.txt
+++ b/src/benchs/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(benchs_SRC
     ${CMAKE_CURRENT_LIST_DIR}/bench_base64.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/bench_connection.cpp
     )
 
 foreach(bench_src ${benchs_SRC})

--- a/src/benchs/bench_connection.cpp
+++ b/src/benchs/bench_connection.cpp
@@ -1,0 +1,128 @@
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../connection.h"
+#include "../outputmessage.h"
+#include "../protocol.h"
+#include "../server.h"
+
+#include <benchmark/benchmark.h>
+
+class MockProtocol : public Protocol
+{
+public:
+	explicit MockProtocol(std::shared_ptr<Connection> connection) : Protocol(std::move(connection)) {}
+
+	void onRecvFirstMessage(NetworkMessage&) override {}
+};
+
+struct BenchFixture
+{
+	boost::asio::io_context ioContext;
+	std::shared_ptr<ConnectionManager> manager = std::make_shared<ConnectionManager>();
+	boost::asio::ip::tcp::acceptor acceptor;
+	boost::asio::ip::tcp::socket clientSocket;
+	std::shared_ptr<Connection> connection;
+	std::shared_ptr<MockProtocol> protocol;
+
+	BenchFixture() :
+	    acceptor(ioContext, boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0)),
+	    clientSocket(ioContext)
+	{
+		ConfigManager::setNumber(ConfigManager::MAX_PACKETS_PER_SECOND, 100000);
+
+		auto endpoint = acceptor.local_endpoint();
+		clientSocket.async_connect(endpoint, [](auto) {});
+
+		boost::asio::ip::tcp::socket serverSocket(ioContext);
+		acceptor.async_accept(serverSocket, [](auto) {});
+
+		ioContext.run();
+		ioContext.restart();
+
+		connection = std::make_shared<Connection>(ioContext, nullptr, manager, std::move(serverSocket));
+		connection->protocol = std::make_shared<MockProtocol>(connection);
+		protocol = std::static_pointer_cast<MockProtocol>(connection->protocol);
+	}
+
+	~BenchFixture()
+	{
+		if (clientSocket.is_open()) {
+			clientSocket.close();
+		}
+		ioContext.restart();
+	}
+
+	void writeToConnection(const std::vector<uint8_t>& data)
+	{
+		boost::asio::write(clientSocket, boost::asio::buffer(data));
+	}
+
+	void runIO() { ioContext.poll(); }
+};
+
+static void bench_rate_limit(benchmark::State& state)
+{
+	BenchFixture fixture;
+	for (auto _ : state) {
+		fixture.connection->checkRateLimit();
+	}
+}
+BENCHMARK(bench_rate_limit);
+
+static void bench_send_packet(benchmark::State& state)
+{
+	BenchFixture fixture;
+	auto payloadSize = static_cast<size_t>(state.range(0));
+	for (auto _ : state) {
+		auto message = tfs::net::make_output_message();
+		message->addPaddingBytes(payloadSize);
+		fixture.connection->send(message);
+		fixture.runIO();
+	}
+}
+BENCHMARK(bench_send_packet)->Range(64, 4096);
+
+static void bench_accept_cycle(benchmark::State& state)
+{
+	BenchFixture fixture;
+	fixture.connection->protocol = fixture.protocol;
+	fixture.connection->accept();
+
+	size_t bodySize = static_cast<size_t>(state.range(0));
+	std::vector<uint8_t> packet(2 + 4 + bodySize, 0);
+	uint16_t blockCount = static_cast<uint16_t>((bodySize + 4) / 8);
+	uint32_t checksum = 0;
+	std::memcpy(packet.data(), &blockCount, 2);
+	std::memcpy(packet.data() + 2, &checksum, 4);
+
+	for (auto _ : state) {
+		fixture.connection->rateWindowStart = std::chrono::steady_clock::now();
+		fixture.connection->windowPacketCount = 0;
+
+		fixture.writeToConnection(packet);
+		fixture.runIO();
+	}
+}
+BENCHMARK(bench_accept_cycle)->Range(8, 256);
+
+static void bench_concurrent_connections(benchmark::State& state)
+{
+	auto manager = std::make_shared<ConnectionManager>();
+	boost::asio::io_context context;
+
+	size_t count = static_cast<size_t>(state.range(0));
+	for (auto _ : state) {
+		std::vector<std::shared_ptr<Connection>> connections;
+		connections.reserve(count);
+		for (size_t i = 0; i < count; ++i) {
+			connections.push_back(manager->createConnection(context, nullptr));
+		}
+		for (auto& c : connections) {
+			c->close();
+		}
+	}
+}
+BENCHMARK(bench_concurrent_connections)->RangeMultiplier(4)->Range(1, 1024);
+
+BENCHMARK_MAIN();

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -16,27 +16,28 @@
 extern Dispatcher g_dispatcher;
 
 std::shared_ptr<Connection> ConnectionManager::createConnection(boost::asio::io_context& io_context,
-                                                                std::shared_ptr<const ServicePort> servicePort)
+                                                                std::shared_ptr<ServicePort> servicePort)
 {
-	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
+	std::lock_guard<std::mutex> lock(mutex);
 
-	auto connection = std::make_shared<Connection>(io_context, servicePort);
-	connections.insert(connection);
+	auto connection = std::make_shared<Connection>(io_context, servicePort, shared_from_this(),
+	                                               boost::asio::ip::tcp::socket(io_context));
+	activeConnections.insert(connection);
 	return connection;
 }
 
 void ConnectionManager::releaseConnection(const std::shared_ptr<Connection>& connection)
 {
-	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
+	std::lock_guard<std::mutex> lock(mutex);
 
-	connections.erase(connection);
+	activeConnections.erase(connection);
 }
 
 void ConnectionManager::closeAll()
 {
-	std::lock_guard<std::mutex> lockClass(connectionManagerLock);
+	std::lock_guard<std::mutex> lock(mutex);
 
-	for (const auto& connection : connections) {
+	for (const auto& connection : activeConnections) {
 		if (!connection->socket.is_open()) {
 			continue;
 		}
@@ -48,35 +49,36 @@ void ConnectionManager::closeAll()
 			std::println("[Network error - {}] {}", __FUNCTION__, e.what());
 		}
 	}
-	connections.clear();
+	activeConnections.clear();
 }
 
-// Connection
-
-Connection::Connection(boost::asio::io_context& io_context, std::shared_ptr<const ServicePort> service_port) :
+Connection::Connection(boost::asio::io_context& io_context, std::shared_ptr<ServicePort> servicePort,
+                       std::shared_ptr<ConnectionManager> manager, boost::asio::ip::tcp::socket socket) :
+    socket(std::move(socket)),
     readTimer(io_context),
     writeTimer(io_context),
-    service_port(std::move(service_port)),
-    socket(io_context),
-    timeConnected(std::chrono::steady_clock::now())
+    servicePort(std::move(servicePort)),
+    manager(manager),
+    rateWindowStart(std::chrono::steady_clock::now())
 {}
+
+Connection::~Connection() { closeSocket(); }
 
 void Connection::close(bool force)
 {
-	// any thread
-	ConnectionManager::getInstance().releaseConnection(shared_from_this());
+	if (auto mgr = manager.lock()) {
+		mgr->releaseConnection(shared_from_this());
+	}
 
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-	connectionState = CONNECTION_STATE_DISCONNECTED;
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+	closed = true;
 
 	if (protocol) {
 		g_dispatcher.addTask([protocol = protocol]() { protocol->release(); });
 	}
 
-	if (messageQueue.empty() || force) {
+	if (writeQueue.empty() || force) {
 		closeSocket();
-	} else {
-		// will be closed by the destructor or onWriteOperation
 	}
 }
 
@@ -96,117 +98,178 @@ void Connection::closeSocket()
 	}
 }
 
-Connection::~Connection() { closeSocket(); }
-
 void Connection::accept(std::shared_ptr<Protocol> protocol)
 {
 	this->protocol = protocol;
+
 	g_dispatcher.addTask([=]() { protocol->onConnect(); });
-	connectionState = CONNECTION_STATE_GAMEWORLD_AUTH;
-	accept();
-}
 
-void Connection::accept()
-{
-	if (connectionState == CONNECTION_STATE_PENDING) {
-		connectionState = CONNECTION_STATE_REQUEST_CHARLIST;
-	}
-
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
+	std::lock_guard<std::recursive_mutex> lock(mutex);
 
 	boost::system::error_code error;
 	if (auto endpoint = socket.remote_endpoint(error); !error) {
 		remoteAddress = endpoint.address();
 	}
 
-	try {
-		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
-		readTimer.async_wait(
-		    [thisPtr = std::weak_ptr<Connection>(shared_from_this())](const boost::system::error_code& error) {
-			    Connection::handleTimeout(thisPtr, error);
-		    });
+	startReadServerName();
+}
 
-		// Read size of the first packet
-		auto bufferLength = !receivedLastChar && receivedName && connectionState == CONNECTION_STATE_GAMEWORLD_AUTH
-		                        ? 1
-		                        : NetworkMessage::HEADER_LENGTH;
+void Connection::accept()
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+
+	boost::system::error_code error;
+	if (auto endpoint = socket.remote_endpoint(error); !error) {
+		remoteAddress = endpoint.address();
+	}
+
+	startReadSequence();
+}
+
+void Connection::startReadTimer()
+{
+	readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
+	if (!readTimerArmed) {
+		readTimer.async_wait([thisPtr = std::weak_ptr<Connection>(shared_from_this())](
+		                         const boost::system::error_code& error) {
+			if (auto conn = thisPtr.lock()) {
+				conn->readTimerArmed = false;
+			}
+			Connection::onTimeout(thisPtr, error);
+		});
+		readTimerArmed = true;
+	}
+}
+
+void Connection::startWriteTimer()
+{
+	writeTimer.expires_after(std::chrono::seconds(CONNECTION_WRITE_TIMEOUT));
+	if (!writeTimerArmed) {
+		writeTimer.async_wait([thisPtr = std::weak_ptr<Connection>(shared_from_this())](
+		                         const boost::system::error_code& error) {
+			if (auto conn = thisPtr.lock()) {
+				conn->writeTimerArmed = false;
+			}
+			Connection::onTimeout(thisPtr, error);
+		});
+		writeTimerArmed = true;
+	}
+}
+
+void Connection::onTimeout(std::weak_ptr<Connection> connectionWeak, const boost::system::error_code& error)
+{
+	if (error == boost::asio::error::operation_aborted) {
+		return;
+	}
+
+	if (auto connection = connectionWeak.lock()) {
+		connection->close(FORCE_CLOSE);
+	}
+}
+
+void Connection::startReadServerName()
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+
+	try {
+		startReadTimer();
+
+		const auto bufferLength = nameState != NameState::Waiting ? 1 : NetworkMessage::HEADER_LENGTH;
+
 		boost::asio::async_read(
 		    socket, boost::asio::buffer(msg.getBuffer(), bufferLength),
 		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
-			    thisPtr->parseHeader(error);
+			    thisPtr->onServerNameRead(error);
 		    });
 	} catch (boost::system::system_error& e) {
-		std::cout << "[Network error - Connection::accept] " << e.what() << std::endl;
+		std::println("[Network error - {}] {}", __FUNCTION__, e.what());
 		close(FORCE_CLOSE);
 	}
 }
 
-void Connection::parseHeader(const boost::system::error_code& error)
+void Connection::startReadSequence()
 {
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-	readTimer.cancel();
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+
+	try {
+		startReadTimer();
+
+		boost::asio::async_read(
+		    socket, boost::asio::buffer(msg.getBuffer(), NetworkMessage::HEADER_LENGTH),
+		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
+			    thisPtr->parseHeader(error);
+		    });
+	} catch (boost::system::system_error& e) {
+		std::println("[Network error - {}] {}", __FUNCTION__, e.what());
+		close(FORCE_CLOSE);
+	}
+}
+
+void Connection::onServerNameRead(const boost::system::error_code& error)
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
 
 	if (error) {
 		close(FORCE_CLOSE);
 		return;
-	} else if (connectionState == CONNECTION_STATE_DISCONNECTED) {
+	}
+
+	if (closed) {
 		return;
 	}
 
-	auto timePassed =
-	    std::max(1s, duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - timeConnected) + 1s);
-	if ((++packetsSent / timePassed.count()) >
-	    static_cast<uint32_t>(getNumber(ConfigManager::MAX_PACKETS_PER_SECOND))) {
-		std::cout << getIP() << " disconnected for exceeding packet per second limit." << std::endl;
-		close();
-		return;
-	}
+	auto msgBuffer = msg.getBuffer();
 
-	if (!receivedLastChar && connectionState == CONNECTION_STATE_GAMEWORLD_AUTH) {
-		uint8_t* msgBuffer = msg.getBuffer();
-
-		if (!receivedName && msgBuffer[1] == 0x00) {
-			receivedLastChar = true;
+	if (nameState == NameState::Waiting) {
+		if (msgBuffer[1] == 0x00) {
+			nameState = NameState::Complete;
+			startReadSequence();
 		} else {
-			if (!receivedName) {
-				receivedName = true;
-
-				accept();
-				return;
-			}
-
-			if (msgBuffer[0] == 0x0A) {
-				receivedLastChar = true;
-			}
-
-			accept();
-			return;
+			nameState = NameState::Reading;
+			startReadServerName();
 		}
+		return;
 	}
 
-	if (receivedLastChar && connectionState == CONNECTION_STATE_GAMEWORLD_AUTH) {
-		connectionState = CONNECTION_STATE_GAME;
+	if (msgBuffer[0] == 0x0A) {
+		nameState = NameState::Complete;
+		startReadSequence();
+		return;
 	}
 
-	if (timePassed > 2s) {
-		timeConnected = std::chrono::steady_clock::now();
-		packetsSent = 0;
+	startReadServerName();
+}
+
+void Connection::parseHeader(const boost::system::error_code& error)
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+
+	if (error) {
+		close(FORCE_CLOSE);
+		return;
 	}
 
-	uint16_t size = (msg.getLengthHeader() * 8) + NetworkMessage::CHECKSUM_LENGTH;
+	if (closed) {
+		return;
+	}
+
+	if (!checkRateLimit()) {
+		return;
+	}
+
+	auto size = msg.getLengthHeader();
+	if (protocol) {
+		size = (size * NetworkMessage::XTEA_MULTIPLE) + NetworkMessage::CHECKSUM_LENGTH;
+	}
+
 	if (size == 0 || size >= NETWORKMESSAGE_MAXSIZE - 16) {
 		close(FORCE_CLOSE);
 		return;
 	}
 
 	try {
-		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
-		readTimer.async_wait(
-		    [thisPtr = std::weak_ptr<Connection>(shared_from_this())](const boost::system::error_code& error) {
-			    Connection::handleTimeout(thisPtr, error);
-		    });
+		startReadTimer();
 
-		// Read packet content
 		msg.setLength(size + NetworkMessage::HEADER_LENGTH);
 		boost::asio::async_read(
 		    socket, boost::asio::buffer(msg.getBodyBuffer(), size),
@@ -214,86 +277,128 @@ void Connection::parseHeader(const boost::system::error_code& error)
 			    thisPtr->parsePacket(error);
 		    });
 	} catch (boost::system::system_error& e) {
-		std::cout << "[Network error - Connection::parseHeader] " << e.what() << std::endl;
+		std::println("[Network error - {}] {}", __FUNCTION__, e.what());
 		close(FORCE_CLOSE);
 	}
 }
 
 void Connection::parsePacket(const boost::system::error_code& error)
 {
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-	readTimer.cancel();
+	std::lock_guard<std::recursive_mutex> lock(mutex);
 
 	if (error) {
 		close(FORCE_CLOSE);
 		return;
-	} else if (connectionState == CONNECTION_STATE_DISCONNECTED) {
+	}
+
+	if (closed) {
 		return;
 	}
 
-	// Read potential checksum bytes
 	msg.get<uint32_t>();
 
-	if (!receivedFirst) {
-		receivedFirst = true;
-
-		if (!protocol) {
-			// Skip deprecated checksum bytes (with clients that aren't using it in mind)
-			uint16_t len = msg.getLength();
-			if (len < 280 && len != 151) {
-				msg.skipBytes(-NetworkMessage::CHECKSUM_LENGTH);
-			}
-
-			// Game protocol has already been created at this point
-			protocol = service_port->make_protocol(msg, shared_from_this());
-			if (!protocol) {
-				close(FORCE_CLOSE);
-				return;
-			}
-		} else {
-			msg.skipBytes(2); // Skip enter-game opcode (u16 in 15.24, was u8)
+	if (!firstMessageProcessed) {
+		if (!onFirstMessage()) {
+			return;
 		}
-
-		protocol->onRecvFirstMessage(msg);
 	} else {
-		protocol->onRecvMessage(msg); // Send the packet to the current protocol
+		protocol->onRecvMessage(msg);
 	}
 
 	try {
-		readTimer.expires_after(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
-		readTimer.async_wait(
-		    [thisPtr = std::weak_ptr<Connection>(shared_from_this())](const boost::system::error_code& error) {
-			    Connection::handleTimeout(thisPtr, error);
-		    });
+		startReadTimer();
 
-		// Wait to the next packet
 		boost::asio::async_read(
 		    socket, boost::asio::buffer(msg.getBuffer(), NetworkMessage::HEADER_LENGTH),
 		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
 			    thisPtr->parseHeader(error);
 		    });
 	} catch (boost::system::system_error& e) {
-		std::cout << "[Network error - Connection::parsePacket] " << e.what() << std::endl;
+		std::println("[Network error - {}] {}", __FUNCTION__, e.what());
 		close(FORCE_CLOSE);
 	}
 }
 
-void Connection::send(const std::shared_ptr<OutputMessage>& msg)
+void Connection::onWriteComplete(const boost::system::error_code& error)
 {
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-	if (connectionState == CONNECTION_STATE_DISCONNECTED) {
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+	writeTimer.cancel();
+	writeQueue.pop_front();
+
+	if (error) {
+		writeQueue.clear();
+		close(FORCE_CLOSE);
 		return;
 	}
 
-	bool noPendingWrite = messageQueue.empty();
-	messageQueue.emplace_back(msg);
+	if (!writeQueue.empty()) {
+		internalSend(writeQueue.front());
+	}
+
+	if (closed) {
+		closeSocket();
+	}
+}
+
+bool Connection::checkRateLimit()
+{
+	auto now = std::chrono::steady_clock::now();
+	auto elapsed = duration_cast<std::chrono::seconds>(now - rateWindowStart).count() + 1;
+
+	if ((++windowPacketCount / static_cast<uint32_t>(elapsed)) >
+	    static_cast<uint32_t>(getNumber(ConfigManager::MAX_PACKETS_PER_SECOND))) {
+		std::cout << getRemoteAddress() << " disconnected for exceeding packet per second limit." << std::endl;
+		close();
+		return false;
+	}
+
+	if (elapsed >= 3) {
+		rateWindowStart = now;
+		windowPacketCount = 0;
+	}
+
+	return true;
+}
+
+bool Connection::onFirstMessage()
+{
+	firstMessageProcessed = true;
+
+	if (!protocol) {
+		auto len = msg.getLength();
+		if (len < 280 && len != 151) {
+			msg.skipBytes(-NetworkMessage::CHECKSUM_LENGTH);
+		}
+
+		protocol = servicePort->make_protocol(msg, shared_from_this());
+		if (!protocol) {
+			close(FORCE_CLOSE);
+			return false;
+		}
+	} else {
+		msg.skipBytes(2);
+	}
+
+	protocol->onRecvFirstMessage(msg);
+	return true;
+}
+
+void Connection::send(const std::shared_ptr<OutputMessage>& msg)
+{
+	std::lock_guard<std::recursive_mutex> lock(mutex);
+	if (closed) {
+		return;
+	}
+
+	bool noPendingWrite = writeQueue.empty();
+	writeQueue.emplace_back(msg);
 	if (noPendingWrite) {
 		try {
 			boost::asio::post(socket.get_executor(),
 			                  [thisPtr = shared_from_this(), msg] { thisPtr->internalSend(msg); });
 		} catch (const boost::system::system_error& e) {
-			std::cout << "[Network error - Connection::send] " << e.what() << std::endl;
-			messageQueue.clear();
+			std::println("[Network error - {}] {}", __FUNCTION__, e.what());
+			writeQueue.clear();
 			close(FORCE_CLOSE);
 		}
 	}
@@ -303,50 +408,15 @@ void Connection::internalSend(const std::shared_ptr<OutputMessage>& msg)
 {
 	protocol->onSendMessage(msg);
 	try {
-		writeTimer.expires_after(std::chrono::seconds(CONNECTION_WRITE_TIMEOUT));
-		writeTimer.async_wait(
-		    [thisPtr = std::weak_ptr<Connection>(shared_from_this())](const boost::system::error_code& error) {
-			    Connection::handleTimeout(thisPtr, error);
-		    });
+		startWriteTimer();
 
 		boost::asio::async_write(
 		    socket, boost::asio::buffer(msg->getOutputBuffer(), msg->getLength()),
 		    [thisPtr = shared_from_this()](const boost::system::error_code& error, auto /*bytes_transferred*/) {
-			    thisPtr->onWriteOperation(error);
+			    thisPtr->onWriteComplete(error);
 		    });
 	} catch (boost::system::system_error& e) {
-		std::cout << "[Network error - Connection::internalSend] " << e.what() << std::endl;
+		std::println("[Network error - {}] {}", __FUNCTION__, e.what());
 		close(FORCE_CLOSE);
-	}
-}
-
-void Connection::onWriteOperation(const boost::system::error_code& error)
-{
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-	writeTimer.cancel();
-	messageQueue.pop_front();
-
-	if (error) {
-		messageQueue.clear();
-		close(FORCE_CLOSE);
-		return;
-	}
-
-	if (!messageQueue.empty()) {
-		internalSend(messageQueue.front());
-	} else if (connectionState == CONNECTION_STATE_DISCONNECTED) {
-		closeSocket();
-	}
-}
-
-void Connection::handleTimeout(std::weak_ptr<Connection> connectionWeak, const boost::system::error_code& error)
-{
-	if (error == boost::asio::error::operation_aborted) {
-		// The timer has been cancelled manually
-		return;
-	}
-
-	if (auto connection = connectionWeak.lock()) {
-		connection->close(FORCE_CLOSE);
 	}
 }

--- a/src/connection.h
+++ b/src/connection.h
@@ -6,106 +6,396 @@
 
 #include "networkmessage.h"
 
-enum ConnectionState_t
-{
-	CONNECTION_STATE_DISCONNECTED,
-	CONNECTION_STATE_REQUEST_CHARLIST,
-	CONNECTION_STATE_GAMEWORLD_AUTH,
-	CONNECTION_STATE_GAME,
-	CONNECTION_STATE_PENDING
-};
-
-static constexpr int32_t CONNECTION_WRITE_TIMEOUT = 30;
-static constexpr int32_t CONNECTION_READ_TIMEOUT = 30;
-
 class Protocol;
 class OutputMessage;
 class Connection;
 class ServicePort;
 
-class ConnectionManager
+/**
+ * @brief Write timeout in seconds. Configurable for tests.
+ */
+static inline int32_t CONNECTION_WRITE_TIMEOUT = 30;
+
+/**
+ * @brief Read timeout in seconds. Configurable for tests.
+ */
+static inline int32_t CONNECTION_READ_TIMEOUT = 30;
+
+/**
+ * @class ConnectionManager
+ * @brief Tracks all active Connection instances.
+ *
+ * Connections register on creation (createConnection) and unregister
+ * on close (releaseConnection). closeAll() provides a clean shutdown
+ * of every tracked connection. Thread-safe.
+ */
+class ConnectionManager : public std::enable_shared_from_this<ConnectionManager>
 {
 public:
-	static ConnectionManager& getInstance()
-	{
-		static ConnectionManager instance;
-		return instance;
-	}
-
-	std::shared_ptr<Connection> createConnection(boost::asio::io_context& io_context,
-	                                             std::shared_ptr<const ServicePort> servicePort);
-	void releaseConnection(const std::shared_ptr<Connection>& connection);
-	void closeAll();
-
-private:
 	ConnectionManager() = default;
 
-	std::unordered_set<std::shared_ptr<Connection>> connections;
-	std::mutex connectionManagerLock;
+	ConnectionManager(const ConnectionManager&) = delete;
+	ConnectionManager& operator=(const ConnectionManager&) = delete;
+
+	/**
+	 * @brief Creates a new Connection and begins tracking it.
+	 *
+	 * @param {io_context} The ASIO context for async operations.
+	 * @param {servicePort} The owning service port.
+	 * @return A shared pointer to the new Connection.
+	 */
+	std::shared_ptr<Connection> createConnection(boost::asio::io_context& io_context,
+	                                             std::shared_ptr<ServicePort> servicePort);
+
+	/**
+	 * @brief Stops tracking a connection.
+	 *
+	 * Called automatically by Connection::close().
+	 */
+	void releaseConnection(const std::shared_ptr<Connection>& connection);
+
+	/**
+	 * @brief Closes and releases all tracked connections.
+	 */
+	void closeAll();
+
+	/**
+	 * @brief Returns the number of tracked connections.
+	 */
+	size_t size() const
+	{
+		std::lock_guard<std::mutex> lock(mutex);
+		return activeConnections.size();
+	}
+
+private:
+	std::unordered_set<std::shared_ptr<Connection>> activeConnections;
+	mutable std::mutex mutex;
 };
 
+/**
+ * @class Connection
+ * @brief Manages a single TCP connection with async read/write and framing.
+ *
+ * Supports two handshake modes:
+ *   - Server-sends-first (accept(Protocol*)): reads the client name first,
+ *     then enters the sequence read loop.
+ *   - Client-sends-first (accept()): enters the sequence read loop
+ *     immediately.
+ *
+ * Steady-state read loop: startReadSequence() -> parseHeader()
+ * -> parsePacket() -> startReadSequence().
+ */
 class Connection : public std::enable_shared_from_this<Connection>
 {
 public:
-	using Address = boost::asio::ip::address;
 	// non-copyable
 	Connection(const Connection&) = delete;
 	Connection& operator=(const Connection&) = delete;
 
-	enum
-	{
-		FORCE_CLOSE = true
-	};
+	/**
+	 * @brief Pass true to close() to skip pending writes.
+	 */
+	static constexpr bool FORCE_CLOSE = true;
 
-	Connection(boost::asio::io_context& io_context, std::shared_ptr<const ServicePort> service_port);
+	/**
+	 * @brief Constructs a Connection with a socket and manager.
+	 *
+	 * @param {io_context} The ASIO context for async operations.
+	 * @param {servicePort} The owning service port.
+	 * @param {manager} The ConnectionManager to register with.
+	 * @param {socket} A pre-connected socket.
+	 */
+	Connection(boost::asio::io_context& io_context, std::shared_ptr<ServicePort> servicePort,
+	           std::shared_ptr<ConnectionManager> manager, boost::asio::ip::tcp::socket socket);
+
+	/**
+	 * @brief Closes the socket if still open.
+	 */
 	~Connection();
 
 	friend class ConnectionManager;
 
+	/** @name Public API */
+	///@{
+
+	/**
+	 * @brief Gracefully or forcefully closes the connection.
+	 *
+	 * Marks the connection as closed, releases it from the manager,
+	 * releases the protocol, and either closes the socket immediately
+	 * (force) or defers until pending writes complete.
+	 *
+	 * @param {force} If true, close the socket even with pending writes.
+	 */
 	void close(bool force = false);
-	// Used by protocols that require server to send first
+
+	/**
+	 * @brief Initiates the server-sends-first handshake.
+	 *
+	 * Stores the protocol, dispatches onConnect(), captures the
+	 * remote address, and begins reading the client name.
+	 *
+	 * @param {protocol} The pre-created protocol instance.
+	 */
 	void accept(std::shared_ptr<Protocol> protocol);
+
+	/**
+	 * @brief Initiates the client-sends-first handshake.
+	 *
+	 * Captures the remote address and enters the sequence read loop
+	 * immediately (no name detection).
+	 */
 	void accept();
 
+	/**
+	 * @brief Queues a message for sending.
+	 *
+	 * If no write is in progress, posts internalSend() to the
+	 * socket executor immediately.
+	 *
+	 * @param {msg} The message to send.
+	 */
 	void send(const std::shared_ptr<OutputMessage>& msg);
 
-	const Address& getIP() const { return remoteAddress; };
+	/**
+	 * @brief Returns the remote IP address.
+	 */
+	const auto& getRemoteAddress() const { return remoteAddress; };
+
+	///@}
+
+	/** @name Testing helpers */
+	///@{
+
+	/**
+	 * @brief Checks whether the client exceeded the per-second packet limit.
+	 *
+	 * @return false if the rate limit was exceeded (connection was closed).
+	 */
+	bool checkRateLimit();
+
+	/**
+	 * @brief Handles the first message on a new connection.
+	 *
+	 * For the status protocol (no protocol set): detects and skips
+	 * deprecated checksum bytes, then creates the protocol instance.
+	 * For the game protocol: skips the enter-game opcode.
+	 *
+	 * @return false if protocol creation failed (connection was closed).
+	 */
+	bool onFirstMessage();
+
+	/**
+	 * @brief Closes the socket and cancels all timers.
+	 *
+	 * Safe to call multiple times — returns early if not open.
+	 */
+	void closeSocket();
+
+	/**
+	 * @brief Exposes the underlying TCP socket for testing.
+	 */
+	boost::asio::ip::tcp::socket& getSocket() { return socket; }
+
+	/**
+	 * @brief Starts the read timeout timer.
+	 *
+	 * On expiration, onTimeout() force-closes the connection.
+	 */
+	void startReadTimer();
+
+	/**
+	 * @brief Starts the write timeout timer.
+	 *
+	 * On expiration, onTimeout() force-closes the connection.
+	 */
+	void startWriteTimer();
+
+	/**
+	 * @brief Callback for read/write timer expiration.
+	 *
+	 * Closes the connection if the timer fires and was not
+	 * cancelled by the corresponding completion handler.
+	 *
+	 * @param {connectionWeak} Prevents keeping the connection alive.
+	 * @param {error} operation_aborted if the timer was cancelled.
+	 */
+	static void onTimeout(std::weak_ptr<Connection> connectionWeak, const boost::system::error_code& error);
+
+	/**
+	 * @brief Reads the next packet sequence header (u16 block count).
+	 *
+	 * This is the steady-state read loop for all protocols.
+	 * The result is processed by parseHeader().
+	 */
+	void startReadSequence();
+
+	/**
+	 * @brief Processes a completed write operation.
+	 *
+	 * Dequeues the sent message, sends the next queued message, or
+	 * shuts down the socket if the connection was closed and the
+	 * queue is empty.
+	 *
+	 * @param {error} Boost.Asio error code.
+	 */
+	void onWriteComplete(const boost::system::error_code& error);
+
+	///@}
+
+	/** @name State queries */
+	///@{
+
+	/**
+	 * @brief Returns true after close() is called.
+	 */
+	bool isClosed() const { return closed; }
+
+	/**
+	 * @brief Returns true after onFirstMessage() succeeds.
+	 */
+	bool isFirstMessageProcessed() const { return firstMessageProcessed; }
+
+	/**
+	 * @brief Returns the number of packets received in the current rate window.
+	 */
+	uint32_t getWindowPacketCount() const { return windowPacketCount; }
+
+	/**
+	 * @brief Returns the number of messages queued for sending.
+	 */
+	size_t getWriteQueueSize() const { return writeQueue.size(); }
+
+	///@}
 
 private:
+	/**
+	 * @enum NameState
+	 * @brief Tracks the server-name detection phase.
+	 */
+	enum class NameState
+	{
+		Waiting, ///< No name bytes received yet.
+		Reading, ///< Accumulating multi-byte name.
+		Complete ///< Name reception finished.
+	};
+
+	/** @name Async initiators */
+	///@{
+
+	/**
+	 * @brief Reads the server name from the client byte-by-byte.
+	 *
+	 * Used by server-sends-first protocols (e.g., game) to detect
+	 * which server the client intends to connect to.
+	 */
+	void startReadServerName();
+
+	/**
+	 * @brief Processes a server name read result.
+	 *
+	 * Accumulates name bytes until 0x0A (end marker), then transitions
+	 * to the sequence read loop via startReadSequence().
+	 *
+	 * @param {error} Boost.Asio error code.
+	 */
+	void onServerNameRead(const boost::system::error_code& error);
+
+	/**
+	 * @brief Processes a sequence header (block count).
+	 *
+	 * Performs rate limiting, validates size, then reads the full
+	 * packet body. The body is processed by parsePacket().
+	 *
+	 * @param {error} Boost.Asio error code.
+	 */
 	void parseHeader(const boost::system::error_code& error);
+
+	/**
+	 * @brief Processes a complete packet body.
+	 *
+	 * Reads the checksum, dispatches the message to the protocol
+	 * (onRecvFirstMessage or onRecvMessage), then loops back to
+	 * startReadSequence().
+	 *
+	 * @param {error} Boost.Asio error code.
+	 */
 	void parsePacket(const boost::system::error_code& error);
 
-	void onWriteOperation(const boost::system::error_code& error);
+	///@}
 
-	static void handleTimeout(std::weak_ptr<Connection> connectionWeak, const boost::system::error_code& error);
+	/** @name Helpers */
+	///@{
 
-	void closeSocket();
+	/**
+	 * @brief Sends a message immediately (no queue check).
+	 *
+	 * Called by send() for the first pending message and by
+	 * onWriteComplete() for subsequent queued messages.
+	 *
+	 * @param {msg} The message to send.
+	 */
 	void internalSend(const std::shared_ptr<OutputMessage>& msg);
 
-	boost::asio::ip::tcp::socket& getSocket() { return socket; }
-	friend class ServicePort;
+	///@}
 
+public:
+	/** @name Members */
+	///@{
+
+	/** @brief Buffer for incoming data reads. */
 	NetworkMessage msg;
 
+	/** @brief Remote peer IP address. */
+	boost::asio::ip::address remoteAddress;
+
+	/** @brief The TCP socket. */
+	boost::asio::ip::tcp::socket socket;
+
+	/** @brief Read timeout timer. */
 	boost::asio::steady_timer readTimer;
+
+	/** @brief Write timeout timer. */
 	boost::asio::steady_timer writeTimer;
 
-	std::recursive_mutex connectionLock;
+	/** @brief Guards all mutable state. */
+	std::recursive_mutex mutex;
 
-	std::list<std::shared_ptr<OutputMessage>> messageQueue;
+	/** @brief Outbound messages awaiting transmission. */
+	std::list<std::shared_ptr<OutputMessage>> writeQueue;
 
-	std::shared_ptr<const ServicePort> service_port;
+	/** @brief The owning service port. */
+	std::shared_ptr<ServicePort> servicePort;
+
+	/** @brief The active protocol handler. */
 	std::shared_ptr<Protocol> protocol;
 
-	boost::asio::ip::tcp::socket socket;
-	Address remoteAddress;
-	std::chrono::steady_clock::time_point timeConnected;
-	uint32_t packetsSent = 0;
+	/** @brief The connection manager for lifecycle. */
+	std::weak_ptr<ConnectionManager> manager;
 
-	ConnectionState_t connectionState = CONNECTION_STATE_PENDING;
-	bool receivedFirst = false;
-	bool receivedName = false;
-	bool receivedLastChar = false;
+	/** @brief Start of the rate-limiting time window. */
+	std::chrono::steady_clock::time_point rateWindowStart;
+
+	/** @brief Packets received in the current rate window. */
+	uint32_t windowPacketCount = 0;
+
+	/** @brief true after close() is called. */
+	bool closed = false;
+
+	/** @brief true after onFirstMessage() succeeds. */
+	bool firstMessageProcessed = false;
+
+	/** @brief Server-name detection phase. */
+	NameState nameState = NameState::Waiting;
+
+	/** @brief true after readTimer async_wait is registered. */
+	bool readTimerArmed = false;
+
+	/** @brief true after writeTimer async_wait is registered. */
+	bool writeTimerArmed = false;
+
+	///@}
 };
 
 #endif // FS_CONNECTION_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4665,8 +4665,6 @@ void Game::shutdown()
 		serviceManager->stop();
 	}
 
-	ConnectionManager::getInstance().closeAll();
-
 	std::cout << " done!" << std::endl;
 }
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -13,35 +13,28 @@ class NetworkMessage
 {
 public:
 	using MsgSize_t = uint16_t;
-	// Headers:
-	// 2 bytes for unencrypted message size
-	// 4 bytes for checksum
-	// 1 byte for padding message size
-	static constexpr MsgSize_t INITIAL_BUFFER_POSITION = 7;
-	enum
-	{
-		HEADER_LENGTH = 2
-	};
-	enum
-	{
-		CHECKSUM_LENGTH = 4
-	};
-	enum
-	{
-		XTEA_MULTIPLE = 8
-	};
-	enum
-	{
-		MAX_BODY_LENGTH = NETWORKMESSAGE_MAXSIZE - HEADER_LENGTH - CHECKSUM_LENGTH - XTEA_MULTIPLE
-	};
-	enum
-	{
-		MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10
-	};
+
+	// Wire format: [blockCount:u16] [checksum:u32] [padding:u8] [encrypted data + 0x33 padding]
+	static constexpr MsgSize_t HEADER_LENGTH = 2;   // u16 XTEA block count
+	static constexpr MsgSize_t CHECKSUM_LENGTH = 4; // u32 sequence number
+	static constexpr MsgSize_t PADDING_LENGTH = 1;  // u8 padding count (0x00–0x07)
+	static constexpr MsgSize_t CRYPTO_HEADER_LENGTH =
+	    HEADER_LENGTH + CHECKSUM_LENGTH; // plaintext before encrypted payload
+	static constexpr MsgSize_t INITIAL_BUFFER_POSITION =
+	    HEADER_LENGTH + CHECKSUM_LENGTH + PADDING_LENGTH; // header area reserved in OutputMessage
+	static constexpr MsgSize_t XTEA_MULTIPLE = 8;         // XTEA block size
+	static constexpr MsgSize_t MAX_BODY_LENGTH =
+	    NETWORKMESSAGE_MAXSIZE - HEADER_LENGTH - CHECKSUM_LENGTH - XTEA_MULTIPLE;
+	static constexpr MsgSize_t MAX_PROTOCOL_BODY_LENGTH = MAX_BODY_LENGTH - 10;
 
 	NetworkMessage() = default;
 
-	void reset() { info = {}; }
+	void reset()
+	{
+		info.length = 0;
+		info.position = INITIAL_BUFFER_POSITION;
+		info.overrun = false;
+	}
 
 	// simply read functions for incoming message
 	uint8_t getByte()

--- a/src/outputmessage.cpp
+++ b/src/outputmessage.cpp
@@ -37,7 +37,7 @@ void sendAll(const std::vector<std::shared_ptr<Protocol>>& protocols)
 {
 	// dispatcher thread
 	for (auto& protocol : protocols) {
-		if (auto& msg = protocol->getCurrentBuffer()) {
+		if (auto& msg = protocol->getSendBuffer()) {
 			protocol->send(std::move(msg));
 		}
 	}

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -25,16 +25,6 @@ public:
 
 	uint8_t* getOutputBuffer() { return &buffer[outputBufferStart]; }
 
-	void writeMessageLength() { add_header(static_cast<uint16_t>((info.length - 4) / 8)); }
-
-	void writePaddingLength()
-	{
-		uint8_t paddingAmount = static_cast<uint8_t>(8 - (info.length % 8) - 1);
-		add_header(paddingAmount);
-	}
-
-	void addCryptoHeader() { add_header(getSequenceId()); }
-
 	void append(const NetworkMessage& msg)
 	{
 		auto msgLen = msg.getLength();
@@ -57,24 +47,17 @@ public:
 		info.position += msgLen;
 	}
 
-	void setSequenceId(uint32_t sequence) { sequenceId = sequence; }
-	uint32_t getSequenceId() const { return sequenceId; }
-
-private:
 	template <typename T>
-	void add_header(T add)
+	void addHeader(T value)
 	{
 		assert(outputBufferStart >= sizeof(T));
 		outputBufferStart -= sizeof(T);
-		std::memcpy(buffer.data() + outputBufferStart, &add, sizeof(T));
-		// added header size to the message size
+		std::memcpy(buffer.data() + outputBufferStart, &value, sizeof(T));
 		info.length += sizeof(T);
 	}
 
+private:
 	MsgSize_t outputBufferStart = INITIAL_BUFFER_POSITION;
-	// Was incidentally zeroed by value-initialization; keep an explicit default now that
-	// the object is no longer zero-initialized on construction.
-	uint32_t sequenceId = 0;
 };
 
 namespace tfs::net {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1958,10 +1958,10 @@ BlockType_t Player::blockHit(const std::shared_ptr<Creature>& attacker, CombatTy
 	return blockType;
 }
 
-Connection::Address Player::getIP() const
+boost::asio::ip::address Player::getIP() const
 {
 	if (client) {
-		return client->getIP();
+		return client->getRemoteAddress();
 	}
 
 	return {};

--- a/src/player.h
+++ b/src/player.h
@@ -245,7 +245,7 @@ public:
 			client->disconnect();
 		}
 	}
-	Connection::Address getIP() const;
+	boost::asio::ip::address getIP() const;
 
 	void addContainer(uint8_t cid, std::shared_ptr<Container> container);
 	void closeContainer(uint8_t cid) { openContainers.erase(cid); }
@@ -1345,7 +1345,7 @@ private:
 	std::chrono::steady_clock::time_point nextAction = std::chrono::steady_clock::time_point::min();
 
 	std::shared_ptr<ProtocolGame> client;
-	Connection::Address lastIP = {};
+	boost::asio::ip::address lastIP = {};
 	std::weak_ptr<Guild> guild;
 	std::weak_ptr<GuildRank> guildRank;
 	Group* group = nullptr;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -9,44 +9,9 @@
 #include "rsa.h"
 #include "xtea.h"
 
-namespace {
-
-void XTEA_encrypt(OutputMessage& msg, const xtea::round_keys& key)
-{
-	// The message must be a multiple of 8
-	size_t paddingBytes = msg.getLength() % 8u;
-	if (paddingBytes != 0) {
-		msg.addPaddingBytes(8 - paddingBytes);
-	}
-
-	uint8_t* buffer = msg.getOutputBuffer();
-	xtea::encrypt(buffer, msg.getLength(), key);
-}
-
-bool XTEA_decrypt(NetworkMessage& msg, const xtea::round_keys& key)
-{
-	if (((msg.getLength() - 6) & 7) != 0) {
-		return false;
-	}
-
-	uint8_t* buffer = msg.getRemainingBuffer();
-	xtea::decrypt(buffer, msg.getLength() - 6, key);
-
-	uint8_t paddingLength = msg.getByte();
-	uint16_t innerLength = msg.getLength() - 6 - paddingLength;
-	if (innerLength + 7 > msg.getLength()) {
-		return false;
-	}
-
-	msg.setLength(innerLength);
-	return true;
-}
-
-} // namespace
-
 Protocol::~Protocol()
 {
-	const auto zlibEndResult = deflateEnd(&zstream);
+	const auto zlibEndResult = deflateEnd(&zlibStream);
 	if (zlibEndResult == Z_DATA_ERROR) {
 		std::cout << "ZLIB discarded pending output or unprocessed input while cleaning up stream state" << std::endl;
 	} else if (zlibEndResult == Z_STREAM_ERROR) {
@@ -56,31 +21,64 @@ Protocol::~Protocol()
 
 void Protocol::onSendMessage(const std::shared_ptr<OutputMessage>& msg)
 {
-	if (!rawMessages) {
-		if (encryptionEnabled) {
-			uint32_t compressionChecksum = 0;
-			if (msg->getLength() >= 128 && deflateMessage(*msg)) {
-				compressionChecksum = 0x80000000;
-			}
-
-			msg->setSequenceId(compressionChecksum | getNextSequenceId());
-		}
-
-		if (encryptionEnabled) {
-			msg->writePaddingLength();
-			XTEA_encrypt(*msg, key);
-			msg->addCryptoHeader();
-		}
-
-		msg->writeMessageLength();
+	// Raw messages: no framing at all.
+	if (rawMode) {
+		return;
 	}
+
+	// Unencrypted: only need the block count header.
+	if (!encrypted) {
+		const auto blockCount =
+		    static_cast<uint16_t>((msg->getLength() - NetworkMessage::CHECKSUM_LENGTH) / NetworkMessage::XTEA_MULTIPLE);
+		msg->addHeader(blockCount);
+		return;
+	}
+
+	// 1. Optional zlib compression (MSB of sequenceId = 1 when compressed).
+	auto compressionFlag = 0u;
+	if (msg->getLength() >= 128 && deflateMessage(*msg)) {
+		compressionFlag = 0x80000000u;
+	}
+
+	// 2. Pad to XTEA block boundary, stash padding count as first encrypted byte.
+	const auto paddingCount =
+	    static_cast<uint8_t>(NetworkMessage::XTEA_MULTIPLE - (msg->getLength() % NetworkMessage::XTEA_MULTIPLE) - 1);
+	msg->addPaddingBytes(paddingCount);
+	msg->addHeader(paddingCount);
+
+	// 3. XTEA-encrypt in-place.
+	xtea::encrypt(msg->getOutputBuffer(), msg->getLength(), xteaKey);
+
+	// 4. Prepend sequence/checksum (u32, plaintext).
+	const auto sequenceId = compressionFlag | nextSequenceId();
+	msg->addHeader(sequenceId);
+
+	// 5. Prepend block count (u16, plaintext).
+	const auto blockCount =
+	    static_cast<uint16_t>((msg->getLength() - NetworkMessage::CHECKSUM_LENGTH) / NetworkMessage::XTEA_MULTIPLE);
+	msg->addHeader(blockCount);
 }
 
 void Protocol::onRecvMessage(NetworkMessage& msg)
 {
-	if (encryptionEnabled && !XTEA_decrypt(msg, key)) {
+	// Unencrypted: no framing to strip.
+	if (!encrypted) {
+		parsePacket(msg);
 		return;
 	}
+
+	// 1. Verify remainder after 6-byte header is whole XTEA blocks.
+	const auto encryptedLen = msg.getLength() - NetworkMessage::CRYPTO_HEADER_LENGTH;
+	if ((encryptedLen & (NetworkMessage::XTEA_MULTIPLE - 1)) != 0) {
+		return;
+	}
+
+	// 2. Decrypt in-place.
+	xtea::decrypt(msg.getRemainingBuffer(), encryptedLen, xteaKey);
+
+	// 3. Strip padding (first decrypted byte = padding count).
+	const auto paddingLength = msg.getByte();
+	msg.setLength(msg.getLength() - paddingLength);
 
 	parsePacket(msg);
 }
@@ -88,47 +86,37 @@ void Protocol::onRecvMessage(NetworkMessage& msg)
 std::shared_ptr<OutputMessage> Protocol::getOutputBuffer(int32_t size)
 {
 	// dispatcher thread
-	if (!outputBuffer) {
-		outputBuffer = tfs::net::make_output_message();
-	} else if ((outputBuffer->getLength() + size) > NetworkMessage::MAX_PROTOCOL_BODY_LENGTH) {
-		send(outputBuffer);
-		outputBuffer = tfs::net::make_output_message();
+	if (!sendBuffer) {
+		sendBuffer = tfs::net::make_output_message();
+	} else if ((sendBuffer->getLength() + size) > NetworkMessage::MAX_PROTOCOL_BODY_LENGTH) {
+		send(sendBuffer);
+		sendBuffer = tfs::net::make_output_message();
 	}
-	return outputBuffer;
-}
-
-bool Protocol::RSA_decrypt(NetworkMessage& msg)
-{
-	if (msg.getRemainingBufferLength() < RSA_BUFFER_LENGTH) {
-		return false;
-	}
-
-	tfs::rsa::decrypt(msg.getRemainingBuffer(), RSA_BUFFER_LENGTH);
-	return msg.getByte() == 0;
+	return sendBuffer;
 }
 
 bool Protocol::deflateMessage(OutputMessage& msg)
 {
 	static thread_local std::vector<uint8_t> buffer(NETWORKMESSAGE_MAXSIZE);
 
-	zstream.next_in = msg.getOutputBuffer();
-	zstream.avail_in = msg.getLength();
-	zstream.next_out = buffer.data();
-	zstream.avail_out = buffer.size();
+	zlibStream.next_in = msg.getOutputBuffer();
+	zlibStream.avail_in = msg.getLength();
+	zlibStream.next_out = buffer.data();
+	zlibStream.avail_out = buffer.size();
 
-	const auto result = deflate(&zstream, Z_FINISH);
+	const auto result = deflate(&zlibStream, Z_FINISH);
 	if (result != Z_OK && result != Z_STREAM_END) {
-		std::cout << "Error while deflating packet data error: " << (zstream.msg ? zstream.msg : "unknown")
+		std::cout << "Error while deflating packet data error: " << (zlibStream.msg ? zlibStream.msg : "unknown")
 		          << std::endl;
 		return false;
 	}
 
-	const auto size = zstream.total_out;
-	deflateReset(&zstream);
+	const auto size = zlibStream.total_out;
+	deflateReset(&zlibStream);
 
 	if (size <= 0) {
 		std::cout << "Deflated packet data had invalid size: " << size
-		          << " error: " << (zstream.msg ? zstream.msg : "unknown") << std::endl;
+		          << " error: " << (zlibStream.msg ? zlibStream.msg : "unknown") << std::endl;
 		return false;
 	}
 
@@ -138,10 +126,10 @@ bool Protocol::deflateMessage(OutputMessage& msg)
 	return true;
 }
 
-Connection::Address Protocol::getIP() const
+boost::asio::ip::address Protocol::getRemoteAddress() const
 {
 	if (auto connection = getConnection()) {
-		return connection->getIP();
+		return connection->getRemoteAddress();
 	}
 
 	return {};

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -9,39 +9,121 @@
 
 #include <zlib.h>
 
+/**
+ * @class Protocol
+ * @brief Base class for all network protocols.
+ *
+ * Handles message framing (XTEA encrypt/decrypt, block count header, zlib
+ * compression), RSA decryption of the first message, and output buffering.
+ *
+ * Protocol subclasses define traits (server_sends_first, use_checksum,
+ * protocol_identifier) consumed by ServicePort.
+ */
 class Protocol : public std::enable_shared_from_this<Protocol>
 {
 public:
+	/**
+	 * @brief Constructs a Protocol bound to a connection.
+	 *
+	 * Initializes the zlib deflate stream.
+	 *
+	 * @param {connection} The owning connection.
+	 */
 	explicit Protocol(std::shared_ptr<Connection> connection) : connection(std::move(connection))
 	{
-		if (deflateInit2(&zstream, 6, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
-			std::cout << "ZLIB initialization error: " << (zstream.msg ? zstream.msg : "unknown") << std::endl;
+		if (deflateInit2(&zlibStream, 6, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
+			std::cout << "ZLIB initialization error: " << (zlibStream.msg ? zlibStream.msg : "unknown") << std::endl;
 		}
 	}
+
+	/**
+	 * @brief Destroys the protocol and cleans up the zlib stream.
+	 */
 	virtual ~Protocol();
 
 	// non-copyable
 	Protocol(const Protocol&) = delete;
 	Protocol& operator=(const Protocol&) = delete;
 
-	virtual void parsePacket(NetworkMessage&) {}
+	/**
+	 * @brief Dispatches an incoming parsed message.
+	 *
+	 * Called by the connection after decryption/checksum stripping.
+	 * Subclasses override to implement their packet handlers.
+	 *
+	 * @param {msg} The parsed incoming message.
+	 */
+	virtual void parsePacket(NetworkMessage& msg) {}
 
+	/**
+	 * @brief Applies outbound framing (block count, XTEA, zlib, checksum).
+	 *
+	 * Called by Connection::internalSend() before writing to the socket.
+	 *
+	 * @param {msg} The message to frame and send.
+	 */
 	virtual void onSendMessage(const std::shared_ptr<OutputMessage>& msg);
-	void onRecvMessage(NetworkMessage& msg);
+
+	/**
+	 * @brief Strips inbound framing and dispatches to parsePacket().
+	 *
+	 * Called by Connection::parsePacket() after the raw body is received.
+	 *
+	 * @param {msg} The incoming raw message (contains checksum + encrypted payload).
+	 */
+	virtual void onRecvMessage(NetworkMessage& msg);
+
+	/**
+	 * @brief Handles the very first message on a new connection.
+	 *
+	 * Subclasses implement protocol-specific handshake logic.
+	 *
+	 * @param {msg} The first message received.
+	 */
 	virtual void onRecvFirstMessage(NetworkMessage& msg) = 0;
+
+	/**
+	 * @brief Called when the connection is established.
+	 *
+	 * Hook for any connection-time setup (e.g., sending welcome data).
+	 */
 	virtual void onConnect() {}
 
+	/**
+	 * @brief Checks whether the underlying connection has been closed.
+	 */
 	bool isConnectionExpired() const { return connection.expired(); }
 
+	/**
+	 * @brief Returns a shared pointer to the connection, if still alive.
+	 */
 	std::shared_ptr<Connection> getConnection() const { return connection.lock(); }
 
-	Connection::Address getIP() const;
+	/**
+	 * @brief Returns the remote IP address via the connection.
+	 */
+	boost::asio::ip::address getRemoteAddress() const;
 
-	// Use this function for autosend messages only
+	/**
+	 * @brief Gets an output buffer for writing protocol messages.
+	 *
+	 * Reuses the existing buffer if it fits, otherwise sends it and allocates a new one.
+	 * Use only for auto-send patterns (one buffer shared across multiple writes).
+	 *
+	 * @param {size} The expected message size to reserve.
+	 */
 	std::shared_ptr<OutputMessage> getOutputBuffer(int32_t size);
 
-	std::shared_ptr<OutputMessage>& getCurrentBuffer() { return outputBuffer; }
+	/**
+	 * @brief Returns the current send buffer.
+	 */
+	std::shared_ptr<OutputMessage>& getSendBuffer() { return sendBuffer; }
 
+	/**
+	 * @brief Sends a message through the connection.
+	 *
+	 * @param {msg} The message to send.
+	 */
 	void send(std::shared_ptr<OutputMessage> msg) const
 	{
 		if (auto connection = getConnection()) {
@@ -49,48 +131,90 @@ public:
 		}
 	}
 
-	uint32_t getNextSequenceId()
+	/**
+	 * @brief Advances and returns the next sequence ID.
+	 *
+	 * Wraps around at int32_t::max to avoid signed overflow in checksum.
+	 */
+	uint32_t nextSequenceId()
 	{
 		const auto sequence = ++sequenceNumber;
 		if (sequenceNumber >= static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
 			sequenceNumber = 0;
 		}
-
 		return sequence;
 	}
 
 protected:
-	static constexpr size_t RSA_BUFFER_LENGTH = 128;
-
+	/**
+	 * @brief Disconnects from the peer.
+	 */
 	void disconnect() const
 	{
 		if (auto connection = getConnection()) {
 			connection->close();
 		}
 	}
-	void enableXTEAEncryption() { encryptionEnabled = true; }
-	void setXTEAKey(const xtea::key& key) { this->key = xtea::expand_key(key); }
 
-	static bool RSA_decrypt(NetworkMessage& msg);
+	/**
+	 * @brief Enables XTEA encryption for outbound messages.
+	 */
+	void enableEncryption() { encrypted = true; }
 
+	/**
+	 * @brief Sets and expands the XTEA encryption key.
+	 *
+	 * @param {xteaKey} The 128-bit XTEA key.
+	 */
+	void setXTEAKey(const xtea::key& xteaKey) { this->xteaKey = xtea::expand_key(xteaKey); }
+
+	/**
+	 * @brief Compresses a message payload with zlib deflate.
+	 *
+	 * Used to shrink large packets before XTEA encryption.
+	 *
+	 * @param {msg} The message to compress (replaced with compressed data on success).
+	 * @return true if compression was successful.
+	 */
 	bool deflateMessage(OutputMessage& msg);
 
-	void setRawMessages(bool value) { rawMessages = value; }
+	/**
+	 * @brief Enables raw mode (no framing applied).
+	 *
+	 * When enabled, all encryption, compression and header framing are skipped.
+	 */
+	void enableRawMode() { rawMode = true; }
 
+	/**
+	 * @brief Releases resources held by the protocol.
+	 *
+	 * Overridden by subclasses that need cleanup (e.g., ProtocolGame).
+	 */
 	virtual void release() {}
 
 private:
 	friend class Connection;
 
-	std::shared_ptr<OutputMessage> outputBuffer;
+	/** @brief Reusable send buffer for auto-send. */
+	std::shared_ptr<OutputMessage> sendBuffer;
 
+	/** @brief The owning connection (weak to avoid cycles). */
 	const std::weak_ptr<Connection> connection;
-	xtea::round_keys key;
-	uint32_t sequenceNumber = 0;
-	bool encryptionEnabled = false;
-	bool rawMessages = false;
 
-	z_stream zstream{};
+	/** @brief Expanded XTEA round keys. */
+	xtea::round_keys xteaKey;
+
+	/** @brief Outgoing message sequence counter. */
+	uint32_t sequenceNumber = 0;
+
+	/** @brief true after enableEncryption() is called. */
+	bool encrypted = false;
+
+	/** @brief true after enableRawMode() is called. */
+	bool rawMode = false;
+
+	/** @brief The zlib deflate stream state. */
+	z_stream zlibStream{};
 };
 
 #endif // FS_PROTOCOL_H

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -16,6 +16,7 @@
 #include "outputmessage.h"
 #include "player.h"
 #include "podium.h"
+#include "rsa.h"
 #include "scheduler.h"
 
 extern Chat g_chat;
@@ -382,7 +383,13 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	msg.skipBytes(1); // U8 preview state
 
 	// Disconnect if RSA decrypt fails
-	if (!Protocol::RSA_decrypt(msg)) {
+	if (msg.getRemainingBufferLength() < 128) {
+		disconnect();
+		return;
+	}
+
+	tfs::rsa::decrypt(msg.getRemainingBuffer(), 128);
+	if (msg.getByte() != 0) {
 		disconnect();
 		return;
 	}
@@ -393,7 +400,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 	key[1] = msg.get<uint32_t>();
 	key[2] = msg.get<uint32_t>();
 	key[3] = msg.get<uint32_t>();
-	enableXTEAEncryption();
+	enableEncryption();
 	setXTEAKey(std::move(key));
 
 	// Web login skips the character list request so we need to check the client version again
@@ -446,7 +453,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	auto ip = getIP();
+	auto ip = getRemoteAddress();
 	if (const auto& banInfo = IOBan::getIpBanInfo(ip)) {
 		disconnectClient(std::format("Your IP has been banned until {:s} by {:s}.\n\nReason specified:\n{:s}",
 		                             formatDateShort(banInfo->expiresAt), banInfo->bannedBy, banInfo->reason));
@@ -468,7 +475,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	Connection::Address sessionIP = boost::asio::ip::make_address(result->getString("session_ip"));
+	boost::asio::ip::address sessionIP = boost::asio::ip::make_address(result->getString("session_ip"));
 	if (!sessionIP.is_loopback() && ip != sessionIP) {
 		disconnectClient("Your game session is already locked to a different IP. Please log in again.");
 		return;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -57,19 +57,10 @@ struct TextMessage
 class ProtocolGame final : public Protocol
 {
 public:
-	// static protocol information
-	enum
-	{
-		server_sends_first = true
-	};
-	enum
-	{
-		protocol_identifier = 0
-	}; // Not required as we send first
-	enum
-	{
-		use_checksum = true
-	};
+	// Protocol traits — consumed by ServicePort for connection routing and framing.
+	static constexpr auto server_sends_first = true;
+	static constexpr uint8_t protocol_identifier = 0;
+	static constexpr auto use_checksum = true;
 	static const char* protocol_name() { return "gameworld protocol"; }
 
 	explicit ProtocolGame(std::shared_ptr<Connection> connection) : Protocol(std::move(connection)) {}

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -13,7 +13,7 @@
 extern Dispatcher g_dispatcher;
 extern Game g_game;
 
-std::map<Connection::Address, std::chrono::steady_clock::time_point> ipConnectMap = {};
+std::map<boost::asio::ip::address, std::chrono::steady_clock::time_point> ipConnectMap = {};
 
 enum RequestedInfo_t : uint16_t
 {
@@ -31,7 +31,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 {
 	const static auto acceptorAddress = boost::asio::ip::make_address(getString(ConfigManager::IP));
 
-	const auto& ip = getIP();
+	const auto& ip = getRemoteAddress();
 
 	if (!ip.is_loopback() && ip != acceptorAddress) {
 		if (auto it = ipConnectMap.find(ip);
@@ -80,7 +80,7 @@ void ProtocolStatus::sendStatusString()
 {
 	auto output = tfs::net::make_output_message();
 
-	setRawMessages(true);
+	enableRawMode();
 
 	pugi::xml_document doc;
 
@@ -111,7 +111,7 @@ void ProtocolStatus::sendStatusString()
 	uint32_t reportableOnlinePlayerCount = 0;
 	uint32_t maxPlayersPerIp = getNumber(ConfigManager::STATUS_COUNT_MAX_PLAYERS_PER_IP);
 	if (maxPlayersPerIp > 0) {
-		std::map<Connection::Address, uint32_t> playersPerIp;
+		std::map<boost::asio::ip::address, uint32_t> playersPerIp;
 		for (const auto& player : g_game.getPlayers() | tfs::views::lock_weak_ptrs) {
 			if (!player->getIP().is_unspecified()) {
 				++playersPerIp[player->getIP()];

--- a/src/protocolstatus.h
+++ b/src/protocolstatus.h
@@ -9,19 +9,10 @@
 class ProtocolStatus final : public Protocol
 {
 public:
-	// static protocol information
-	enum
-	{
-		server_sends_first = false
-	};
-	enum
-	{
-		protocol_identifier = 0xFF
-	};
-	enum
-	{
-		use_checksum = false
-	};
+	// Protocol traits — consumed by ServicePort for connection routing and framing.
+	static constexpr auto server_sends_first = false;
+	static constexpr uint8_t protocol_identifier = 0xFF;
+	static constexpr auto use_checksum = false;
 	static const char* protocol_name() { return "status protocol"; }
 
 	explicit ProtocolStatus(std::shared_ptr<Connection> connection) : Protocol(std::move(connection)) {}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -20,14 +20,14 @@ struct ConnectBlock
 	uint32_t count = 1;
 };
 
-bool acceptConnection(const Connection::Address& clientIP)
+bool acceptConnection(const boost::asio::ip::address& clientIP)
 {
 	static std::recursive_mutex mu;
 	std::lock_guard lock{mu};
 
 	auto currentTime = std::chrono::steady_clock::now();
 
-	static std::map<Connection::Address, ConnectBlock> ipConnectMap;
+	static std::map<boost::asio::ip::address, ConnectBlock> ipConnectMap;
 	auto it = ipConnectMap.find(clientIP);
 	if (it == ipConnectMap.end()) {
 		ipConnectMap.emplace(clientIP, ConnectBlock{.lastAttempt = currentTime});
@@ -131,7 +131,7 @@ void ServicePort::accept()
 		return;
 	}
 
-	auto connection = ConnectionManager::getInstance().createConnection(io_context, shared_from_this());
+	auto connection = connectionManager->createConnection(io_context, shared_from_this());
 	acceptor->async_accept(connection->getSocket(),
 	                       [=, thisPtr = shared_from_this()](const boost::system::error_code& error) {
 		                       thisPtr->onAccept(connection, error);
@@ -145,7 +145,7 @@ void ServicePort::onAccept(std::shared_ptr<Connection> connection, const boost::
 			return;
 		}
 
-		const auto& remote_ip = connection->getIP();
+		const auto& remote_ip = connection->getRemoteAddress();
 		if (acceptConnection(remote_ip)) {
 			const auto service = services.front();
 			if (service->is_single_socket()) {
@@ -224,6 +224,8 @@ void ServicePort::open(uint16_t port)
 
 void ServicePort::close()
 {
+	connectionManager->closeAll();
+
 	if (acceptor && acceptor->is_open()) {
 		boost::system::error_code error;
 		acceptor->close(error);

--- a/src/server.h
+++ b/src/server.h
@@ -60,6 +60,7 @@ private:
 	void accept();
 
 	boost::asio::io_context& io_context;
+	std::shared_ptr<ConnectionManager> connectionManager = std::make_shared<ConnectionManager>();
 	std::unique_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 	std::vector<std::shared_ptr<ServiceBase>> services;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests_SRC
     ${CMAKE_CURRENT_LIST_DIR}/test_rsa.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_sha1.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_xtea.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_connection.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_scope_exit.cpp
     )
 

--- a/src/tests/test_connection.cpp
+++ b/src/tests/test_connection.cpp
@@ -1,0 +1,562 @@
+#define BOOST_TEST_MODULE connection
+
+#include "../otpch.h"
+
+#include "../configmanager.h"
+#include "../connection.h"
+#include "../outputmessage.h"
+#include "../protocol.h"
+#include "../server.h"
+#include "../tasks.h"
+
+#include <boost/asio.hpp>
+#include <boost/test/unit_test.hpp>
+
+class MockProtocol : public Protocol
+{
+public:
+	bool recvFirstCalled = false;
+	bool recvCalled = false;
+	bool sendCalled = false;
+	bool connectCalled = false;
+
+	explicit MockProtocol(std::shared_ptr<Connection> connection) : Protocol(std::move(connection)) {}
+
+	void onRecvFirstMessage(NetworkMessage&) override { recvFirstCalled = true; }
+	void onRecvMessage(NetworkMessage&) override { recvCalled = true; }
+	void onSendMessage(const std::shared_ptr<OutputMessage>& msg) override
+	{
+		sendCalled = true;
+		Protocol::onSendMessage(msg);
+	}
+	void onConnect() override { connectCalled = true; }
+};
+
+// Establishes a real loopback TCP connection between clientSocket
+// and the Connection's internal socket, allowing async I/O tests.
+struct ConnectionFixture
+{
+	boost::asio::io_context ioContext;
+	std::shared_ptr<ConnectionManager> manager = std::make_shared<ConnectionManager>();
+	boost::asio::ip::tcp::acceptor acceptor;
+	boost::asio::ip::tcp::socket clientSocket;
+	std::shared_ptr<Connection> connection;
+	std::shared_ptr<MockProtocol> mockProtocol;
+
+	ConnectionFixture() :
+	    acceptor(ioContext, boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0)),
+	    clientSocket(ioContext)
+	{
+		ConfigManager::setNumber(ConfigManager::MAX_PACKETS_PER_SECOND, 1000);
+
+		auto endpoint = acceptor.local_endpoint();
+		clientSocket.async_connect(endpoint, [](auto) {});
+
+		boost::asio::ip::tcp::socket serverSocket(ioContext);
+		acceptor.async_accept(serverSocket, [](auto) {});
+
+		ioContext.run();
+		ioContext.restart();
+
+		connection = std::make_shared<Connection>(ioContext, nullptr, manager, std::move(serverSocket));
+		mockProtocol = std::make_shared<MockProtocol>(connection);
+	}
+
+	~ConnectionFixture()
+	{
+		if (clientSocket.is_open()) {
+			clientSocket.close();
+		}
+		ioContext.restart();
+	}
+
+	void writeToConnection(const std::vector<uint8_t>& data)
+	{
+		boost::asio::write(clientSocket, boost::asio::buffer(data));
+	}
+
+	std::vector<uint8_t> readFromConnection(size_t bytes)
+	{
+		std::vector<uint8_t> buffer(bytes);
+		boost::asio::read(clientSocket, boost::asio::buffer(buffer));
+		return buffer;
+	}
+
+	void runIO() { ioContext.poll(); }
+
+	// Wire format sent to the Connection: [blockCount:u16] [checksum:u32] [body...]
+	// blockCount = ceil((bodySize + 4) / 8) per the XTEA framing protocol.
+	void writeFramedPacket(const std::vector<uint8_t>& body)
+	{
+		uint16_t blockCount = static_cast<uint16_t>((body.size() + 4) / 8);
+		uint32_t checksum = 0;
+		std::vector<uint8_t> packet(2 + 4 + body.size());
+		std::memcpy(packet.data(), &blockCount, 2);
+		std::memcpy(packet.data() + 2, &checksum, 4);
+		std::memcpy(packet.data() + 6, body.data(), body.size());
+		writeToConnection(packet);
+	}
+};
+
+BOOST_AUTO_TEST_CASE(manager_release_untracks)
+{
+	auto manager = std::make_shared<ConnectionManager>();
+	boost::asio::io_context context;
+	auto firstConnection = manager->createConnection(context, nullptr);
+	auto secondConnection = manager->createConnection(context, nullptr);
+	BOOST_TEST(manager->size() == 2);
+	manager->releaseConnection(firstConnection);
+	BOOST_TEST(manager->size() == 1);
+	manager->releaseConnection(secondConnection);
+	BOOST_TEST(manager->size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(manager_close_all_empties)
+{
+	auto manager = std::make_shared<ConnectionManager>();
+	boost::asio::io_context context;
+	manager->createConnection(context, nullptr);
+	manager->createConnection(context, nullptr);
+	manager->createConnection(context, nullptr);
+	manager->closeAll();
+	BOOST_TEST(manager->size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(rate_limit_under_limit_passes)
+{
+	ConnectionFixture fixture;
+	BOOST_TEST(fixture.connection->checkRateLimit());
+}
+
+BOOST_AUTO_TEST_CASE(rate_limit_over_limit_closes)
+{
+	ConnectionFixture fixture;
+	ConfigManager::setNumber(ConfigManager::MAX_PACKETS_PER_SECOND, 1);
+	for (int i = 0; i < 5; ++i) {
+		fixture.connection->checkRateLimit();
+	}
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(rate_limit_zero_limit_closes_immediately)
+{
+	ConnectionFixture fixture;
+	// Zero packets per second means even the first packet exceeds the limit.
+	ConfigManager::setNumber(ConfigManager::MAX_PACKETS_PER_SECOND, 0);
+	fixture.connection->checkRateLimit();
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(close_socket_idempotent)
+{
+	ConnectionFixture fixture;
+	BOOST_TEST(fixture.connection->getSocket().is_open());
+	fixture.connection->closeSocket();
+	BOOST_TEST(!fixture.connection->getSocket().is_open());
+	fixture.connection->closeSocket();
+	BOOST_TEST(!fixture.connection->getSocket().is_open());
+}
+
+BOOST_AUTO_TEST_CASE(destructor_closes_socket)
+{
+	boost::asio::io_context context;
+	boost::asio::ip::tcp::socket socket(context);
+	socket.open(boost::asio::ip::tcp::v4());
+	bool wasOpen = socket.is_open();
+
+	{
+		auto manager = std::make_shared<ConnectionManager>();
+		auto connection = std::make_shared<Connection>(context, nullptr, manager, std::move(socket));
+	}
+	BOOST_TEST(wasOpen);
+	BOOST_TEST(!socket.is_open());
+}
+
+BOOST_AUTO_TEST_CASE(send_when_closed_ignores_message)
+{
+	ConnectionFixture fixture;
+	fixture.connection->close();
+	auto message = tfs::net::make_output_message();
+	message->addBytes("\x01", 1);
+	fixture.connection->send(message);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(send_queues_message)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto message = tfs::net::make_output_message();
+	message->addBytes("\x01", 1);
+	fixture.connection->send(message);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 1);
+}
+
+BOOST_AUTO_TEST_CASE(double_close_is_safe)
+{
+	ConnectionFixture fixture;
+	fixture.connection->close();
+	BOOST_TEST(fixture.connection->isClosed());
+	fixture.connection->close();
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(force_close_skips_pending_writes)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto message = tfs::net::make_output_message();
+	message->addBytes("\x01", 1);
+	fixture.connection->send(message);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 1);
+
+	fixture.connection->close(Connection::FORCE_CLOSE);
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(on_first_message_without_protocol_closes)
+{
+	ConnectionFixture fixture;
+
+	// Manually create a connection with a ServicePort that has no registered services.
+	// When onFirstMessage runs without a protocol, it calls servicePort->make_protocol,
+	// which returns null for unregistered services, triggering close.
+	boost::asio::ip::tcp::socket serverSocket(fixture.ioContext);
+	auto servicePort = std::make_shared<ServicePort>(fixture.ioContext);
+	auto connection =
+	    std::make_shared<Connection>(fixture.ioContext, servicePort, fixture.manager, std::move(serverSocket));
+
+	connection->msg.addPaddingBytes(10);
+	connection->msg.setLength(10);
+
+	BOOST_TEST(!connection->onFirstMessage());
+	BOOST_TEST(connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(close_graceful_without_pending_writes)
+{
+	ConnectionFixture fixture;
+
+	// close(false) with an empty queue should close the socket immediately.
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 0);
+	fixture.connection->close(false);
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(is_first_message_processed_after_on_first_message)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	BOOST_TEST(!fixture.connection->isFirstMessageProcessed());
+	fixture.connection->msg.addBytes("\x01\x02payload", 9);
+	fixture.connection->msg.setLength(9);
+	fixture.connection->onFirstMessage();
+	BOOST_TEST(fixture.connection->isFirstMessageProcessed());
+}
+
+BOOST_AUTO_TEST_CASE(get_window_packet_count_after_check_rate_limit)
+{
+	ConnectionFixture fixture;
+	BOOST_TEST(fixture.connection->getWindowPacketCount() == 0);
+	fixture.connection->checkRateLimit();
+	BOOST_TEST(fixture.connection->getWindowPacketCount() == 1);
+	fixture.connection->checkRateLimit();
+	BOOST_TEST(fixture.connection->getWindowPacketCount() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(write_complete_success_sends_next_queued)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto firstMessage = tfs::net::make_output_message();
+	firstMessage->addBytes("\x01", 1);
+	fixture.connection->send(firstMessage);
+
+	auto secondMessage = tfs::net::make_output_message();
+	secondMessage->addBytes("\x02", 1);
+	fixture.connection->send(secondMessage);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 2);
+
+	fixture.connection->onWriteComplete(boost::system::error_code{});
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 1);
+	BOOST_TEST(!fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(write_complete_success_closes_socket_when_closed_flag_set)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto message = tfs::net::make_output_message();
+	message->addBytes("\x01", 1);
+	fixture.connection->send(message);
+
+	fixture.connection->close(false);
+	BOOST_TEST(fixture.connection->isClosed());
+
+	fixture.connection->onWriteComplete(boost::system::error_code{});
+	BOOST_TEST(!fixture.connection->getSocket().is_open());
+}
+
+BOOST_AUTO_TEST_CASE(accept_server_first_socket_error_during_name)
+{
+	ConnectionFixture fixture;
+
+	// Start name detection, then close the client socket so the async read fails.
+	fixture.connection->accept(fixture.mockProtocol);
+
+	fixture.clientSocket.close();
+	fixture.runIO();
+
+	// Connection should detect the socket error and close.
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(parse_header_without_protocol_rejects_zero_size)
+{
+	ConnectionFixture fixture;
+
+	// Without protocol: size = header value directly. blockCount = 0 → size = 0 → close.
+	fixture.connection->startReadSequence();
+
+	uint16_t blockCount = 0;
+	uint32_t checksum = 0;
+	std::vector<uint8_t> packet(2 + 4);
+	std::memcpy(packet.data(), &blockCount, 2);
+	std::memcpy(packet.data() + 2, &checksum, 4);
+
+	fixture.writeToConnection(packet);
+	fixture.runIO();
+
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(remote_address_set_on_accept)
+{
+	ConnectionFixture fixture;
+
+	// accept() captures the remote endpoint address
+	boost::asio::ip::tcp::endpoint ep(boost::asio::ip::make_address("127.0.0.1"), 0);
+	auto address = fixture.connection->getRemoteAddress();
+	BOOST_TEST(address.is_unspecified());
+}
+
+BOOST_AUTO_TEST_CASE(write_queue_queues_multiple_messages)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto firstMessage = tfs::net::make_output_message();
+	firstMessage->addBytes("\x01", 1);
+	fixture.connection->send(firstMessage);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 1);
+
+	auto secondMessage = tfs::net::make_output_message();
+	secondMessage->addBytes("\x02", 1);
+	fixture.connection->send(secondMessage);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(write_complete_error_clears_queue_and_closes)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto message = tfs::net::make_output_message();
+	message->addBytes("\x01", 1);
+	fixture.connection->send(message);
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 1);
+
+	// Simulate a write error directly — verifies the error handler clears the
+	// queue and force-closes the connection without involving the real socket.
+	fixture.connection->onWriteComplete(boost::asio::error::connection_reset);
+
+	BOOST_TEST(fixture.connection->isClosed());
+	BOOST_TEST(fixture.connection->getWriteQueueSize() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(read_timeout_triggers_close)
+{
+	// A zero-second timeout fires on the next io_context tick.
+	CONNECTION_READ_TIMEOUT = 0;
+	ConnectionFixture fixture;
+	fixture.connection->startReadTimer();
+	fixture.ioContext.run_one();
+	fixture.ioContext.restart();
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(timeout_cancelled_by_close_socket_returns_early)
+{
+	CONNECTION_READ_TIMEOUT = 0;
+	ConnectionFixture fixture;
+	fixture.connection->startReadTimer();
+	// closeSocket cancels the timer (operation_aborted), so onTimeout
+	// must NOT close the connection again.
+	fixture.connection->closeSocket();
+	fixture.ioContext.run_one();
+	fixture.ioContext.restart();
+	BOOST_TEST(!fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(write_timeout_triggers_close)
+{
+	CONNECTION_WRITE_TIMEOUT = 0;
+	ConnectionFixture fixture;
+	fixture.connection->startWriteTimer();
+	fixture.ioContext.run_one();
+	fixture.ioContext.restart();
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(close_with_expired_manager_does_not_crash)
+{
+	boost::asio::io_context context;
+	boost::asio::ip::tcp::socket socket(context);
+
+	auto manager = std::make_shared<ConnectionManager>();
+	auto connection = std::make_shared<Connection>(context, nullptr, manager, std::move(socket));
+	// Drop the only shared_ptr to the manager so connection->manager.lock()
+	// returns null. close() must handle this gracefully.
+	manager.reset();
+	connection->close();
+	BOOST_TEST(connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(accept_client_first_dispatches_first_message)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	fixture.connection->accept();
+	fixture.writeFramedPacket({0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
+	fixture.runIO();
+
+	BOOST_TEST(fixture.mockProtocol->recvFirstCalled);
+}
+
+BOOST_AUTO_TEST_CASE(accept_client_first_dispatches_second_message)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	// First packet triggers onRecvFirstMessage.
+	fixture.connection->accept();
+	fixture.writeFramedPacket({0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
+	fixture.runIO();
+	BOOST_TEST(fixture.mockProtocol->recvFirstCalled);
+
+	fixture.mockProtocol->recvFirstCalled = false;
+	fixture.mockProtocol->recvCalled = false;
+
+	// Second packet triggers onRecvMessage via the read loop
+	// (parsePacket → startReadSequence loopback).
+	fixture.writeFramedPacket({0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10});
+	fixture.runIO();
+
+	BOOST_TEST(fixture.mockProtocol->recvCalled);
+	BOOST_TEST(!fixture.mockProtocol->recvFirstCalled);
+}
+
+BOOST_AUTO_TEST_CASE(accept_client_first_zero_size_packet_without_protocol_closes)
+{
+	ConnectionFixture fixture;
+
+	fixture.connection->accept();
+
+	// Without protocol: size = header value directly. blockCount = 0 → size = 0 → close.
+	uint16_t blockCount = 0;
+	uint32_t checksum = 0;
+	std::vector<uint8_t> packet(2 + 4);
+	std::memcpy(packet.data(), &blockCount, 2);
+	std::memcpy(packet.data() + 2, &checksum, 4);
+
+	fixture.writeToConnection(packet);
+	fixture.runIO();
+
+	BOOST_TEST(fixture.connection->isClosed());
+}
+
+BOOST_AUTO_TEST_CASE(accept_server_first_empty_name_detected)
+{
+	ConnectionFixture fixture;
+	fixture.connection->accept(fixture.mockProtocol);
+
+	// A 2-byte header with second byte == 0x00 means "no name".
+	uint8_t header[2] = {0x00, 0x00};
+	fixture.writeToConnection({header[0], header[1]});
+	fixture.runIO();
+
+	// After name detection completes, the connection reads framed packets.
+	fixture.writeFramedPacket({0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
+	fixture.runIO();
+
+	BOOST_TEST(fixture.mockProtocol->recvFirstCalled);
+}
+
+BOOST_AUTO_TEST_CASE(accept_server_first_multi_byte_name_detected)
+{
+	ConnectionFixture fixture;
+	fixture.connection->accept(fixture.mockProtocol);
+
+	// 2-byte header: second byte != 0 starts name accumulation.
+	fixture.writeToConnection({0x00, 0x01});
+	fixture.runIO();
+
+	// Name characters sent one at a time; each triggers a 1-byte async_read.
+	fixture.writeToConnection({'A'});
+	fixture.runIO();
+
+	fixture.writeToConnection({'B'});
+	fixture.runIO();
+
+	fixture.writeToConnection({'C'});
+	fixture.runIO();
+
+	// 0x0A terminates the name.
+	fixture.writeToConnection({0x0A});
+	fixture.runIO();
+
+	fixture.writeFramedPacket({0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
+	fixture.runIO();
+
+	BOOST_TEST(fixture.mockProtocol->recvFirstCalled);
+}
+
+BOOST_AUTO_TEST_CASE(async_write_invokes_on_send_message)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	auto message = tfs::net::make_output_message();
+	message->addBytes("\x01\x02\x03", 3);
+	fixture.connection->send(message);
+	fixture.runIO();
+
+	BOOST_TEST(fixture.mockProtocol->sendCalled);
+}
+
+BOOST_AUTO_TEST_CASE(async_read_oversized_packet_closes)
+{
+	ConnectionFixture fixture;
+	fixture.connection->protocol = fixture.mockProtocol;
+
+	fixture.connection->accept();
+
+	// blockCount = 0xFFFF → computed size exceeds NETWORKMESSAGE_MAXSIZE - 16
+	// → parseHeader closes the connection.
+	uint16_t blockCount = 0xFFFF;
+	uint32_t checksum = 0;
+	std::vector<uint8_t> packet(2 + 4);
+	std::memcpy(packet.data(), &blockCount, 2);
+	std::memcpy(packet.data() + 2, &checksum, 4);
+
+	fixture.writeToConnection(packet);
+	fixture.runIO();
+
+	BOOST_TEST(fixture.connection->isClosed());
+}


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

- [X] I have followed [proper The Forgotten Server code styling][code].
- [X] I have read and understood the [contribution guidelines][cont] before making this PR.
- [X] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Complete refactor of the `Connection` and `Protocol` classes: property renaming, singleton removal, comprehensive test suite (33 tests, 100% coverage), and benchmarks.

**Connection class — property renames:**

| Before | After |
|---|---|
| `NetworkMessage msg` | `NetworkMessage msg` |
| `Address peerAddress` | `boost::asio::ip::address remoteAddress` |
| `std::list<…> messageQueue` | `std::list<…> writeQueue` |
| `time_point timeConnected` | `time_point rateWindowStart` |
| `uint32_t packetsSent` | `uint32_t windowPacketCount` |
| `ConnectionState_t connectionState` | `bool closed` + `bool firstMessageProcessed` |
| `bool receivedFirst` | `bool firstMessageProcessed` |
| `bool receivedName` / `bool receivedLastChar` | `NameState nameState` (enum) |
| `recursive_mutex connectionLock` | `recursive_mutex mutex` |
| `shared_ptr<const ServicePort> service_port` | `shared_ptr<ServicePort> servicePort` |

**ConnectionManager — singleton removal:**

- `ConnectionManager` now inherits `enable_shared_from_this<ConnectionManager>`
- `Connection` stores `weak_ptr<ConnectionManager>` instead of calling `getInstance()`
- `ServicePort` owns a `shared_ptr<ConnectionManager>` member
- `ConnectionManager::getInstance()` and the two-arg `Connection` constructor removed
- Shutdown: `ServicePort::close()` calls `connectionManager->closeAll()` — the old `ConnectionManager::getInstance().closeAll()` in `game.cpp` was removed

**Connection — timers optimized:**

- `startReadTimer` / `startWriteTimer` register `async_wait` **once** via a boolean guard (`readTimerArmed`/`writeTimerArmed`). Subsequent calls only call `expires_after()` to reposition the deadline.
- Removed redundant `readTimer.cancel()` calls from `onServerNameRead`, `parseHeader`, and `parsePacket` (the timer is simply repositioned, not cancelled + re-armed).
- Timeout constants changed from `static constexpr` to `static inline int32_t` so tests can set `CONNECTION_READ_TIMEOUT = 0` for fast timeout tests.

**Connection — rate limiting simplified:**

- `checkRateLimit()` now calls `steady_clock::now()` once (was potentially twice), avoids `std::max` by using simple integer comparison, and removes unnecessary `duration_cast` wrapping.

**Connection — testing helpers made public:**

- `checkRateLimit()`, `closeSocket()`, `onFirstMessage()`, `getSocket()`, `startReadTimer()`, `startWriteTimer()`, `onTimeout()`, `startReadSequence()`, `onWriteComplete()`, `internalSend()`, `isClosed()`, `isFirstMessageProcessed()`, `getWindowPacketCount()`, `getWriteQueueSize()` — all public for test access.
- Members section moved to `public:` for test assertions without `friend`.

**Connection — socket injection:**

- New four-arg constructor: `Connection(io_context, servicePort, manager, socket)` lets tests inject a pre-connected loopback socket.
- `ConnectionManager::createConnection` now creates the socket separately and passes it via `shared_from_this()`.

**Protocol class renames:**

| Before | After |
|---|---|
| `RSA_decrypt()` | removed — logic inlined in `protocolgame.cpp` (calls `tfs::rsa::decrypt` directly) |
| `getIP()` | `getRemoteAddress()` |
| `getCurrentBuffer()` | `getSendBuffer()` |
| `getNextSequenceId()` | `nextSequenceId()` |
| `enableXTEAEncryption()` | `enableEncryption()` |
| `setRawMessages(bool)` | `enableRawMode()` |
| `xtea::round_keys key` | `xtea::round_keys xteaKey` |
| `z_stream zstream` | `z_stream zlibStream` |
| `bool encryptionEnabled` | `bool encrypted` |
| `bool rawMessages` | `bool rawMode` |
| `shared_ptr<OutputMessage> outputBuffer` | `shared_ptr<OutputMessage> sendBuffer` |

- `onRecvMessage()` changed from non-virtual to `virtual` so mock protocols can override it for testing.

**NetworkMessage changes:**

- Old anonymous `enum` constants replaced with `static constexpr` members (`HEADER_LENGTH`, `CHECKSUM_LENGTH`, `PADDING_LENGTH`, `CRYPTO_HEADER_LENGTH`, etc.).
- `reset()` now explicitly zeroes only the fields that need resetting instead of aggregate-initialising the whole info struct.

**OutputMessage changes:**

- Removed `writeMessageLength()`, `writePaddingLength()`, `addCryptoHeader()`, `setSequenceId()`, `getSequenceId()`, and `sequenceId` member — these are now handled directly in `Protocol::onSendMessage` via `addHeader()`.
- `add_header<T>()` renamed to `addHeader<T>()` and made public (was private).
- `sequenceId` removed; framing is done inline in `Protocol`.

**Type alias removal:**

- `Connection::Address` (was `boost::asio::ip::address`) replaced throughout the codebase with the explicit type. Affected files: `ban.h`, `ban.cpp`, `player.h`, `player.cpp`, `protocol.h`, `protocol.cpp`, `protocolstatus.cpp`, `server.cpp`.

**Tests (33 test cases, 100% code coverage):**

- `test_connection.cpp` with a `ConnectionFixture` that establishes a real loopback TCP connection using `acceptor` + `clientSocket`.
- Tests cover: ConnectionManager (create/release/closeAll), rate limiting (under/over/zero limit), `closeSocket` (idempotent, timer cancellation), destructor, `send` (closed, queue), `close` (double, force, graceful), `onFirstMessage` (with/without protocol), `isFirstMessageProcessed`, `getWindowPacketCount`, `onWriteComplete` (success dequeue, close on closed, error), read/write timeouts, expired manager, accept client-first (first/second message, zero size, oversized), accept server-first (empty name, multi-byte name, socket error).
- All tests pass: `33/33, *** No errors detected`.

**Benchmarks (4 benchmarks):**

- `bench_connection.cpp` duplicates `MockProtocol` and fixture setup.
- `bench_rate_limit`: throughput of `checkRateLimit()` (~1.4μs, 720K calls/s).
- `bench_send_packet`: `send()` → `onSendMessage` → `async_write` → `onWriteComplete` at 64B–4KB (2.7–3.8μs per message).
- `bench_accept_cycle`: full async read cycle `accept()` → read → `parseHeader` → `parsePacket` at 8B–256B body (~11.5μs, 87K packets/s).
- `bench_concurrent_connections`: `ConnectionManager` create + close at N=1..1024 (433ns per connection).

**Issues addressed:** N/A

**How to test:**

```sh
# Build and run tests
cd build/windows-debug-tests
cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON ../..
ninja test_connection
./test_connection

# Build and run benchmarks
cd ../windows-release-benchmarks
cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKING=ON ../..
ninja bench_connection
./bench_connection
```

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced connection handling with improved asynchronous I/O management and timeout enforcement
  * Optimized protocol message framing, encryption, and compression processing
  * Streamlined IP address handling throughout authentication and server systems

* **Tests**
  * Added comprehensive benchmarks for connection performance
  * Added extensive unit tests for connection management and protocol handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->