### PR TITLE
perf(lua): userdata caching

### DIFF
--- a/src/lua/api.cpp
+++ b/src/lua/api.cpp
@@ -19,12 +19,10 @@ extern Spells* g_spells;
 
 namespace tfs::lua {
 
-const char* SHARED_PTR_CACHE_KEY = "tfs::lua::shared_ptr_cache";
-
 void requireSharedPtrCache(lua_State* L)
 {
-	// look up the cache table in the registry
-	lua_pushstring(L, SHARED_PTR_CACHE_KEY);
+	// use the function's own address as the registry key (unique, stable, zero-overhead)
+	lua_pushlightuserdata(L, reinterpret_cast<void*>(&requireSharedPtrCache));
 	lua_rawget(L, LUA_REGISTRYINDEX);
 	if (!lua_isnil(L, -1)) {
 		return;
@@ -37,7 +35,7 @@ void requireSharedPtrCache(lua_State* L)
 	lua_pushstring(L, "v");
 	lua_setfield(L, -2, "__mode");
 	lua_setmetatable(L, -2);
-	lua_pushstring(L, SHARED_PTR_CACHE_KEY);
+	lua_pushlightuserdata(L, reinterpret_cast<void*>(&requireSharedPtrCache));
 	lua_pushvalue(L, -2);
 	lua_rawset(L, LUA_REGISTRYINDEX);
 }

--- a/src/lua/api.cpp
+++ b/src/lua/api.cpp
@@ -19,6 +19,29 @@ extern Spells* g_spells;
 
 namespace tfs::lua {
 
+const char* SHARED_PTR_CACHE_KEY = "tfs::lua::shared_ptr_cache";
+
+void requireSharedPtrCache(lua_State* L)
+{
+	// look up the cache table in the registry
+	lua_pushstring(L, SHARED_PTR_CACHE_KEY);
+	lua_rawget(L, LUA_REGISTRYINDEX);
+	if (!lua_isnil(L, -1)) {
+		return;
+	}
+
+	// not found, create a new weak table for it
+	lua_pop(L, 1);
+	lua_newtable(L);
+	lua_newtable(L);
+	lua_pushstring(L, "v");
+	lua_setfield(L, -2, "__mode");
+	lua_setmetatable(L, -2);
+	lua_pushstring(L, SHARED_PTR_CACHE_KEY);
+	lua_pushvalue(L, -2);
+	lua_rawset(L, LUA_REGISTRYINDEX);
+}
+
 bool isNumber(lua_State* L, int32_t arg) { return lua_type(L, arg) == LUA_TNUMBER; }
 
 int luaUserdataCompare(lua_State* L)

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -137,9 +137,6 @@ std::shared_ptr<T>* getRawSharedPtr(lua_State* L, int32_t arg)
 	return static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));
 }
 
-// Registry key for the weak-table cache that deduplicates shared_ptr userdata
-extern const char* SHARED_PTR_CACHE_KEY;
-
 // Pushes the weak cache table onto the stack, creating it if absent
 void requireSharedPtrCache(lua_State* L);
 

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -137,31 +137,14 @@ std::shared_ptr<T>* getRawSharedPtr(lua_State* L, int32_t arg)
 	return static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));
 }
 
-namespace detail {
+// Registry key for the weak-table cache that deduplicates shared_ptr userdata
+extern const char* SHARED_PTR_CACHE_KEY;
 
-inline constexpr const char* kUserdataCacheKey = "tfs::lua::userdata_cache";
+// Pushes the weak cache table onto the stack, creating it if absent
+void requireSharedPtrCache(lua_State* L);
 
-inline void ensureUserdataCache(lua_State* L)
-{
-	lua_pushstring(L, kUserdataCacheKey);
-	lua_rawget(L, LUA_REGISTRYINDEX);
-	if (lua_isnil(L, -1)) {
-		lua_pop(L, 1);
-
-		lua_newtable(L);
-		lua_newtable(L);
-		lua_pushstring(L, "v");
-		lua_setfield(L, -2, "__mode");
-		lua_setmetatable(L, -2);
-
-		lua_pushstring(L, kUserdataCacheKey);
-		lua_pushvalue(L, -2);
-		lua_rawset(L, LUA_REGISTRYINDEX);
-	}
-}
-
-} // namespace detail
-
+// Push a shared_ptr as a single userdata, reusing any existing one via weak cache
+// Keyed by raw pointer address, avoids use_count inflation from duplicates
 template <class T>
 void pushSharedPtr(lua_State* L, const std::shared_ptr<T>& value)
 {
@@ -170,11 +153,14 @@ void pushSharedPtr(lua_State* L, const std::shared_ptr<T>& value)
 		return;
 	}
 
-	detail::ensureUserdataCache(L);
+	// ensure the weak cache table is on the stack
+	requireSharedPtrCache(L);
 
+	// use the raw address as the cache key
 	using RawT = std::remove_const_t<T>;
 	auto* key = const_cast<RawT*>(value.get());
 
+	// look up the existing userdata
 	lua_pushlightuserdata(L, key);
 	lua_rawget(L, -2);
 	if (!lua_isnil(L, -1)) {
@@ -183,9 +169,11 @@ void pushSharedPtr(lua_State* L, const std::shared_ptr<T>& value)
 	}
 	lua_pop(L, 1);
 
+	// create a new userdata and copy the shared_ptr into it
 	auto* ud = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
 	std::construct_at(ud, value);
 
+	// store in cache so future pushes reuse it
 	lua_pushlightuserdata(L, key);
 	lua_pushvalue(L, -2);
 	lua_rawset(L, -4);

--- a/src/lua/api.h
+++ b/src/lua/api.h
@@ -137,10 +137,60 @@ std::shared_ptr<T>* getRawSharedPtr(lua_State* L, int32_t arg)
 	return static_cast<std::shared_ptr<T>*>(lua_touserdata(L, arg));
 }
 
-template <class T>
-void pushSharedPtr(lua_State* L, std::shared_ptr<T> value)
+namespace detail {
+
+inline constexpr const char* kUserdataCacheKey = "tfs::lua::userdata_cache";
+
+inline void ensureUserdataCache(lua_State* L)
 {
-	new (lua_newuserdata(L, sizeof(std::shared_ptr<T>))) std::shared_ptr<T>(std::move(value));
+	lua_pushstring(L, kUserdataCacheKey);
+	lua_rawget(L, LUA_REGISTRYINDEX);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+
+		lua_newtable(L);
+		lua_newtable(L);
+		lua_pushstring(L, "v");
+		lua_setfield(L, -2, "__mode");
+		lua_setmetatable(L, -2);
+
+		lua_pushstring(L, kUserdataCacheKey);
+		lua_pushvalue(L, -2);
+		lua_rawset(L, LUA_REGISTRYINDEX);
+	}
+}
+
+} // namespace detail
+
+template <class T>
+void pushSharedPtr(lua_State* L, const std::shared_ptr<T>& value)
+{
+	if (!value) {
+		lua_pushnil(L);
+		return;
+	}
+
+	detail::ensureUserdataCache(L);
+
+	using RawT = std::remove_const_t<T>;
+	auto* key = const_cast<RawT*>(value.get());
+
+	lua_pushlightuserdata(L, key);
+	lua_rawget(L, -2);
+	if (!lua_isnil(L, -1)) {
+		lua_remove(L, -2);
+		return;
+	}
+	lua_pop(L, 1);
+
+	auto* ud = static_cast<std::shared_ptr<T>*>(lua_newuserdata(L, sizeof(std::shared_ptr<T>)));
+	std::construct_at(ud, value);
+
+	lua_pushlightuserdata(L, key);
+	lua_pushvalue(L, -2);
+	lua_rawset(L, -4);
+
+	lua_remove(L, -2);
 }
 
 // High-level converters (Lua -> C++)

--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -917,13 +917,13 @@ bool LuaEnvironment::initState()
 	luaL_openlibs(L);
 	registerFunctions();
 
-	// Pre-create the weak userdata cache table
+	// shared_ptr userdata cache: a weak table keyed by pointer address
 	lua_newtable(L);
 	lua_newtable(L);
 	lua_pushstring(L, "v");
 	lua_setfield(L, -2, "__mode");
 	lua_setmetatable(L, -2);
-	lua_setfield(L, LUA_REGISTRYINDEX, tfs::lua::detail::kUserdataCacheKey);
+	lua_setfield(L, LUA_REGISTRYINDEX, tfs::lua::SHARED_PTR_CACHE_KEY);
 
 	runningEventId = EVENT_ID_USER;
 	return true;

--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -917,6 +917,14 @@ bool LuaEnvironment::initState()
 	luaL_openlibs(L);
 	registerFunctions();
 
+	// Pre-create the weak userdata cache table
+	lua_newtable(L);
+	lua_newtable(L);
+	lua_pushstring(L, "v");
+	lua_setfield(L, -2, "__mode");
+	lua_setmetatable(L, -2);
+	lua_setfield(L, LUA_REGISTRYINDEX, tfs::lua::detail::kUserdataCacheKey);
+
 	runningEventId = EVENT_ID_USER;
 	return true;
 }

--- a/src/lua/script.cpp
+++ b/src/lua/script.cpp
@@ -917,13 +917,9 @@ bool LuaEnvironment::initState()
 	luaL_openlibs(L);
 	registerFunctions();
 
-	// shared_ptr userdata cache: a weak table keyed by pointer address
-	lua_newtable(L);
-	lua_newtable(L);
-	lua_pushstring(L, "v");
-	lua_setfield(L, -2, "__mode");
-	lua_setmetatable(L, -2);
-	lua_setfield(L, LUA_REGISTRYINDEX, tfs::lua::SHARED_PTR_CACHE_KEY);
+	// Ensure the shared_ptr userdata weak cache is initialized
+	tfs::lua::requireSharedPtrCache(L);
+	lua_pop(L, 1);
 
 	runningEventId = EVENT_ID_USER;
 	return true;


### PR DESCRIPTION
### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Implement a weak-table cache in the Lua registry to deduplicate shared_ptr userdata. Instead of creating a new userdata (and copying the shared_ptr) on every pushSharedPtr call, the cache stores a single userdata per object address. Future pushes for the same object return the cached userdata directly

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lua object handling by reusing existing shared-pointer objects instead of creating duplicates.
  * Added proper handling for null shared pointers.
  * Reduced unnecessary memory usage through automatic cache cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->