### PR TITLE
fix: remove automatic config.lua.dist copy on startup

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -96,22 +96,6 @@ void mainLoader(ServiceManager* services)
 
 	printServerVersion();
 
-	// check if config.lua or config.lua.dist exist
-	const std::string& configFile = getString(ConfigManager::CONFIG_FILE);
-	std::ifstream c_test("./" + configFile);
-	if (!c_test.is_open()) {
-		std::ifstream config_lua_dist("./config.lua.dist");
-		if (config_lua_dist.is_open()) {
-			std::cout << ">> copying config.lua.dist to " << configFile << std::endl;
-			std::ofstream config_lua(configFile);
-			config_lua << config_lua_dist.rdbuf();
-			config_lua.close();
-			config_lua_dist.close();
-		}
-	} else {
-		c_test.close();
-	}
-
 	// read global config
 	std::cout << ">> Loading config" << std::endl;
 	if (!ConfigManager::load()) {


### PR DESCRIPTION
Close #370 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified server startup behavior to remove automatic configuration file fallback. The server now requires `config.lua` to exist; it no longer automatically copies from `config.lua.dist` if the configuration file is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->