### PR TITLE
fix: restore condition removal order

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1120,9 +1120,10 @@ void Creature::removeCondition(ConditionType_t type, bool force /* = false*/)
 			}
 		}
 
-		condition->endCondition(asCreature());
+		auto removedCondition = std::move(condition);
 		it = conditions.erase(it);
 
+		removedCondition->endCondition(asCreature());
 		onEndCondition(type);
 	}
 }
@@ -1146,9 +1147,10 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 			}
 		}
 
-		condition->endCondition(asCreature());
+		auto removedCondition = std::move(condition);
 		it = conditions.erase(it);
 
+		removedCondition->endCondition(asCreature());
 		onEndCondition(type);
 	}
 }
@@ -1184,9 +1186,11 @@ void Creature::removeCondition(Condition* condition, bool force /* = false*/)
 		}
 	}
 
-	condition->endCondition(asCreature());
-	onEndCondition(condition->getType());
+	auto removedCondition = std::move(*it);
 	conditions.erase(it);
+
+	removedCondition->endCondition(asCreature());
+	onEndCondition(removedCondition->getType());
 }
 
 Condition* Creature::getCondition(ConditionType_t type) const
@@ -1235,9 +1239,11 @@ void Creature::executeConditions(std::chrono::milliseconds interval)
 			continue;
 		}
 
-		condition->endCondition(asCreature());
-		onEndCondition(condition->getType());
+		auto removedCondition = std::move(*it);
 		conditions.erase(it);
+
+		removedCondition->endCondition(asCreature());
+		onEndCondition(removedCondition->getType());
 	}
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2072,9 +2072,11 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 		while (it != conditions.end()) {
 			auto& condition = *it;
 			if (condition->isPersistent()) {
-				condition->endCondition(asPlayer());
-				onEndCondition(condition->getType());
+				auto removedCondition = std::move(condition);
 				it = conditions.erase(it);
+
+				removedCondition->endCondition(asPlayer());
+				onEndCondition(removedCondition->getType());
 			} else {
 				++it;
 			}
@@ -2086,9 +2088,11 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 		while (it != conditions.end()) {
 			auto& condition = *it;
 			if (condition->isPersistent()) {
-				condition->endCondition(asPlayer());
-				onEndCondition(condition->getType());
+				auto removedCondition = std::move(condition);
 				it = conditions.erase(it);
+
+				removedCondition->endCondition(asPlayer());
+				onEndCondition(removedCondition->getType());
 			} else {
 				++it;
 			}


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed proper The Forgotten Server code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Restore the original condition removal order by moving ownership out of the active condition list before invoking `endCondition()` and `onEndCondition()`.

This keeps the `Condition` object alive while ensuring callbacks no longer observe the condition being removed as active.

In particular, `ConditionInvisible::endCondition()` previously detected its own condition and failed to make the creature visible again. The server could then send a movement packet for a creature that was no longer present on the client tile, resulting in `no thing at pos` and `no creature found to move`.

The same ordering is restored for condition expiration, explicit removal, and persistent conditions removed on player death.

**Issues addressed:** #335 

**How to test:**

1. Spawn a monster that uses invisibility within a player's viewport.
2. Wait for the invisibility condition to expire.
3. Verify that the creature becomes visible before its next movement.
4. Confirm that the client does not report `no thing at pos` or `no creature found to move`.
5. Verify that removing one of multiple invisibility conditions does not reveal the creature until the last condition is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of temporary and persistent conditions when they expire, are removed, or are processed during gameplay.
  - Fixed condition cleanup during player death and other removal scenarios to ensure effects end reliably without causing unexpected behavior.
  - Lifecycle events now complete safely after conditions have been removed, improving gameplay stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->