### PR TITLE
Feat: migrate Spells to smart pointers

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -13,7 +13,7 @@
 #include "spells.h"
 
 extern Game g_game;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Actions* g_actions;
 
 Actions::Actions() : scriptInterface("Action Interface") { scriptInterface.initState(); }
@@ -159,7 +159,10 @@ Action* Actions::getAction(const std::shared_ptr<const Item>& item)
 	}
 
 	// rune items
-	return g_spells->getRuneSpell(item->getID());
+	if (const auto& rune = g_spells->getRuneSpell(item->getID())) {
+		return rune.get();
+	}
+	return nullptr;
 }
 
 ReturnValue Actions::internalUseItem(const std::shared_ptr<Player>& player, const Position& pos, uint8_t index,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -42,7 +42,7 @@ extern Monsters g_monsters;
 extern MoveEvents* g_moveEvents;
 extern Scheduler g_scheduler;
 extern Scripts* g_scripts;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern TalkActions* g_talkActions;
 extern Vocations g_vocations;
 extern std::unique_ptr<Weapons> g_weapons;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -17,7 +17,7 @@
 class Spells;
 
 extern Game g_game;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Vocations g_vocations;
 
 Items Item::items;

--- a/src/lua/api.cpp
+++ b/src/lua/api.cpp
@@ -15,7 +15,7 @@
 #include <string>
 
 extern Game g_game;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 
 namespace tfs::lua {
 
@@ -301,7 +301,6 @@ void pushSpell(lua_State* L, const Spell& spell)
 	setField(L, "mlevel", spell.getMagicLevel());
 	setField(L, "mana", spell.getMana());
 	setField(L, "manapercent", spell.getManaPercent());
-	setMetatable(L, -1, "Spell");
 }
 
 void pushPosition(lua_State* L, const Position& position, int32_t stackpos /* = 0*/)

--- a/src/lua/modules/game.cpp
+++ b/src/lua/modules/game.cpp
@@ -17,7 +17,7 @@
 
 extern Game g_game;
 extern LuaEnvironment g_luaEnvironment;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Monsters g_monsters;
 extern Scripts* g_scripts;
 extern Dispatcher g_dispatcher;
@@ -289,7 +289,7 @@ int luaGameGetRuneSpells(lua_State* L)
 
 	int index = 0;
 	for (const auto& spell : runeSpells | std::views::values) {
-		tfs::lua::pushUserdata<const Spell>(L, &spell);
+		tfs::lua::pushSharedPtr<Spell>(L, spell);
 		tfs::lua::setMetatable(L, -1, "Spell");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -306,7 +306,7 @@ int luaGameGetInstantSpells(lua_State* L)
 
 	int index = 0;
 	for (const auto& spell : instantSpells | std::views::values) {
-		tfs::lua::pushUserdata<const Spell>(L, &spell);
+		tfs::lua::pushSharedPtr<Spell>(L, spell);
 		tfs::lua::setMetatable(L, -1, "Spell");
 		lua_rawseti(L, -2, ++index);
 	}

--- a/src/lua/modules/monsters.cpp
+++ b/src/lua/modules/monsters.cpp
@@ -890,7 +890,12 @@ int luaMonsterTypeGetAttackList(lua_State* L)
 		tfs::lua::setField(L, "maxCombatValue", spellBlock.maxCombatValue);
 		tfs::lua::setField(L, "range", spellBlock.range);
 		tfs::lua::setField(L, "speed", spellBlock.speed.count());
-		tfs::lua::pushUserdata(L, static_cast<CombatSpell*>(spellBlock.spell));
+		const auto spell = spellBlock.spell.lock();
+		if (const auto& combatSpell = std::dynamic_pointer_cast<CombatSpell>(spell)) {
+			tfs::lua::pushUserdata(L, combatSpell.get());
+		} else {
+			lua_pushnil(L);
+		}
 		lua_setfield(L, -2, "spell");
 
 		lua_rawseti(L, -2, ++index);
@@ -943,7 +948,12 @@ int luaMonsterTypeGetDefenseList(lua_State* L)
 		tfs::lua::setField(L, "maxCombatValue", spellBlock.maxCombatValue);
 		tfs::lua::setField(L, "range", spellBlock.range);
 		tfs::lua::setField(L, "speed", spellBlock.speed.count());
-		tfs::lua::pushUserdata(L, static_cast<CombatSpell*>(spellBlock.spell));
+		const auto spell = spellBlock.spell.lock();
+		if (const auto& combatSpell = std::dynamic_pointer_cast<CombatSpell>(spell)) {
+			tfs::lua::pushUserdata(L, combatSpell.get());
+		} else {
+			lua_pushnil(L);
+		}
 		lua_setfield(L, -2, "spell");
 
 		lua_rawseti(L, -2, ++index);

--- a/src/lua/modules/player.cpp
+++ b/src/lua/modules/player.cpp
@@ -17,7 +17,7 @@
 
 extern Chat g_chat;
 extern Game g_game;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Vocations g_vocations;
 
 namespace {
@@ -1680,7 +1680,7 @@ int luaPlayerCanLearnSpell(lua_State* L)
 	}
 
 	const std::string& spellName = tfs::lua::getString(L, 2);
-	InstantSpell* spell = g_spells->getInstantSpellByName(spellName);
+	const auto& spell = g_spells->getInstantSpellByName(spellName);
 	if (!spell) {
 		tfs::lua::reportError(L, "Spell \"" + spellName + "\" not found");
 		tfs::lua::pushBoolean(L, false);
@@ -1993,18 +1993,18 @@ int luaPlayerGetContainerIndex(lua_State* L)
 int luaPlayerGetRuneSpells(lua_State* L)
 {
 	// player:getRuneSpells()
-	Player* player = tfs::lua::getUserdata<Player>(L, 1);
+	const auto& player = tfs::lua::getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	auto runeSpells = g_spells->getRuneSpells();
+	const auto& runeSpells = g_spells->getRuneSpells();
 
-	std::vector<RuneSpell*> spells;
-	for (auto& spell : runeSpells | std::views::values) {
-		if (spell.canUse(player)) {
-			spells.push_back(&spell);
+	std::vector<std::shared_ptr<RuneSpell>> spells;
+	for (const auto& spell : runeSpells | std::views::values) {
+		if (spell->canUse(player.get())) {
+			spells.push_back(spell);
 		}
 	}
 
@@ -2012,7 +2012,7 @@ int luaPlayerGetRuneSpells(lua_State* L)
 
 	int index = 0;
 	for (auto& spell : spells) {
-		tfs::lua::pushUserdata<Spell>(L, spell);
+		tfs::lua::pushSharedPtr<Spell>(L, spell);
 		tfs::lua::setMetatable(L, -1, "Spell");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -2029,10 +2029,10 @@ int luaPlayerGetInstantSpells(lua_State* L)
 		return 1;
 	}
 
-	std::vector<const InstantSpell*> spells;
-	for (auto&& spell : g_spells->getInstantSpells() | std::views::values | std::views::as_const) {
-		if (spell.canCast(player)) {
-			spells.push_back(&spell);
+	std::vector<std::shared_ptr<InstantSpell>> spells;
+	for (const auto& spell : g_spells->getInstantSpells() | std::views::values) {
+		if (spell->canCast(player)) {
+			spells.push_back(spell);
 		}
 	}
 
@@ -2050,7 +2050,6 @@ int luaPlayerGetInstantSpells(lua_State* L)
 		tfs::lua::setField(L, "manapercent", spell->getManaPercent());
 		tfs::lua::setField(L, "params", spell->getHasParam());
 
-		tfs::lua::setMetatable(L, -1, "Spell");
 		lua_rawseti(L, -2, ++index);
 	}
 	return 1;
@@ -2060,9 +2059,10 @@ int luaPlayerCanCast(lua_State* L)
 {
 	// player:canCast(spell)
 	const auto& player = tfs::lua::getSharedPtr<Player>(L, 1);
-	InstantSpell* spell = tfs::lua::getUserdata<InstantSpell>(L, 2);
-	if (player && spell) {
-		tfs::lua::pushBoolean(L, spell->canCast(player));
+	std::shared_ptr<Spell> spell = lua_isuserdata(L, 2) ? tfs::lua::getSharedPtr<Spell>(L, 2) : nullptr;
+	const auto& instant = std::dynamic_pointer_cast<InstantSpell>(spell);
+	if (player && instant) {
+		tfs::lua::pushBoolean(L, instant->canCast(player));
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/modules/spell.cpp
+++ b/src/lua/modules/spell.cpp
@@ -8,7 +8,7 @@
 #include "../register.h"
 #include "../script.h"
 
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Vocations g_vocations;
 
 namespace {
@@ -27,10 +27,10 @@ int luaSpellCreate(lua_State* L)
 
 	if (tfs::lua::isNumber(L, 2)) {
 		uint16_t id = tfs::lua::getNumber<uint16_t>(L, 2);
-		RuneSpell* rune = g_spells->getRuneSpell(id);
+		const auto& rune = g_spells->getRuneSpell(id);
 
 		if (rune) {
-			tfs::lua::pushUserdata<Spell>(L, rune);
+			tfs::lua::pushSharedPtr<Spell>(L, rune);
 			tfs::lua::setMetatable(L, -1, "Spell");
 			return 1;
 		}
@@ -38,21 +38,21 @@ int luaSpellCreate(lua_State* L)
 		spellType = static_cast<SpellType_t>(id);
 	} else if (lua_isstring(L, 2)) {
 		std::string arg = tfs::lua::getString(L, 2);
-		InstantSpell* instant = g_spells->getInstantSpellByName(arg);
+		auto instant = g_spells->getInstantSpellByName(arg);
 		if (instant) {
-			tfs::lua::pushUserdata<Spell>(L, instant);
+			tfs::lua::pushSharedPtr<Spell>(L, instant);
 			tfs::lua::setMetatable(L, -1, "Spell");
 			return 1;
 		}
 		instant = g_spells->getInstantSpell(arg);
 		if (instant) {
-			tfs::lua::pushUserdata<Spell>(L, instant);
+			tfs::lua::pushSharedPtr<Spell>(L, instant);
 			tfs::lua::setMetatable(L, -1, "Spell");
 			return 1;
 		}
-		RuneSpell* rune = g_spells->getRuneSpellByName(arg);
+		const auto& rune = g_spells->getRuneSpellByName(arg);
 		if (rune) {
-			tfs::lua::pushUserdata<Spell>(L, rune);
+			tfs::lua::pushSharedPtr<Spell>(L, rune);
 			tfs::lua::setMetatable(L, -1, "Spell");
 			return 1;
 		}
@@ -66,16 +66,16 @@ int luaSpellCreate(lua_State* L)
 	}
 
 	if (spellType == SPELL_INSTANT) {
-		InstantSpell* spell = new InstantSpell(tfs::lua::getScriptEnv()->getScriptInterface());
+		auto spell = std::make_shared<InstantSpell>(tfs::lua::getScriptEnv()->getScriptInterface());
 		spell->fromLua = true;
-		tfs::lua::pushUserdata<Spell>(L, spell);
+		tfs::lua::pushSharedPtr<Spell>(L, spell);
 		tfs::lua::setMetatable(L, -1, "Spell");
 		spell->spellType = SPELL_INSTANT;
 		return 1;
 	} else if (spellType == SPELL_RUNE) {
-		RuneSpell* spell = new RuneSpell(tfs::lua::getScriptEnv()->getScriptInterface());
+		auto spell = std::make_shared<RuneSpell>(tfs::lua::getScriptEnv()->getScriptInterface());
 		spell->fromLua = true;
-		tfs::lua::pushUserdata<Spell>(L, spell);
+		tfs::lua::pushSharedPtr<Spell>(L, spell);
 		tfs::lua::setMetatable(L, -1, "Spell");
 		spell->spellType = SPELL_RUNE;
 		return 1;
@@ -88,16 +88,16 @@ int luaSpellCreate(lua_State* L)
 int luaSpellOnCastSpell(lua_State* L)
 {
 	// spell:onCastSpell(callback)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
-		if (InstantSpell* instant = spell->getInstantSpell()) {
+		if (const auto& instant = std::dynamic_pointer_cast<InstantSpell>(spell)) {
 			if (!instant->loadCallback()) {
 				tfs::lua::pushBoolean(L, false);
 				return 1;
 			}
 			instant->scripted = true;
 			tfs::lua::pushBoolean(L, true);
-		} else if (RuneSpell* rune = spell->getRuneSpell()) {
+		} else if (const auto& rune = std::dynamic_pointer_cast<RuneSpell>(spell)) {
 			if (!rune->loadCallback()) {
 				tfs::lua::pushBoolean(L, false);
 				return 1;
@@ -114,16 +114,16 @@ int luaSpellOnCastSpell(lua_State* L)
 int luaSpellRegister(lua_State* L)
 {
 	// spell:register()
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
-		if (InstantSpell* instant = spell->getInstantSpell()) {
+		if (const auto& instant = std::dynamic_pointer_cast<InstantSpell>(spell)) {
 			if (!instant->isScripted()) {
 				tfs::lua::pushBoolean(L, false);
 				return 1;
 			}
 
-			tfs::lua::pushBoolean(L, g_spells->registerInstantLuaEvent(std::unique_ptr<InstantSpell>{instant}));
-		} else if (RuneSpell* rune = spell->getRuneSpell()) {
+			tfs::lua::pushBoolean(L, g_spells->registerInstantLuaEvent(instant));
+		} else if (const auto& rune = std::dynamic_pointer_cast<RuneSpell>(spell)) {
 			if (rune->getMagicLevel() != 0 || rune->getLevel() != 0) {
 				// Change information in the ItemType to get accurate description
 				ItemType& iType = Item::items.getItemType(rune->getRuneItemId());
@@ -138,7 +138,7 @@ int luaSpellRegister(lua_State* L)
 				return 1;
 			}
 
-			tfs::lua::pushBoolean(L, g_spells->registerRuneLuaEvent(std::unique_ptr<RuneSpell>{rune}));
+			tfs::lua::pushBoolean(L, g_spells->registerRuneLuaEvent(rune));
 		}
 	} else {
 		lua_pushnil(L);
@@ -149,7 +149,7 @@ int luaSpellRegister(lua_State* L)
 int luaSpellName(lua_State* L)
 {
 	// spell:name(name)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushString(L, spell->getName());
@@ -166,7 +166,7 @@ int luaSpellName(lua_State* L)
 int luaSpellId(lua_State* L)
 {
 	// spell:id(id)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getId());
@@ -183,7 +183,7 @@ int luaSpellId(lua_State* L)
 int luaSpellGroup(lua_State* L)
 {
 	// spell:group(primaryGroup[, secondaryGroup])
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getGroup());
@@ -251,7 +251,7 @@ int luaSpellGroup(lua_State* L)
 int luaSpellCooldown(lua_State* L)
 {
 	// spell:cooldown(cooldown)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getCooldown().count());
@@ -268,7 +268,7 @@ int luaSpellCooldown(lua_State* L)
 int luaSpellGroupCooldown(lua_State* L)
 {
 	// spell:groupCooldown(primaryGroupCd[, secondaryGroupCd])
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getGroupCooldown().count());
@@ -291,7 +291,7 @@ int luaSpellGroupCooldown(lua_State* L)
 int luaSpellLevel(lua_State* L)
 {
 	// spell:level(lvl)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getLevel());
@@ -308,7 +308,7 @@ int luaSpellLevel(lua_State* L)
 int luaSpellMagicLevel(lua_State* L)
 {
 	// spell:magicLevel(lvl)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getMagicLevel());
@@ -325,7 +325,7 @@ int luaSpellMagicLevel(lua_State* L)
 int luaSpellMana(lua_State* L)
 {
 	// spell:mana(mana)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getMana());
@@ -342,7 +342,7 @@ int luaSpellMana(lua_State* L)
 int luaSpellManaPercent(lua_State* L)
 {
 	// spell:manaPercent(percent)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getManaPercent());
@@ -359,7 +359,7 @@ int luaSpellManaPercent(lua_State* L)
 int luaSpellSoul(lua_State* L)
 {
 	// spell:soul(soul)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getSoulCost());
@@ -376,7 +376,7 @@ int luaSpellSoul(lua_State* L)
 int luaSpellRange(lua_State* L)
 {
 	// spell:range(range)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getRange());
@@ -393,7 +393,7 @@ int luaSpellRange(lua_State* L)
 int luaSpellPremium(lua_State* L)
 {
 	// spell:isPremium(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->isPremium());
@@ -410,7 +410,7 @@ int luaSpellPremium(lua_State* L)
 int luaSpellEnabled(lua_State* L)
 {
 	// spell:isEnabled(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->isEnabled());
@@ -427,7 +427,7 @@ int luaSpellEnabled(lua_State* L)
 int luaSpellNeedTarget(lua_State* L)
 {
 	// spell:needTarget(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getNeedTarget());
@@ -444,7 +444,7 @@ int luaSpellNeedTarget(lua_State* L)
 int luaSpellNeedWeapon(lua_State* L)
 {
 	// spell:needWeapon(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getNeedWeapon());
@@ -461,7 +461,7 @@ int luaSpellNeedWeapon(lua_State* L)
 int luaSpellNeedLearn(lua_State* L)
 {
 	// spell:needLearn(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getNeedLearn());
@@ -478,7 +478,7 @@ int luaSpellNeedLearn(lua_State* L)
 int luaSpellSelfTarget(lua_State* L)
 {
 	// spell:isSelfTarget(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getSelfTarget());
@@ -495,7 +495,7 @@ int luaSpellSelfTarget(lua_State* L)
 int luaSpellBlocking(lua_State* L)
 {
 	// spell:isBlocking(blockingSolid, blockingCreature)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getBlockingSolid());
@@ -515,7 +515,7 @@ int luaSpellBlocking(lua_State* L)
 int luaSpellAggressive(lua_State* L)
 {
 	// spell:isAggressive(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getAggressive());
@@ -532,7 +532,7 @@ int luaSpellAggressive(lua_State* L)
 int luaSpellPzLock(lua_State* L)
 {
 	// spell:isPzLock(bool)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getPzLock());
@@ -549,7 +549,7 @@ int luaSpellPzLock(lua_State* L)
 int luaSpellVocation(lua_State* L)
 {
 	// spell:vocation(vocation)
-	Spell* spell = tfs::lua::getUserdata<Spell>(L, 1);
+	const auto& spell = tfs::lua::getSharedPtr<Spell>(L, 1);
 	if (!spell) {
 		lua_pushnil(L);
 		return 1;
@@ -579,8 +579,8 @@ int luaSpellVocation(lua_State* L)
 int luaSpellWords(lua_State* L)
 {
 	// spell:words(words[, separator = ""])
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	InstantSpell* spell = spellBase ? spellBase->getInstantSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getInstantSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushString(L, spell->getWords());
@@ -605,8 +605,8 @@ int luaSpellWords(lua_State* L)
 int luaSpellNeedDirection(lua_State* L)
 {
 	// spell:needDirection(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	InstantSpell* spell = spellBase ? spellBase->getInstantSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getInstantSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getNeedDirection());
@@ -624,8 +624,8 @@ int luaSpellNeedDirection(lua_State* L)
 int luaSpellHasParams(lua_State* L)
 {
 	// spell:hasParams(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	InstantSpell* spell = spellBase ? spellBase->getInstantSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getInstantSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getHasParam());
@@ -643,8 +643,8 @@ int luaSpellHasParams(lua_State* L)
 int luaSpellHasPlayerNameParam(lua_State* L)
 {
 	// spell:hasPlayerNameParam(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	InstantSpell* spell = spellBase ? spellBase->getInstantSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getInstantSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getHasPlayerNameParam());
@@ -662,8 +662,8 @@ int luaSpellHasPlayerNameParam(lua_State* L)
 int luaSpellNeedCasterTargetOrDirection(lua_State* L)
 {
 	// spell:needCasterTargetOrDirection(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	InstantSpell* spell = spellBase ? spellBase->getInstantSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getInstantSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getNeedCasterTargetOrDirection());
@@ -681,8 +681,8 @@ int luaSpellNeedCasterTargetOrDirection(lua_State* L)
 int luaSpellIsBlockingWalls(lua_State* L)
 {
 	// spell:blockWalls(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	InstantSpell* spell = spellBase ? spellBase->getInstantSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getInstantSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getBlockWalls());
@@ -700,8 +700,8 @@ int luaSpellIsBlockingWalls(lua_State* L)
 int luaSpellRuneLevel(lua_State* L)
 {
 	// spell:runeLevel(level)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* spell = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getRuneSpell() : nullptr;
 	int32_t level = tfs::lua::getNumber<int32_t>(L, 2);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
@@ -720,8 +720,8 @@ int luaSpellRuneLevel(lua_State* L)
 int luaSpellRuneMagicLevel(lua_State* L)
 {
 	// spell:runeMagicLevel(magLevel)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* spell = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getRuneSpell() : nullptr;
 	int32_t magLevel = tfs::lua::getNumber<int32_t>(L, 2);
 	if (spell) {
 		if (lua_gettop(L) == 1) {
@@ -740,8 +740,8 @@ int luaSpellRuneMagicLevel(lua_State* L)
 int luaSpellRuneId(lua_State* L)
 {
 	// spell:runeId(id)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* rune = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto rune = spellBase ? spellBase->getRuneSpell() : nullptr;
 	if (rune) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, rune->getRuneItemId());
@@ -759,8 +759,8 @@ int luaSpellRuneId(lua_State* L)
 int luaSpellCharges(lua_State* L)
 {
 	// spell:charges(charges)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* spell = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getRuneSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushNumber(L, spell->getCharges());
@@ -778,8 +778,8 @@ int luaSpellCharges(lua_State* L)
 int luaSpellAllowFarUse(lua_State* L)
 {
 	// spell:allowFarUse(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* spell = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getRuneSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getAllowFarUse());
@@ -797,8 +797,8 @@ int luaSpellAllowFarUse(lua_State* L)
 int luaSpellBlockWalls(lua_State* L)
 {
 	// spell:blockWalls(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* spell = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getRuneSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getCheckLineOfSight());
@@ -816,8 +816,8 @@ int luaSpellBlockWalls(lua_State* L)
 int luaSpellCheckFloor(lua_State* L)
 {
 	// spell:checkFloor(bool)
-	Spell* spellBase = tfs::lua::getUserdata<Spell>(L, 1);
-	RuneSpell* spell = spellBase ? spellBase->getRuneSpell() : nullptr;
+	const auto& spellBase = tfs::lua::getSharedPtr<Spell>(L, 1);
+	auto spell = spellBase ? spellBase->getRuneSpell() : nullptr;
 	if (spell) {
 		if (lua_gettop(L) == 1) {
 			tfs::lua::pushBoolean(L, spell->getCheckFloor());
@@ -840,6 +840,7 @@ void tfs::lua::registerSpell(LuaScriptInterface& lsi)
 
 	lsi.registerClass("Spell", "", luaSpellCreate);
 	lsi.registerMetaMethod("Spell", "__eq", tfs::lua::luaUserdataCompare);
+	lsi.registerMetaMethod("Spell", "__gc", tfs::lua::luaSharedPtrDelete<Spell>);
 
 	lsi.registerMethod("Spell", "onCastSpell", luaSpellOnCastSpell);
 	lsi.registerMethod("Spell", "register", luaSpellRegister);

--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -26,7 +26,7 @@ extern Chat g_chat;
 extern Game g_game;
 extern Monsters g_monsters;
 extern Vocations g_vocations;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Actions* g_actions;
 extern TalkActions* g_talkActions;
 extern Scheduler g_scheduler;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -776,6 +776,11 @@ void Monster::onAttacking(std::chrono::milliseconds interval)
 			break;
 		}
 
+		auto spell = spellBlock.spell.lock();
+		if (!spell) {
+			continue;
+		}
+
 		bool inRange = false;
 
 		if (canUseSpell(position, targetPosition, spellBlock, interval, inRange, resetTicks)) {
@@ -787,7 +792,7 @@ void Monster::onAttacking(std::chrono::milliseconds interval)
 
 				minCombatValue = spellBlock.minCombatValue;
 				maxCombatValue = spellBlock.maxCombatValue;
-				spellBlock.spell->castSpell(asMonster(), attackedCreature);
+				spell->castSpell(asMonster(), attackedCreature);
 
 				if (spellBlock.isMelee) {
 					lastMeleeAttack = std::chrono::steady_clock::now();
@@ -914,6 +919,11 @@ void Monster::onThinkDefense(std::chrono::milliseconds interval)
 	defenseTicks += interval;
 
 	for (const spellBlock_t& spellBlock : mType->info.defenseSpells) {
+		auto spell = spellBlock.spell.lock();
+		if (!spell) {
+			continue;
+		}
+
 		if (spellBlock.speed > defenseTicks) {
 			resetTicks = false;
 			continue;
@@ -927,7 +937,7 @@ void Monster::onThinkDefense(std::chrono::milliseconds interval)
 		if ((spellBlock.chance >= static_cast<uint32_t>(uniform_random(1, 100)))) {
 			minCombatValue = spellBlock.minCombatValue;
 			maxCombatValue = spellBlock.maxCombatValue;
-			spellBlock.spell->castSpell(asMonster(), asMonster());
+			spell->castSpell(asMonster(), asMonster());
 		}
 	}
 

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -14,16 +14,9 @@
 #include "weapons.h"
 
 extern Game g_game;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 
 Monsters g_monsters;
-
-spellBlock_t::~spellBlock_t()
-{
-	if (combatSpell) {
-		delete spell;
-	}
-}
 
 void MonsterType::loadLoot(MonsterType* monsterType, LootBlock lootBlock)
 {
@@ -171,7 +164,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 		return true;
 	}
 
-	CombatSpell* combatSpell = nullptr;
+	std::shared_ptr<CombatSpell> combatSpell = nullptr;
 	bool needTarget = false;
 	bool needDirection = false;
 
@@ -184,7 +177,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 			needTarget = attr.as_bool();
 		}
 
-		std::unique_ptr<CombatSpell> combatSpellPtr(new CombatSpell(nullptr, needTarget, needDirection));
+		auto combatSpellPtr = std::make_shared<CombatSpell>(nullptr, needTarget, needDirection);
 		if (!combatSpellPtr->loadScript("data/" + std::string{g_spells->getScriptBaseName()} + "/scripts/" +
 		                                scriptName)) {
 			return false;
@@ -194,7 +187,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 			return false;
 		}
 
-		combatSpell = combatSpellPtr.release();
+		combatSpell = combatSpellPtr;
 		combatSpell->getCombat()->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue,
 		                                                0);
 	} else {
@@ -514,7 +507,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 		}
 
 		combat->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue, 0);
-		combatSpell = new CombatSpell(combat, needTarget, needDirection);
+		combatSpell = std::make_shared<CombatSpell>(combat, needTarget, needDirection);
 
 		for (auto attributeNode : node.children()) {
 			if ((attr = attributeNode.attribute("key"))) {
@@ -551,6 +544,7 @@ bool Monsters::deserializeSpell(const pugi::xml_node& node, spellBlock_t& sb, co
 
 	sb.spell = combatSpell;
 	if (combatSpell) {
+		sb.ownedSpell = combatSpell;
 		sb.combatSpell = true;
 	}
 	return true;
@@ -587,15 +581,15 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 		sb.minCombatValue = value;
 	}
 
-	sb.spell = g_spells->getSpellByName(spell->name);
-	if (sb.spell) {
+	if (auto spellPtr = g_spells->getSpellByName(spell->name)) {
+		sb.spell = spellPtr;
 		return true;
 	}
 
-	CombatSpell* combatSpell = nullptr;
+	std::shared_ptr<CombatSpell> combatSpell = nullptr;
 
 	if (spell->isScripted) {
-		std::unique_ptr<CombatSpell> combatSpellPtr(new CombatSpell(nullptr, spell->needTarget, spell->needDirection));
+		auto combatSpellPtr = std::make_shared<CombatSpell>(nullptr, spell->needTarget, spell->needDirection);
 		if (!combatSpellPtr->loadScript("data/" + std::string{g_spells->getScriptBaseName()} + "/scripts/" +
 		                                spell->scriptName)) {
 			std::cout << "cannot find file" << std::endl;
@@ -606,7 +600,7 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			return false;
 		}
 
-		combatSpell = combatSpellPtr.release();
+		combatSpell = combatSpellPtr;
 		combatSpell->getCombat()->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue,
 		                                                0);
 	} else {
@@ -787,11 +781,12 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 		}
 
 		combat->setPlayerCombatValues(COMBAT_FORMULA_DAMAGE, sb.minCombatValue, 0, sb.maxCombatValue, 0);
-		combatSpell = new CombatSpell(combat, spell->needTarget, spell->needDirection);
+		combatSpell = std::make_shared<CombatSpell>(combat, spell->needTarget, spell->needDirection);
 	}
 
 	sb.spell = combatSpell;
 	if (combatSpell) {
+		sb.ownedSpell = combatSpell;
 		sb.combatSpell = true;
 	}
 	return true;

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -65,23 +65,14 @@ class BaseSpell;
 struct spellBlock_t
 {
 	constexpr spellBlock_t() = default;
-	~spellBlock_t();
+	~spellBlock_t() = default;
 	spellBlock_t(const spellBlock_t& other) = delete;
 	spellBlock_t& operator=(const spellBlock_t& other) = delete;
-	spellBlock_t(spellBlock_t&& other) :
-	    spell(other.spell),
-	    chance(other.chance),
-	    speed(other.speed),
-	    range(other.range),
-	    minCombatValue(other.minCombatValue),
-	    maxCombatValue(other.maxCombatValue),
-	    combatSpell(other.combatSpell),
-	    isMelee(other.isMelee)
-	{
-		other.spell = nullptr;
-	}
+	spellBlock_t(spellBlock_t&& other) noexcept = default;
+	spellBlock_t& operator=(spellBlock_t&& other) noexcept = default;
 
-	BaseSpell* spell = nullptr;
+	std::weak_ptr<BaseSpell> spell;
+	std::shared_ptr<BaseSpell> ownedSpell = nullptr;
 	uint32_t chance = 100;
 	std::chrono::milliseconds speed = 2000ms;
 	uint32_t range = 0;

--- a/src/scriptmanager.cpp
+++ b/src/scriptmanager.cpp
@@ -16,7 +16,7 @@
 
 Actions* g_actions = nullptr;
 Chat g_chat;
-Spells* g_spells = nullptr;
+std::unique_ptr<Spells> g_spells = nullptr;
 TalkActions* g_talkActions = nullptr;
 MoveEvents* g_moveEvents = nullptr;
 std::unique_ptr<Weapons> g_weapons = nullptr;
@@ -27,7 +27,7 @@ extern LuaEnvironment g_luaEnvironment;
 ScriptingManager::~ScriptingManager()
 {
 	g_weapons.reset();
-	delete g_spells;
+	g_spells.reset();
 	delete g_actions;
 	delete g_talkActions;
 	delete g_moveEvents;
@@ -50,7 +50,7 @@ bool ScriptingManager::loadScriptSystems()
 	g_weapons = std::make_unique<Weapons>();
 	g_weapons->loadDefaults();
 
-	g_spells = new Spells();
+	g_spells = std::make_unique<Spells>();
 	if (!g_spells->loadFromXml()) {
 		std::cout << "> ERROR: Unable to load spells!" << std::endl;
 		return false;

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -29,7 +29,7 @@ extern Actions* g_actions;
 extern Monsters g_monsters;
 extern TalkActions* g_talkActions;
 extern MoveEvents* g_moveEvents;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern std::unique_ptr<Weapons> g_weapons;
 extern Game g_game;
 extern Chat g_chat;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -18,7 +18,7 @@
 extern Game g_game;
 extern LuaEnvironment g_luaEnvironment;
 extern Monsters g_monsters;
-extern Spells* g_spells;
+extern std::unique_ptr<Spells> g_spells;
 extern Vocations g_vocations;
 
 Spells::Spells() { scriptInterface.initState(); }
@@ -32,7 +32,7 @@ TalkActionResult_t Spells::playerSaySpell(const std::shared_ptr<Player>& player,
 	// strip trailing spaces
 	boost::algorithm::trim(str_words);
 
-	InstantSpell* instantSpell = getInstantSpell(str_words);
+	const auto& instantSpell = getInstantSpell(str_words);
 	if (!instantSpell) {
 		return TALKACTION_CONTINUE;
 	}
@@ -82,7 +82,7 @@ TalkActionResult_t Spells::playerSaySpell(const std::shared_ptr<Player>& player,
 void Spells::clearMaps(bool fromLua)
 {
 	for (auto instant = instants.begin(); instant != instants.end();) {
-		if (fromLua == instant->second.fromLua) {
+		if (fromLua == instant->second->fromLua) {
 			instant = instants.erase(instant);
 		} else {
 			++instant;
@@ -90,7 +90,7 @@ void Spells::clearMaps(bool fromLua)
 	}
 
 	for (auto rune = runes.begin(); rune != runes.end();) {
-		if (fromLua == rune->second.fromLua) {
+		if (fromLua == rune->second->fromLua) {
 			rune = runes.erase(rune);
 		} else {
 			++rune;
@@ -125,8 +125,9 @@ bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 	}
 
 	if (InstantSpell* instantPtr = spell->getInstantSpell()) {
-		std::unique_ptr<InstantSpell> instant{instantPtr};
-		auto result = instants.emplace(instant->getWords(), std::move(*instant));
+		event.release();
+		std::shared_ptr<InstantSpell> instant{instantPtr};
+		auto result = instants.emplace(instant->getWords(), instant);
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerEvent] Duplicate registered instant spell with words: "
 			          << instant->getWords() << std::endl;
@@ -135,8 +136,9 @@ bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 	}
 
 	if (RuneSpell* runePtr = spell->getRuneSpell()) {
-		std::unique_ptr<RuneSpell> rune{runePtr};
-		auto result = runes.emplace(rune->getRuneItemId(), std::move(*rune));
+		event.release();
+		std::shared_ptr<RuneSpell> rune{runePtr};
+		auto result = runes.emplace(rune->getRuneItemId(), rune);
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerEvent] Duplicate registered rune with id: "
 			          << rune->getRuneItemId() << std::endl;
@@ -147,14 +149,14 @@ bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 	return false;
 }
 
-bool Spells::registerInstantLuaEvent(std::unique_ptr<InstantSpell> instant)
+bool Spells::registerInstantLuaEvent(std::shared_ptr<InstantSpell> instant)
 {
 	if (!instant) {
 		return false;
 	}
 
 	const auto words = instant->getWords();
-	auto result = instants.emplace(instant->getWords(), std::move(*instant));
+	auto result = instants.emplace(instant->getWords(), instant);
 	if (!result.second) {
 		std::cout << "[Warning - Spells::registerInstantLuaEvent] Duplicate registered instant spell with words: "
 		          << words << std::endl;
@@ -163,14 +165,14 @@ bool Spells::registerInstantLuaEvent(std::unique_ptr<InstantSpell> instant)
 	return result.second;
 }
 
-bool Spells::registerRuneLuaEvent(std::unique_ptr<RuneSpell> rune)
+bool Spells::registerRuneLuaEvent(std::shared_ptr<RuneSpell> rune)
 {
 	if (!rune) {
 		return false;
 	}
 
 	const auto id = rune->getRuneItemId();
-	auto result = runes.emplace(rune->getRuneItemId(), std::move(*rune));
+	auto result = runes.emplace(rune->getRuneItemId(), rune);
 	if (!result.second) {
 		std::cout << "[Warning - Spells::registerRuneLuaEvent] Duplicate registered rune with id: " << id << std::endl;
 	}
@@ -178,49 +180,49 @@ bool Spells::registerRuneLuaEvent(std::unique_ptr<RuneSpell> rune)
 	return result.second;
 }
 
-Spell* Spells::getSpellByName(const std::string& name)
+std::shared_ptr<Spell> Spells::getSpellByName(const std::string& name)
 {
-	Spell* spell = getRuneSpellByName(name);
+	std::shared_ptr<Spell> spell = getRuneSpellByName(name);
 	if (!spell) {
 		spell = getInstantSpellByName(name);
 	}
 	return spell;
 }
 
-RuneSpell* Spells::getRuneSpell(uint16_t id)
+std::shared_ptr<RuneSpell> Spells::getRuneSpell(uint16_t id)
 {
 	auto it = runes.find(id);
 	if (it == runes.end()) {
-		for (auto&& rune : runes | std::views::values) {
-			if (rune.getId() == id) {
-				return &rune;
+		for (const auto& rune : runes | std::views::values) {
+			if (rune->getId() == id) {
+				return rune;
 			}
 		}
 		return nullptr;
 	}
-	return &it->second;
+	return it->second;
 }
 
-RuneSpell* Spells::getRuneSpellByName(const std::string& name)
+std::shared_ptr<RuneSpell> Spells::getRuneSpellByName(const std::string& name)
 {
-	for (auto&& rune : runes | std::views::values) {
-		if (boost::iequals(rune.getName(), name)) {
-			return &rune;
+	for (const auto& rune : runes | std::views::values) {
+		if (boost::iequals(rune->getName(), name)) {
+			return rune;
 		}
 	}
 	return nullptr;
 }
 
-InstantSpell* Spells::getInstantSpell(const std::string& words)
+std::shared_ptr<InstantSpell> Spells::getInstantSpell(const std::string& words)
 {
-	InstantSpell* result = nullptr;
+	std::shared_ptr<InstantSpell> result = nullptr;
 
-	for (auto&& spell : instants | std::views::values) {
-		const std::string& instantSpellWords = spell.getWords();
+	for (const auto& spell : instants | std::views::values) {
+		const std::string& instantSpellWords = spell->getWords();
 		size_t spellLen = instantSpellWords.length();
 		if (boost::istarts_with(words, instantSpellWords)) {
 			if (!result || spellLen > result->getWords().size()) {
-				result = &spell;
+				result = spell;
 				if (words.length() == spellLen) {
 					break;
 				}
@@ -246,11 +248,11 @@ InstantSpell* Spells::getInstantSpell(const std::string& words)
 	return nullptr;
 }
 
-InstantSpell* Spells::getInstantSpellByName(const std::string& name)
+std::shared_ptr<InstantSpell> Spells::getInstantSpellByName(const std::string& name)
 {
-	for (auto&& spell : instants | std::views::values) {
-		if (boost::iequals(spell.getName(), name)) {
-			return &spell;
+	for (const auto& spell : instants | std::views::values) {
+		if (boost::iequals(spell->getName(), name)) {
+			return spell;
 		}
 	}
 	return nullptr;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -119,14 +119,8 @@ std::unique_ptr<Event> Spells::getEvent(const std::string& nodeName)
 
 bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 {
-	Spell* spell = dynamic_cast<Spell*>(event.get());
-	if (!spell) {
-		return false;
-	}
-
-	if (InstantSpell* instantPtr = spell->getInstantSpell()) {
-		event.release();
-		std::shared_ptr<InstantSpell> instant{instantPtr};
+	auto spellEvent = std::shared_ptr<Event>{std::move(event)};
+	if (auto instant = std::dynamic_pointer_cast<InstantSpell>(spellEvent)) {
 		auto result = instants.emplace(instant->getWords(), instant);
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerEvent] Duplicate registered instant spell with words: "
@@ -135,9 +129,7 @@ bool Spells::registerEvent(std::unique_ptr<Event> event, const pugi::xml_node&)
 		return result.second;
 	}
 
-	if (RuneSpell* runePtr = spell->getRuneSpell()) {
-		event.release();
-		std::shared_ptr<RuneSpell> rune{runePtr};
+	if (auto rune = std::dynamic_pointer_cast<RuneSpell>(spellEvent)) {
 		auto result = runes.emplace(rune->getRuneItemId(), rune);
 		if (!result.second) {
 			std::cout << "[Warning - Spells::registerEvent] Duplicate registered rune with id: "

--- a/src/spells.h
+++ b/src/spells.h
@@ -25,33 +25,33 @@ public:
 	Spells(const Spells&) = delete;
 	Spells& operator=(const Spells&) = delete;
 
-	Spell* getSpellByName(const std::string& name);
-	RuneSpell* getRuneSpell(uint16_t id);
-	RuneSpell* getRuneSpellByName(const std::string& name);
+	std::shared_ptr<Spell> getSpellByName(const std::string& name);
+	std::shared_ptr<RuneSpell> getRuneSpell(uint16_t id);
+	std::shared_ptr<RuneSpell> getRuneSpellByName(const std::string& name);
 
-	InstantSpell* getInstantSpell(const std::string& words);
-	InstantSpell* getInstantSpellByName(const std::string& name);
+	std::shared_ptr<InstantSpell> getInstantSpell(const std::string& words);
+	std::shared_ptr<InstantSpell> getInstantSpellByName(const std::string& name);
 
 	TalkActionResult_t playerSaySpell(const std::shared_ptr<Player>& player, std::string& words);
 
 	static Position getCasterPosition(const std::shared_ptr<Creature>& creature, Direction dir);
 	std::string_view getScriptBaseName() const override { return "spells"; }
 
-	const std::map<uint16_t, RuneSpell>& getRuneSpells() const { return runes; };
-	const std::map<std::string, InstantSpell>& getInstantSpells() const { return instants; };
+	const std::map<uint16_t, std::shared_ptr<RuneSpell>>& getRuneSpells() const { return runes; };
+	const std::map<std::string, std::shared_ptr<InstantSpell>>& getInstantSpells() const { return instants; };
 
 	void clearMaps(bool fromLua);
 	void clear(bool fromLua) override final;
-	bool registerInstantLuaEvent(std::unique_ptr<InstantSpell> instant);
-	bool registerRuneLuaEvent(std::unique_ptr<RuneSpell> rune);
+	bool registerInstantLuaEvent(std::shared_ptr<InstantSpell> instant);
+	bool registerRuneLuaEvent(std::shared_ptr<RuneSpell> rune);
 
 private:
 	LuaScriptInterface& getScriptInterface() override;
 	std::unique_ptr<Event> getEvent(const std::string& nodeName) override;
 	bool registerEvent(std::unique_ptr<Event> event, const pugi::xml_node& node) override;
 
-	std::map<uint16_t, RuneSpell> runes;
-	std::map<std::string, InstantSpell> instants;
+	std::map<uint16_t, std::shared_ptr<RuneSpell>> runes;
+	std::map<std::string, std::shared_ptr<InstantSpell>> instants;
 
 	friend class CombatSpell;
 	LuaScriptInterface scriptInterface{"Spell Interface"};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - #393 issue
  - Improved spell handling to safely skip expired referenced spells during monster attack and defense processing.
  - Lua integrations now reliably return `nil` when spell references are unavailable or when the spell type doesn’t match the requested interface.
- **Improvements**
  - Updated spell registry and Lua spell bindings to use safer shared ownership, improving consistency for both built-in and Lua-created spells.
  - Added proper Lua garbage-collection behavior for Lua-exposed spell objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->