### PR TITLE
feat: implement email validation handler

### DIFF
--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(http_SRC
 	${CMAKE_CURRENT_LIST_DIR}/cacheinfo.cpp
+	${CMAKE_CURRENT_LIST_DIR}/check_email.cpp
 	${CMAKE_CURRENT_LIST_DIR}/error.cpp
 	${CMAKE_CURRENT_LIST_DIR}/http.cpp
 	${CMAKE_CURRENT_LIST_DIR}/listener.cpp
@@ -11,6 +12,7 @@ set(http_SRC
 
 set(http_HDR
 	${CMAKE_CURRENT_LIST_DIR}/cacheinfo.h
+	${CMAKE_CURRENT_LIST_DIR}/check_email.h
 	${CMAKE_CURRENT_LIST_DIR}/error.h
 	${CMAKE_CURRENT_LIST_DIR}/http.h
 	${CMAKE_CURRENT_LIST_DIR}/listener.h

--- a/src/http/check_email.cpp
+++ b/src/http/check_email.cpp
@@ -1,0 +1,52 @@
+#include "../otpch.h"
+
+#include "check_email.h"
+
+#include "error.h"
+
+#include <regex>
+
+namespace {
+
+const std::regex email_regex{R"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"};
+
+} // namespace
+
+std::pair<beast::http::status, json::value> tfs::http::handle_check_email(const json::object& body, std::string_view)
+{
+	using namespace std::chrono;
+
+	auto emailField = body.if_contains("email");
+	if (!emailField) {
+		return make_error_response(
+		    {.code = 57, .message = "Please enter your email address!", .additional_fields = {{"EMail", ""}}});
+	}
+
+	if (!emailField->is_string()) {
+		return make_error_response(
+		    {.code = 59,
+		     .message = "This email address has an invalid format. Please enter a correct email address!",
+		     .additional_fields = {{"EMail", *emailField}}});
+	}
+
+	const std::string email{emailField->get_string()};
+	if (email.empty()) {
+		return make_error_response(
+		    {.code = 57, .message = "Please enter your email address!", .additional_fields = {{"EMail", ""}}});
+	}
+
+	if (!std::regex_match(email, email_regex)) {
+		return make_error_response(
+		    {.code = 59,
+		     .message = "This email address has an invalid format. Please enter a correct email address!",
+		     .additional_fields = {{"EMail", *emailField}}});
+	}
+
+	return {
+	    beast::http::status::ok,
+	    {
+	        {"IsValid", true},
+	        {"EMail", *emailField},
+	    },
+	};
+}

--- a/src/http/check_email.h
+++ b/src/http/check_email.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <boost/beast/http/status.hpp>
+#include <boost/json/value.hpp>
+
+namespace beast = boost::beast;
+namespace json = boost::json;
+
+namespace tfs::http {
+
+std::pair<beast::http::status, json::value> handle_check_email(const json::object& body, std::string_view ip);
+
+}

--- a/src/http/error.cpp
+++ b/src/http/error.cpp
@@ -9,8 +9,11 @@ std::pair<beast::http::status, json::value> tfs::http::make_error_response(detai
 	body["errorMessage"] = params.message;
 
 	for (const auto& [key, value] : params.additional_fields) {
+		if (key == "errorCode" || key == "errorMessage") {
+			continue;
+		}
 		body[key] = value;
 	}
 
-	return std::make_pair(beast::http::status::ok, body);
+	return std::make_pair(params.status, body);
 }

--- a/src/http/error.cpp
+++ b/src/http/error.cpp
@@ -8,5 +8,9 @@ std::pair<beast::http::status, json::value> tfs::http::make_error_response(detai
 	body["errorCode"] = params.code;
 	body["errorMessage"] = params.message;
 
+	for (const auto& [key, value] : params.additional_fields) {
+		body[key] = value;
+	}
+
 	return std::make_pair(beast::http::status::ok, body);
 }

--- a/src/http/error.h
+++ b/src/http/error.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "boost/json/object.hpp"
 #include <boost/beast/http/status.hpp>
 #include <boost/json/value.hpp>
 
@@ -16,6 +17,7 @@ struct ErrorResponseParams
 	std::string_view message =
 	    "Internal error. Please try again later or contact customer support if the problem persists.";
 	beast::http::status status = beast::http::status::bad_request;
+	json::object additional_fields = {};
 };
 
 } // namespace detail

--- a/src/http/router.cpp
+++ b/src/http/router.cpp
@@ -3,6 +3,7 @@
 #include "router.h"
 
 #include "cacheinfo.h"
+#include "check_email.h"
 #include "error.h"
 #include "login.h"
 #include "serverinfo.h"
@@ -19,6 +20,9 @@ auto router(std::string_view type, const json::object& body, std::string_view ip
 
 	if (type == "cacheinfo") {
 		return handle_cacheinfo(body, ip);
+	}
+	if (type == "CheckEMail") {
+		return handle_check_email(body, ip);
 	}
 	if (type == "login") {
 		return handle_login(body, ip);

--- a/src/http/tests/CMakeLists.txt
+++ b/src/http/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(tests_SRC
     ${CMAKE_CURRENT_LIST_DIR}/test_cacheinfo.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_check_email.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_login.cpp
     )
 

--- a/src/http/tests/test_check_email.cpp
+++ b/src/http/tests/test_check_email.cpp
@@ -1,0 +1,48 @@
+#define BOOST_TEST_MODULE http_check_email
+
+#include "../../otpch.h"
+
+#include "../check_email.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std::chrono;
+
+struct CheckEmailFixture
+{
+	std::string_view ip = "74.125.224.72";
+};
+
+using status = boost::beast::http::status;
+
+BOOST_FIXTURE_TEST_CASE(test_check_email_missing_field, CheckEmailFixture)
+{
+	auto&& [stat, body] = tfs::http::handle_check_email({{"type", "CheckEMail"}}, ip);
+	BOOST_TEST(stat == status::bad_request);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_check_email_not_string, CheckEmailFixture)
+{
+	auto&& [stat, body] = tfs::http::handle_check_email({{"type", "CheckEMail"}, {"email", 123}}, ip);
+	BOOST_TEST(stat == status::bad_request);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_check_email_empty, CheckEmailFixture)
+{
+	auto&& [stat, body] = tfs::http::handle_check_email({{"type", "CheckEMail"}, {"email", ""}}, ip);
+	BOOST_TEST(stat == status::bad_request);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_check_email_invalid_format, CheckEmailFixture)
+{
+	auto&& [stat, body] = tfs::http::handle_check_email({{"type", "CheckEMail"}, {"email", "not-an-email"}}, ip);
+	BOOST_TEST(stat == status::bad_request);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_check_email_success, CheckEmailFixture)
+{
+	auto&& [stat, body] = tfs::http::handle_check_email({{"type", "CheckEMail"}, {"email", "valid@example.com"}}, ip);
+	BOOST_TEST(stat == status::ok);
+	BOOST_TEST(body.at("IsValid").as_bool() == true);
+	BOOST_TEST(body.at("EMail").get_string() == "valid@example.com");
+}


### PR DESCRIPTION
Adds the HTTP endpoint for validating email addresses when creating accounts in, integrates it into the router, and provides unit tests. It also enhances the error response mechanism to support additional fields in error messages.

Complements #376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email validation endpoint: validates format, returns success with IsValid/EMail or specific error codes for missing/invalid input.

* **Bug Fixes**
  * Error responses now return the configured HTTP status and include extra JSON fields without overwriting errorCode/errorMessage.

* **Tests**
  * Added tests covering missing, wrong-type, empty, invalid-format, and valid email scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->