### PR TITLE
Fix conditions start, end and delay in turns

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1081,8 +1081,9 @@ bool Creature::addCondition(std::unique_ptr<Condition> condition, bool force /* 
 	}
 
 	if (condition->startCondition(asCreature())) {
-		onAddCondition(condition->getType());
+		ConditionType_t type = condition->getType();
 		conditions.push_back(std::move(condition));
+		onAddCondition(type);
 		return true;
 	}
 
@@ -1120,9 +1121,9 @@ void Creature::removeCondition(ConditionType_t type, bool force /* = false*/)
 			}
 		}
 
-		condition->endCondition(asCreature());
+		auto removedCondition = std::move(condition);
 		it = conditions.erase(it);
-
+		removedCondition->endCondition(asCreature());
 		onEndCondition(type);
 	}
 }
@@ -1146,9 +1147,9 @@ void Creature::removeCondition(ConditionType_t type, ConditionId_t conditionId, 
 			}
 		}
 
-		condition->endCondition(asCreature());
+		auto removedCondition = std::move(condition);
 		it = conditions.erase(it);
-
+		removedCondition->endCondition(asCreature());
 		onEndCondition(type);
 	}
 }
@@ -1184,9 +1185,10 @@ void Creature::removeCondition(Condition* condition, bool force /* = false*/)
 		}
 	}
 
-	condition->endCondition(asCreature());
-	onEndCondition(condition->getType());
+	auto removedCondition = std::move(*it);
 	conditions.erase(it);
+	removedCondition->endCondition(asCreature());
+	onEndCondition(removedCondition->getType());
 }
 
 Condition* Creature::getCondition(ConditionType_t type) const
@@ -1235,9 +1237,10 @@ void Creature::executeConditions(std::chrono::milliseconds interval)
 			continue;
 		}
 
-		condition->endCondition(asCreature());
-		onEndCondition(condition->getType());
+		auto removedCondition = std::move(*it);
 		conditions.erase(it);
+		removedCondition->endCondition(asCreature());
+		onEndCondition(removedCondition->getType());
 	}
 }
 

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -1703,17 +1703,20 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 								start = std::max<int32_t>(0, pugi::cast<int32_t>(subValueAttribute.value()));
 							} else if (tmpStrValue == "damage") {
 								damage = -pugi::cast<int32_t>(subValueAttribute.value());
-								if (start > 0) {
-									std::list<int32_t> damageList;
-									ConditionDamage::generateDamageList(damage, start, damageList);
-									for (int32_t damageValue : damageList) {
-										conditionDamage->addDamage(1, ticks, -damageValue);
-									}
+							}
+						}
 
-									start = 0;
-								} else {
-									conditionDamage->addDamage(count, ticks, damage);
+						if (damage != 0) {
+							if (start > 0) {
+								std::list<int32_t> damageList;
+								ConditionDamage::generateDamageList(damage, start, damageList);
+								for (int32_t damageValue : damageList) {
+									conditionDamage->addDamage(1, ticks, -damageValue);
 								}
+
+								start = 0;
+							} else {
+								conditionDamage->addDamage(count, ticks, damage);
 							}
 						}
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1004,10 +1004,12 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 
 	if (isLogin) {
 		// Restore conditions stored during previous logout
+		loadingStoredConditions = true;
 		for (auto& condition : storedConditionList) {
 			addCondition(std::move(condition));
 		}
 		storedConditionList.clear();
+		loadingStoredConditions = false;
 
 		auto offlineTime = std::chrono::seconds::zero();
 		if (getLastLogout() != std::chrono::system_clock::time_point::min()) {
@@ -2072,9 +2074,10 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 		while (it != conditions.end()) {
 			auto& condition = *it;
 			if (condition->isPersistent()) {
-				condition->endCondition(asPlayer());
-				onEndCondition(condition->getType());
+				auto removedCondition = std::move(condition);
 				it = conditions.erase(it);
+				removedCondition->endCondition(asPlayer());
+				onEndCondition(removedCondition->getType());
 			} else {
 				++it;
 			}
@@ -2086,9 +2089,10 @@ void Player::death(const std::shared_ptr<Creature>& lastHitCreature)
 		while (it != conditions.end()) {
 			auto& condition = *it;
 			if (condition->isPersistent()) {
-				condition->endCondition(asPlayer());
-				onEndCondition(condition->getType());
+				auto removedCondition = std::move(condition);
 				it = conditions.erase(it);
+				removedCondition->endCondition(asPlayer());
+				onEndCondition(removedCondition->getType());
 			} else {
 				++it;
 			}
@@ -3305,6 +3309,10 @@ void Player::updateItemsLight(bool internal /*=false*/)
 void Player::onAddCondition(ConditionType_t type)
 {
 	Creature::onAddCondition(type);
+
+	if (loadingStoredConditions) {
+		return;
+	}
 
 	sendIcons();
 }

--- a/src/player.h
+++ b/src/player.h
@@ -1419,6 +1419,7 @@ private:
 	bool inMarket = false;
 	bool ghostMode = false;
 	bool pzLocked = false;
+	bool loadingStoredConditions = false;
 	bool addAttackSkillPoint = false;
 	bool inventoryAbilities[CONST_SLOT_LAST + 1] = {};
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved condition handling when conditions are added, removed, or expire.
  - Fixed restoration of stored conditions during login.
  - Prevented duplicate follow-up processing while restoring saved conditions.
  - Corrected persistent condition cleanup when a player dies.
  - Prevented zero-damage field effects from generating unnecessary damage sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->