### PR TITLE
fix(benchs): correct XTEA benchmark throughput metric and max range

### DIFF
--- a/src/benchs/bench_xtea.cpp
+++ b/src/benchs/bench_xtea.cpp
@@ -28,11 +28,10 @@ static void bench_xtea_encrypt(benchmark::State& state)
 	for (auto&& _ : state) {
 		xtea::encrypt(data.data(), size, roundKeys);
 		benchmark::DoNotOptimize(data);
-
-		state.SetBytesProcessed(state.range(0) * state.iterations());
 	}
+	state.SetBytesProcessed(state.iterations() * state.range(0));
 }
-BENCHMARK(bench_xtea_encrypt)->Range(8, 65500);
+BENCHMARK(bench_xtea_encrypt)->Range(8, 65496);
 
 static void bench_xtea_decrypt(benchmark::State& state)
 {
@@ -48,10 +47,9 @@ static void bench_xtea_decrypt(benchmark::State& state)
 	for (auto&& _ : state) {
 		xtea::decrypt(data.data(), size, roundKeys);
 		benchmark::DoNotOptimize(data);
-
-		state.SetBytesProcessed(state.range(0) * state.iterations());
 	}
+	state.SetBytesProcessed(state.iterations() * state.range(0));
 }
-BENCHMARK(bench_xtea_decrypt)->Range(8, 65500);
+BENCHMARK(bench_xtea_decrypt)->Range(8, 65496);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
SetBytesProcessed was called inside the measurement loop, where state.iterations() still returns 0 in Google Benchmark range-for mode, so every result reported bytes_per_second=0/s. Move it after the loop.

Also change the upper range bound from 65500 to 65496: 65500 is not a multiple of 8, which trips the assert in Debug builds and causes a 4-byte heap-buffer-overflow in xtea::encrypt/decrypt in Release builds (confirmed with AddressSanitizer).
