### PR TITLE
fix(config): disable special gamemaster outfit by default

### DIFF
--- a/data/scripts/systems/outfits/config.lua
+++ b/data/scripts/systems/outfits/config.lua
@@ -19,6 +19,10 @@ Outfits = {
     -- Cooldown (ms) enforced for manual mount toggles (Ctrl+R). Forced zone toggles may bypass this.
     ToggleMountCooldown = 3000,
 
+    -- Show the special Gamemaster outfit (lookType 75) in outfit windows for staff members.
+    -- Disabled by default because it can crash with mount and random outfit behavior.
+    EnableGamemasterOutfit = false,
+
     -- Print outfit/mount command usage to console.
     PrintCommandsToConsole = true
 }

--- a/data/scripts/systems/outfits/core/mounts.lua
+++ b/data/scripts/systems/outfits/core/mounts.lua
@@ -173,6 +173,10 @@ function Player.setRandomizeMount(self, randomize)
 end
 
 -- Returns whether the player can ride the given mount lookType.
+function Game.isMountableOutfit(lookType)
+    return type(lookType) == "number" and lookType > 0 and Game.getOutfitByLookType(lookType) ~= nil
+end
+
 function Player.canRideMount(self, mountId)
     if self:getGroup():getAccess() then
         return type(mountId) == "number" and mountId > 0 and Game.getMountByLookType(mountId) ~= nil
@@ -298,6 +302,10 @@ function Player.toggleMount(self, mounted, keepWasMounted)
 
         if self:hasCondition(CONDITION_OUTFIT) then
             self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+            return false
+        end
+
+        if not Game.isMountableOutfit(self:getOutfit().lookType) then
             return false
         end
 

--- a/data/scripts/systems/outfits/core/windows.lua
+++ b/data/scripts/systems/outfits/core/windows.lua
@@ -15,14 +15,12 @@ local function getAvailableOutfits(player)
     local availableOutfits = {}
 
     local isAccessPlayer = player:getGroup():getAccess()
-    if isAccessPlayer then
-        -- Add GM outfit for staff members.
-        local gamemaster = {
+    if Outfits.EnableGamemasterOutfit and isAccessPlayer then
+        table.insert(availableOutfits, {
             name = "Gamemaster",
             lookType = 75,
             addons = 0
-        }
-        table.insert(availableOutfits, gamemaster)
+        })
     end
 
     local outfits = Game.getOutfits(player:getSex())

--- a/data/scripts/systems/outfits/events/login.lua
+++ b/data/scripts/systems/outfits/events/login.lua
@@ -6,7 +6,7 @@ function event.onPlayerLogin(player)
         local outfit = player:getDefaultOutfit()
         local lookMount = outfit.lookMount
 
-        if player:canRideMount(lookMount) then
+        if Game.isMountableOutfit(outfit.lookType) and player:canRideMount(lookMount) then
             if not player:getCurrentMount() then
                 player:setCurrentMount(lookMount)
             end
@@ -14,6 +14,7 @@ function event.onPlayerLogin(player)
             player:setWasMounted(true)
         else
             outfit.lookMount = 0
+            player:setCurrentMount(nil)
             player:setDefaultOutfit(outfit)
             player:setCurrentOutfit(outfit)
             player:setWasMounted(false)

--- a/data/scripts/systems/outfits/network/set_outfit.lua
+++ b/data/scripts/systems/outfits/network/set_outfit.lua
@@ -59,19 +59,24 @@ function handler.onReceive(player, msg)
             return
         end
 
+        local sanitizedMount = lookMount
+
         if lookMount ~= 0 then
             if not Game.isMountableOutfit(outfit.lookType) then
                 outfit.lookMount = 0
+                sanitizedMount = 0
             elseif not player:canRideMount(lookMount) then
                 player:setCurrentMount(nil)
                 return
-            else
-                player:setCurrentMount(lookMount)
             end
         end
 
+        if sanitizedMount ~= 0 then
+            player:setCurrentMount(sanitizedMount)
+        end
+
         if player:setOutfitWithMountSpeed(outfit) then
-            player:setWasMounted(lookMount ~= 0)
+            player:setWasMounted(sanitizedMount ~= 0)
         end
         player:setRandomizeMount(randomizeMount)
     elseif outfitType == 1 then -- try outfit from store window

--- a/data/scripts/systems/outfits/network/set_outfit.lua
+++ b/data/scripts/systems/outfits/network/set_outfit.lua
@@ -60,12 +60,14 @@ function handler.onReceive(player, msg)
         end
 
         if lookMount ~= 0 then
-            if not player:canRideMount(lookMount) then
+            if not Game.isMountableOutfit(outfit.lookType) then
+                outfit.lookMount = 0
+            elseif not player:canRideMount(lookMount) then
                 player:setCurrentMount(nil)
                 return
+            else
+                player:setCurrentMount(lookMount)
             end
-
-            player:setCurrentMount(lookMount)
         end
 
         if player:setOutfitWithMountSpeed(outfit) then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control whether a special staff outfit is shown in outfit selection.

* **Bug Fixes**
  * Improved validation for whether outfits can be mounted, preventing invalid mount states.
  * Updated login mount restoration to clear the current mount when the default outfit isn’t mount-compatible.
  * Refined outfit selection behavior to sanitize mount settings and ensure the mount state is only applied when valid.
  * Adjusted outfit window listing so the special staff outfit only appears when enabled and accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->