### PR TITLE
refactor(docker): build with ubuntu base image, pin version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM debian:forky-slim AS build
+FROM docker.io/ubuntu:resolute-20260421 AS build
 RUN apt-get update -q && apt-get install -yq \
   build-essential \
   cmake \
-  libboost-iostreams1.83-dev \
-  libboost-json1.83-dev \
-  libboost-system1.83-dev \
+  libboost-iostreams1.90-dev \
+  libboost-json1.90-dev \
   liblua5.4-dev \
   libmariadb-dev \
   libpugixml-dev \
@@ -20,14 +19,14 @@ WORKDIR /usr/src/atlas
 RUN cmake -G Ninja -B build/docker-release -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   && cmake --build build/docker-release
 
-FROM debian:forky-slim
+FROM docker.io/ubuntu:resolute-20260421
 RUN apt-get update -q && apt-get install -yq \
-  libboost-iostreams1.83.0 \
-  libboost-json1.83.0 \
+  libboost-iostreams1.90.0 \
+  libboost-json1.90.0 \
   liblua5.4-0 \
   libmariadb3 \
   libpugixml1v5 \
-  libsimdutf33 \
+  libsimdutf31 \
   libspdlog1.15 \
   libssl3t64 \
   && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This pull request updates the Docker build environment by switching the base image from Debian to Ubuntu. This is an alternative to #381 keeping packages installed from the package manager but changing to an already release LTS base image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image and dependency versions to maintain compatibility and security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->