### PR TITLE
Fix: selling house process has not completed

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -305,7 +305,7 @@ std::shared_ptr<HouseTransferItem> House::getTransferItem()
 	}
 
 	transferContainer.setParent(nullptr);
-	const auto transferItem = HouseTransferItem::createHouseTransferItem(shared_from_this());
+	transferItem = HouseTransferItem::createHouseTransferItem(shared_from_this());
 	transferContainer.addThing(transferItem);
 	return transferItem;
 }


### PR DESCRIPTION
How to reproduce:

Following the process to selling house with talkaction script, at the end of the process, the house is not sold, and no error occurs.

This happens because a temporary item is being created instead of saving the value to the transferItem