### PR TITLE
fix: follow throttle chrono overflow

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3205,7 +3205,7 @@ void Player::goToFollowCreature()
 		return;
 	}
 
-	if ((std::chrono::steady_clock::now() - lastFailedFollow) < 2s) {
+	if (std::chrono::steady_clock::now() < lastFailedFollow + 2s) {
 		return;
 	}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

**Bug:**
Following creatures didn't work at all. Using `time_point::min()` as an initial sentinel caused a chrono overflow, which permanently throttled the first follow attempt.

**Fix:**
Instead of subtracting the sentinel value, the code now correctly compares the current time against the retry deadline. The standard 2-second cooldown after a failed path search is preserved.

**How to test:**
1. Log in and follow any creature (it should work immediately).
2. Block the path to the creature to force a pathfinding failure.
3. Try following again – it should be throttled for 2 seconds, and work normally afterwards.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature-following behavior by correctly enforcing the brief wait period after a failed follow attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->