### PR TITLE
Fix: crash when selling house process

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -12,7 +12,7 @@
 
 extern Game g_game;
 
-House::House(uint32_t houseId) : id(houseId) {}
+House::House(uint32_t houseId) : id(houseId), transferContainer(std::make_shared<Container>(ITEM_LOCKER)) {}
 
 void House::addTile(const std::shared_ptr<HouseTile>& tile)
 {
@@ -304,9 +304,9 @@ std::shared_ptr<HouseTransferItem> House::getTransferItem()
 		return nullptr;
 	}
 
-	transferContainer.setParent(nullptr);
+	transferContainer->setParent(nullptr);
 	const auto transferItem = HouseTransferItem::createHouseTransferItem(shared_from_this());
-	transferContainer.addThing(transferItem);
+	transferContainer->addThing(transferItem);
 	return transferItem;
 }
 
@@ -315,9 +315,9 @@ void House::resetTransferItem()
 	if (transferItem) {
 		auto tmpItem = transferItem;
 		transferItem = nullptr;
-		transferContainer.setParent(nullptr);
+		transferContainer->setParent(nullptr);
 
-		transferContainer.removeThing(tmpItem, tmpItem->getItemCount());
+		transferContainer->removeThing(tmpItem, tmpItem->getItemCount());
 	}
 }
 

--- a/src/house.h
+++ b/src/house.h
@@ -167,7 +167,7 @@ private:
 	AccessList guestList;
 	AccessList subOwnerList;
 
-	Container transferContainer{ITEM_LOCKER};
+	std::shared_ptr<Container> transferContainer;
 
 	boost::container::flat_set<std::weak_ptr<HouseTile>, std::owner_less<std::weak_ptr<HouseTile>>> tiles;
 	boost::container::flat_set<std::weak_ptr<Door>, std::owner_less<std::weak_ptr<Door>>> doors;


### PR DESCRIPTION
How to reproduce:

Use the process to selling house with talkaction script.

The crash occurs due to an incompatibility between the smart pointers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of item transfers within houses.
  * Transfer items are now added, cleared, and removed more reliably during house operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->