### PR TITLE
Fix: use correct max duration syntax in creature.cpp

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -83,7 +83,7 @@ std::chrono::milliseconds Creature::getTimeSinceLastMove() const
 	if (lastStep != std::chrono::steady_clock::time_point{}) {
 		return duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - lastStep);
 	}
-	return std::numeric_limits<std::chrono::milliseconds>::max();
+	return std::chrono::milliseconds::max();
 }
 
 std::chrono::milliseconds Creature::getWalkDelay(Direction dir) const


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Fixed an issue in `Creature::getTimeSinceLastMove()` where `std::numeric_limits` was incorrectly used on a chrono duration type. Replaced it with the built-in and idiomatic `std::chrono::milliseconds::max()`.

**Issues addressed:** Fixes https://github.com/atlas-kit/atlas/issues/333

**How to test:** 
Compile the server with the changes. Log into the game and observe the creatures as they move. Ensure they behave naturally without any delays or sudden pathfinding issues caused by walk delay calculations.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of creature movement timing behavior in edge cases where movement history data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->