### PR TITLE
feat(web): add get and post of create character

### DIFF
--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -1,23 +1,29 @@
 set(http_SRC
 	${CMAKE_CURRENT_LIST_DIR}/cacheinfo.cpp
+	${CMAKE_CURRENT_LIST_DIR}/createcharacter.cpp
 	${CMAKE_CURRENT_LIST_DIR}/error.cpp
+	${CMAKE_CURRENT_LIST_DIR}/getaccountcreationstatus.cpp
 	${CMAKE_CURRENT_LIST_DIR}/http.cpp
 	${CMAKE_CURRENT_LIST_DIR}/listener.cpp
 	${CMAKE_CURRENT_LIST_DIR}/login.cpp
 	${CMAKE_CURRENT_LIST_DIR}/router.cpp
 	${CMAKE_CURRENT_LIST_DIR}/serverinfo.cpp
 	${CMAKE_CURRENT_LIST_DIR}/session.cpp
+	${CMAKE_CURRENT_LIST_DIR}/success.cpp
 	)
 
 set(http_HDR
 	${CMAKE_CURRENT_LIST_DIR}/cacheinfo.h
+	${CMAKE_CURRENT_LIST_DIR}/createcharacter.h
 	${CMAKE_CURRENT_LIST_DIR}/error.h
+	${CMAKE_CURRENT_LIST_DIR}/getaccountcreationstatus.h
 	${CMAKE_CURRENT_LIST_DIR}/http.h
 	${CMAKE_CURRENT_LIST_DIR}/listener.h
 	${CMAKE_CURRENT_LIST_DIR}/login.h
 	${CMAKE_CURRENT_LIST_DIR}/router.h
 	${CMAKE_CURRENT_LIST_DIR}/serverinfo.h
 	${CMAKE_CURRENT_LIST_DIR}/session.h
+	${CMAKE_CURRENT_LIST_DIR}/success.h
 	)
 
 add_library(http OBJECT ${http_SRC})

--- a/src/http/createcharacter.cpp
+++ b/src/http/createcharacter.cpp
@@ -1,0 +1,161 @@
+#include "../otpch.h"
+
+#include "createcharacter.h"
+
+#include "../database.h"
+#include "../game.h"
+#include "../iologindata.h"
+#include "error.h"
+#include "success.h"
+
+extern Vocations g_vocations;
+extern Game g_game;
+
+namespace {
+
+int getPvpType()
+{
+	switch (g_game.getWorldType()) {
+		case WORLD_TYPE_PVP:
+			return 0;
+		case WORLD_TYPE_NO_PVP:
+			return 1;
+		case WORLD_TYPE_PVP_ENFORCED:
+			return 2;
+	}
+
+	std::unreachable();
+}
+
+} // namespace
+
+std::pair<beast::http::status, json::value> tfs::http::handle_create_character(const json::object& body,
+                                                                               std::string_view)
+{
+	using namespace std::chrono;
+	thread_local auto& db = Database::getInstance();
+
+	auto sessionKeyField = body.if_contains("sessionkey");
+	if (!sessionKeyField || !sessionKeyField->is_string()) {
+		return make_error_response({.code = 1, .message = "Invalid session."});
+	}
+
+	auto nameField = body.if_contains("charactername");
+	if (!nameField || !nameField->is_string()) {
+		return make_error_response({.code = 1, .message = "Invalid character name."});
+	}
+
+	auto sexField = body.if_contains("charactersex");
+	if (!sexField || !sexField->is_string()) {
+		return make_error_response({.code = 1, .message = "Invalid character sex."});
+	}
+
+	const auto& sessionResult =
+	    db.storeQuery(std::format("SELECT s.`account_id`, a.`premium_ends_at` "
+	                              "FROM `sessions` s "
+	                              "INNER JOIN `accounts` a ON a.`id` = s.`account_id` "
+	                              "WHERE s.`token` = FROM_BASE64({:s}) "
+	                              "AND (s.`expired_at` IS NULL OR s.`expired_at` > NOW())",
+	                              db.escapeString(sessionKeyField->get_string())));
+
+	if (!sessionResult) {
+		return make_error_response({.code = 1, .message = "Invalid session."});
+	}
+
+	const uint32_t accountId = sessionResult->getNumber<uint32_t>("account_id");
+
+	const std::string characterName(nameField->get_string());
+
+	if (characterName.empty()) {
+		return make_error_response({.code = 1, .message = "Invalid character name."});
+	}
+
+	if (IOLoginData::getGuidByName(characterName) != 0) {
+		return make_error_response({.code = 1, .message = "Character name already exists."});
+	}
+
+	if (const auto& result = db.storeQuery(std::format("SELECT COUNT(*) AS `count` "
+	                                                   "FROM `players` "
+	                                                   "WHERE `account_id` = {:d}",
+	                                                   accountId))) {
+		if (result->getNumber<uint32_t>("count") >= 20) {
+			return make_error_response({.code = 1, .message = "Character limit reached."});
+		}
+	}
+
+	PlayerSex_t sex;
+	uint16_t lookType;
+
+	if (sexField->get_string() == "male") {
+		sex = PLAYERSEX_MALE;
+		lookType = 128;
+	} else if (sexField->get_string() == "female") {
+		sex = PLAYERSEX_FEMALE;
+		lookType = 136;
+	} else {
+		return make_error_response({.code = 1, .message = "Invalid character sex."});
+	}
+
+	if (!db.executeQuery(std::format("INSERT INTO `players` "
+	                                 "(`name`, `account_id`, `sex`, `looktype`) "
+	                                 "VALUES ({:s}, {:d}, {:d}, {:d})",
+	                                 db.escapeString(characterName), accountId, static_cast<uint32_t>(sex),
+	                                 lookType))) {
+		return make_error_response();
+	}
+
+	json::array characters;
+	if (const auto& playersRes = db.storeQuery(std::format(
+	        "SELECT `id`, `name`, `level`, `vocation`, `lastlogin`, `sex`, `looktype`, `lookhead`, `lookbody`, `looklegs`, `lookfeet`, `lookaddons` FROM `players` WHERE `account_id` = {:d}",
+	        accountId))) {
+		uint32_t lastLogin = 0;
+		do {
+			auto vocation = g_vocations.getVocation(playersRes->getNumber<uint32_t>("vocation"));
+			assert(vocation);
+
+			characters.push_back({
+			    {"worldid", 0}, // not implemented
+			    {"name", playersRes->getString("name")},
+			    {"level", playersRes->getNumber<uint32_t>("level")},
+			    {"vocation", vocation->getVocName()},
+			    {"lastlogin", playersRes->getNumber<uint64_t>("lastlogin")},
+			    {"ismale", playersRes->getNumber<uint16_t>("sex") == PLAYERSEX_MALE},
+			    {"ishidden", false},        // not implemented
+			    {"ismaincharacter", false}, // not implemented
+			    {"tutorial", false},        // not implemented
+			    {"outfitid", playersRes->getNumber<uint32_t>("looktype")},
+			    {"headcolor", playersRes->getNumber<uint32_t>("lookhead")},
+			    {"torsocolor", playersRes->getNumber<uint32_t>("lookbody")},
+			    {"legscolor", playersRes->getNumber<uint32_t>("looklegs")},
+			    {"detailcolor", playersRes->getNumber<uint32_t>("lookfeet")},
+			    {"addonsflags", playersRes->getNumber<uint32_t>("lookaddons")},
+			    {"dailyrewardstate", 0}, // not implemented
+			});
+
+			lastLogin = std::max(lastLogin, playersRes->getNumber<uint32_t>("lastlogin"));
+		} while (playersRes->next());
+	}
+
+	json::array worlds{
+	    {
+	        {"id", 0}, // not implemented
+	        {"name", getString(ConfigManager::SERVER_NAME)},
+	        {"externaladdressprotected", getString(ConfigManager::IP)},
+	        {"externalportprotected", getNumber(ConfigManager::GAME_PORT)},
+	        {"externaladdressunprotected", getString(ConfigManager::IP)},
+	        {"externalportunprotected", getNumber(ConfigManager::GAME_PORT)},
+	        {"previewstate", 0}, // not implemented
+	        {"location", getString(ConfigManager::LOCATION)},
+	        {"anticheatprotection", false}, // not implemented
+	        {"pvptype", getPvpType()},
+	    },
+	};
+
+	return make_success_response({
+	    {"playdata",
+	     {
+	         {"worlds", worlds},
+	         {"characters", characters},
+	     }},
+	});
+}

--- a/src/http/createcharacter.h
+++ b/src/http/createcharacter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <boost/beast/http/status.hpp>
+#include <boost/json/value.hpp>
+
+namespace beast = boost::beast;
+namespace json = boost::json;
+
+namespace tfs::http {
+
+std::pair<beast::http::status, json::value> handle_create_character(const json::object& body, std::string_view ip);
+
+}

--- a/src/http/getaccountcreationstatus.cpp
+++ b/src/http/getaccountcreationstatus.cpp
@@ -1,0 +1,45 @@
+#include "../otpch.h"
+
+#include "getaccountcreationstatus.h"
+
+#include "../game.h"
+#include "error.h"
+
+extern Game g_game;
+
+namespace {
+
+std::string_view getPvpType()
+{
+	switch (g_game.getWorldType()) {
+		case WORLD_TYPE_PVP:
+			return "Open PvP";
+
+		case WORLD_TYPE_NO_PVP:
+			return "Optional PvP";
+
+		case WORLD_TYPE_PVP_ENFORCED:
+			return "Hardcore PvP";
+	}
+
+	std::unreachable();
+}
+
+} // namespace
+
+std::pair<beast::http::status, json::value> tfs::http::handle_worlds_info(const json::object&, std::string_view)
+{
+	return std::pair<beast::http::status, json::value>{beast::http::status::ok,
+	                                                   {{"Worlds",
+	                                                     {{{"Name", getString(ConfigManager::SERVER_NAME).c_str()},
+	                                                       {"Region", getString(ConfigManager::LOCATION)},
+	                                                       {"PvPType", getPvpType()},
+	                                                       {"PlayersOnline", 0},
+	                                                       {"CreationDate", 0},
+	                                                       {"BattlEyeActivationTimestamp", 0},
+	                                                       {"BattlEyeInitiallyActive", 0},
+	                                                       {"PremiumOnly", 0},
+	                                                       {"TransferType", "-"}}}},
+	                                                    {"IsCaptchaDeactivated", true},
+	                                                    {"RecommendedWorld", getString(ConfigManager::SERVER_NAME).c_str()}}};
+}

--- a/src/http/getaccountcreationstatus.h
+++ b/src/http/getaccountcreationstatus.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <boost/beast/http/status.hpp>
+#include <boost/json/value.hpp>
+
+namespace beast = boost::beast;
+namespace json = boost::json;
+
+namespace tfs::http {
+
+std::pair<beast::http::status, json::value> handle_worlds_info(const json::object& body, std::string_view ip);
+
+}

--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -3,13 +3,16 @@
 #include "router.h"
 
 #include "cacheinfo.h"
+#include "createcharacter.h"
 #include "error.h"
+#include "getaccountcreationstatus.h"
 #include "login.h"
 #include "serverinfo.h"
 
 #include <boost/json/monotonic_resource.hpp>
 #include <boost/json/parse.hpp>
 #include <boost/json/serialize.hpp>
+#include <iostream>
 
 namespace {
 
@@ -26,11 +29,32 @@ auto router(std::string_view type, const json::object& body, std::string_view ip
 	if (type == "serverinfo") {
 		return handle_serverinfo(body, ip);
 	}
+	if (type == "getaccountcreationstatus") {
+		return handle_worlds_info(body, ip);
+	}
+	if (type == "createCharacter") {
+		return handle_create_character(body, ip);
+	}
 
 	return make_error_response();
 }
 
 thread_local json::monotonic_resource mr;
+
+json::object normalizeKeys(const json::object& obj)
+{
+	json::object normalized;
+
+	for (auto const& [key, value] : obj) {
+		std::string k(key);
+
+		std::ranges::transform(k, k.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+		normalized[k] = value;
+	}
+
+	return normalized;
+}
 
 } // namespace
 
@@ -44,7 +68,7 @@ beast::http::message_generator tfs::http::handle_request(const beast::http::requ
 			return make_error_response({.code = 2, .message = "Invalid request body."});
 		}
 
-		const auto& requestBodyObj = requestBody.get_object();
+		const auto& requestBodyObj = normalizeKeys(requestBody.get_object());
 		auto typeField = requestBodyObj.if_contains("type");
 		if (!typeField || !typeField->is_string()) {
 			return make_error_response({.code = 2, .message = "Invalid request type."});

--- a/src/http/success.cpp
+++ b/src/http/success.cpp
@@ -1,0 +1,8 @@
+#include "success.h"
+
+std::pair<beast::http::status, json::value> tfs::http::make_success_response(json::object body)
+{
+	body["Success"] = true;
+
+	return std::make_pair(beast::http::status::ok, std::move(body));
+}

--- a/src/http/success.h
+++ b/src/http/success.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <boost/beast/http/status.hpp>
+#include <boost/json/value.hpp>
+
+namespace beast = boost::beast;
+namespace json = boost::json;
+
+namespace tfs::http {
+
+std::pair<beast::http::status, json::value> make_success_response(json::object body = {});
+
+} // namespace tfs::http


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Add get and post endpoints for the in-client character creation.

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added character creation API with support for character names and sex selection, enforcing per-account character limits.
  * New world information endpoint providing server metadata including name, location, and PvP type.
  * HTTP request routing now supports case-insensitive JSON keys for improved API flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->