### PR TITLE
Fix: Remove console spam from raids schedule event

### DIFF
--- a/data/scripts/scheduleevents/raids.lua
+++ b/data/scripts/scheduleevents/raids.lua
@@ -7,7 +7,6 @@ local lastRaidEnd = 0
 local event = ScheduleEvent(CHECK_RAIDS_INTERVAL)
 
 event.onTrigger = function()
-	io.write(">> Executing raids event...\n")
 	if running then
 		return true
 	end


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Removed the `io.write(">> Executing raids event...\n")` debug message from the raid schedule event trigger. This prevents the server console from being continuously spammed every time the raid check interval occurs.

**Issues addressed:** None

**How to test:** 
1. Start the server.
2. Wait for the `CHECK_RAIDS_INTERVAL` to occur.
3. Observe that the console no longer prints the `>> Executing raids event...` message.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug console output from raid event execution for cleaner logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->