### PR TITLE
fix(benchs): report throughput in RSA decrypt benchmark

### DIFF
--- a/src/benchs/bench_rsa.cpp
+++ b/src/benchs/bench_rsa.cpp
@@ -32,11 +32,13 @@ static void bench_rsa_decrypt(benchmark::State& state)
 {
 	tfs::rsa::loadPEM(privateKey);
 
+	// RSA decrypts a single block whose size must match the key modulus (128 bytes for a 1024-bit key).
 	std::vector<uint8_t> data(state.range(0), 0x42);
 	for (auto&& _ : state) {
 		tfs::rsa::decrypt(data.data(), data.size());
 		benchmark::DoNotOptimize(data);
 	}
+	state.SetItemsProcessed(state.iterations());
 }
 BENCHMARK(bench_rsa_decrypt)->Arg(128);
 


### PR DESCRIPTION
Follow-up to #358: report items/s via SetItemsProcessed so the CI benchmark graphs track RSA decrypt throughput, and document why the block size is fixed at 128 bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal benchmarking infrastructure for RSA decryption testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->