### PR TITLE
fix(docker): build on Debian trixie and vendor simdutf from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,39 @@
-FROM debian:forky-slim AS build
+FROM debian:trixie-slim AS build
+
+# simdutf is only packaged in Debian testing/unstable (forky/sid), not in trixie
+# (stable), so build it from source and link it statically into the server binary.
+# This keeps the runtime image free of any simdutf dependency.
+ARG SIMDUTF_VERSION=8.2.0
+
 RUN apt-get update -q && apt-get install -yq \
   build-essential \
+  ca-certificates \
   cmake \
-  libboost-iostreams1.83-dev \
-  libboost-json1.83-dev \
-  libboost-system1.83-dev \
+  curl \
+  libboost-iostreams-dev \
+  libboost-json-dev \
+  libboost-system-dev \
   liblua5.4-dev \
   libmariadb-dev \
   libpugixml-dev \
-  libsimdutf-dev \
   libspdlog-dev \
   libssl-dev \
   ninja-build
+
+# Build and install simdutf as a static, position-independent library. The CMake
+# package config it installs is what `find_package(simdutf CONFIG REQUIRED)` consumes.
+RUN curl -fsSL "https://github.com/simdutf/simdutf/archive/refs/tags/v${SIMDUTF_VERSION}.tar.gz" \
+    | tar -xz -C /tmp \
+  && cmake -G Ninja -S "/tmp/simdutf-${SIMDUTF_VERSION}" -B /tmp/simdutf-build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DSIMDUTF_TESTS=OFF \
+    -DSIMDUTF_BENCHMARKS=OFF \
+    -DSIMDUTF_TOOLS=OFF \
+  && cmake --build /tmp/simdutf-build \
+  && cmake --install /tmp/simdutf-build \
+  && rm -rf /tmp/simdutf-build "/tmp/simdutf-${SIMDUTF_VERSION}"
 
 COPY cmake /usr/src/atlas/cmake/
 COPY src /usr/src/atlas/src/
@@ -20,14 +42,13 @@ WORKDIR /usr/src/atlas
 RUN cmake -G Ninja -B build/docker-release -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   && cmake --build build/docker-release
 
-FROM debian:forky-slim
+FROM debian:trixie-slim
 RUN apt-get update -q && apt-get install -yq \
   libboost-iostreams1.83.0 \
   libboost-json1.83.0 \
   liblua5.4-0 \
   libmariadb3 \
   libpugixml1v5 \
-  libsimdutf33 \
   libspdlog1.15 \
   libssl3t64 \
   && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

The Docker image build is currently broken:

```
E: Package 'libboost-iostreams1.83-dev' has no installation candidate
E: Package 'libboost-json1.83-dev' has no installation candidate
E: Unable to locate package libboost-system1.83-dev
```

The image was based on `debian:forky-slim` (Debian **testing**, a rolling target). Forky's default Boost has advanced past 1.83, so the pinned `libboost-*1.83-dev` packages were dropped from the archive index and the build fails. This affects every build against the current forky repositories, not just any single PR.

Naively pinning to stable `debian:trixie-slim` does not work either, because **`simdutf` is only packaged in forky/sid** and is absent from trixie (and bookworm) — which is the reason the image was on forky in the first place.

## Fix

- Switch the base image to `debian:trixie-slim` (stable — frozen package sonames, so the image won't break on its own as testing drifts).
- Build `simdutf` from source as a **static, position-independent** library and link it into the server binary. The CMake package config it installs satisfies `find_package(simdutf CONFIG REQUIRED)`, and the runtime image no longer needs any `simdutf` package.
- Install the Boost build dependencies via the unversioned `libboost-*-dev` metapackages, which resolve to Boost 1.83 on trixie — matching the runtime sonames that stay pinned.

All other dependencies (Boost 1.83, Lua, MariaDB, pugixml, spdlog, OpenSSL) ship in trixie, so their runtime sonames remain pinned and stable.

## Notes

- `SIMDUTF_VERSION` is exposed as a build `ARG` (default `8.2.0`, matching the version Debian packages) so it can be bumped easily.
- The simdutf source build is verified to expose the `SIMDUTF_TESTS`/`SIMDUTF_BENCHMARKS`/`SIMDUTF_TOOLS` options and to install `simdutf-config.cmake` with the `simdutf::simdutf` target.
- Package availability for every build and runtime dependency was confirmed against the trixie archive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build process to compile dependencies from source with improved build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->