### PR TITLE
ci: fix ccache so PR builds actually get cache hits

### DIFF
--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -45,6 +45,9 @@ jobs:
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed/x64-linux
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg_cache
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 256M
+      CCACHE_COMPRESS: "1"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -64,12 +67,19 @@ jobs:
           restore-keys: |
             vcpkg-linux-
 
-      - name: CCache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+      - name: Restore ccache cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          key: ${{ runner.os }}-ccache-${{ hashFiles('src/**', 'CMakeLists.txt', 'vcpkg.json') }}
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-linux-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-ccache-
+            ccache-linux-
+
+      - name: Set up ccache
+        run: |
+          sudo apt-get install -y ccache
+          ccache --zero-stats
+        shell: bash
 
       - name: Run vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
@@ -78,8 +88,19 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: linux-release
-          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
+          configurePresetAdditionalArgs: "['-DOPTIONS_ENABLE_CCACHE=ON', '-DOPTIONS_ENABLE_SCCACHE=OFF']"
           buildPreset: linux-release
+
+      - name: CCache statistics
+        run: ccache --show-stats
+        shell: bash
+
+      - name: Save ccache cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: github.event_name == 'push'
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-linux-${{ github.sha }}
 
       - name: Upload build logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -114,13 +135,6 @@ jobs:
       - name: Get latest CMake
         uses: lukka/get-cmake@7bfc9baacbbdcb5e37957ad05c3546b3e222be3c # v4.3.2
 
-      - name: CCache
-        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
-        with:
-          key: windows-ccache-${{ hashFiles('src/**', 'CMakeLists.txt', 'vcpkg.json') }}
-          restore-keys: |
-            windows-ccache-
-
       - name: Cache vcpkg binary packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
@@ -136,7 +150,6 @@ jobs:
         uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
         with:
           configurePreset: windows-release
-          configurePresetAdditionalArgs: "['-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
           buildPreset: windows-release
 
       - name: Upload build logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
         include:
           # Default backend: the libmariadb/libmysql C client (src/database.cpp).
           - backend: c-client
-            cmake_args: "[]"
+            cmake_args: "['-DOPTIONS_ENABLE_CCACHE=ON', '-DOPTIONS_ENABLE_SCCACHE=OFF']"
           # Boost.MySQL backend (src/database_boost.cpp). Runs the exact same test suite against
           # the same MariaDB service to prove behavioral parity between the two backends.
           - backend: boost-mysql
-            cmake_args: "['-DUSE_BOOST_MYSQL=ON']"
+            cmake_args: "['-DOPTIONS_ENABLE_CCACHE=ON', '-DOPTIONS_ENABLE_SCCACHE=OFF', '-DUSE_BOOST_MYSQL=ON']"
 
     name: test (${{ matrix.backend }})
 
@@ -56,6 +56,9 @@ jobs:
       VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed/x64-linux-debug-asan-${{ matrix.backend }}
       VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}/vcpkg_cache
       VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/vcpkg_cache,readwrite
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
+      CCACHE_COMPRESS: "1"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -74,6 +77,20 @@ jobs:
           key: vcpkg-binary-ubuntu-test-${{ matrix.backend }}-${{ hashFiles('vcpkg.json', 'CMakeLists.txt', '**/CMakeLists.txt', 'CMakePresets.json') }}
           restore-keys: |
             vcpkg-binary-ubuntu-test-${{ matrix.backend }}-
+
+      - name: Restore ccache cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-test-${{ matrix.backend }}-${{ github.sha }}
+          restore-keys: |
+            ccache-test-${{ matrix.backend }}-
+
+      - name: Set up ccache
+        run: |
+          sudo apt-get install -y ccache
+          ccache --zero-stats
+        shell: bash
 
       - name: Run vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.6
@@ -94,3 +111,14 @@ jobs:
           configurePresetAdditionalArgs: ${{ matrix.cmake_args }}
           buildPreset: linux-debug-asan
           testPreset: linux-debug-asan
+
+      - name: CCache statistics
+        run: ccache --show-stats
+        shell: bash
+
+      - name: Save ccache cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: github.event_name == 'push'
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-test-${{ matrix.backend }}-${{ github.sha }}


### PR DESCRIPTION
Follow-up to #275. I checked the ccache statistics of the runs that executed since it merged, and the current setup is not delivering what it was supposed to:

**Evidence from run logs:**

- **PR runs never restore the dev cache.** `hendrikmuhs/ccache-action` logged `No cache found` in every `pull_request` run (e.g. runs 27315532631 and 27317287707), even though the dev branch had saved `ccache-Linux-ccache-*` minutes earlier — while `actions/cache` (vcpkg step) successfully restored dev-branch caches cross-branch *in the same jobs*. So every PR build runs with a cold ccache: `Hits: 0 / 15 (0.00%)`.
- **When a cache does restore, hits are 100% without any sloppiness tweaks.** A run that restored a same-PR cache got `Hits: 17 / 17 (100.0%)` — GCC PCH is not a blocker in practice, so no `CCACHE_SLOPPINESS` configuration is needed.
- **Windows ccache is pure overhead.** `Cacheable calls: 0 / 17 (0.00%), Uncacheable calls: 17 / 17 (100.0%)` — MSVC `/Zi` (RelWithDebInfo) and MSVC PCH are both unsupported by ccache, and migrating to `/Z7` would not help while `target_precompile_headers` is in use.
- **Cache storage is over the limit.** The repo is at 10.68 GB / 10 GB across 112 caches, and `append-timestamp: true` (the action's default) saves a new ~110 MB ccache entry on *every* run on both OSes, accelerating LRU eviction of the vcpkg binary caches.
- **The unit test jobs have no compiler cache at all** and spend ~9.5 of their ~10 minutes compiling (144 targets, Debug+ASAN, unity off); configure is 17s and ctest 7s.

**Changes:**

- Linux build: replace `hendrikmuhs/ccache-action` with `actions/cache/restore` + `actions/cache/save` (the client that demonstrably works cross-branch here), install/configure ccache in a plain step, and print `ccache --show-stats` after the build for future verification.
- Save the ccache cache only on `push` events, keyed by SHA with a stable restore prefix: one cache entry per push to dev instead of one per run.
- Use `-DOPTIONS_ENABLE_CCACHE=ON -DOPTIONS_ENABLE_SCCACHE=OFF` instead of overriding only `CMAKE_CXX_COMPILER_LAUNCHER`: this goes through the project's own option (covering the C launcher too) and removes the latent risk of the base preset's `OPTIONS_ENABLE_SCCACHE=ON` overriding the launcher if sccache ever appears on a runner image.
- Remove ccache from the Windows job entirely (see evidence above).
- Unit tests: apply the same restore/save pattern, keyed per backend (the per-backend `VCPKG_INSTALLED_DIR` changes every compile command line, so the backends cannot share objects). This should take the test jobs from ~10 min to ~2-3 min on typical PRs once dev has seeded a cache.

Expected outcome: PR Linux builds restore the latest dev cache and only recompile what their diff touches; the Windows job loses ~30s of useless cache traffic per run; cache storage pressure drops substantially.

Note on the remaining Windows time: the occasional ~12 min Windows job is a different cause — when the runner image updates MSVC, the vcpkg ABI of all ~80 dependencies changes and they rebuild from source inside configure (`Configuring done (455.4s)`, `Restored 0 package(s)`). Steady-state with an exact vcpkg binary cache hit is ~4-5 min. That is periodic and not worth pinning the VS toolset over.