### PR TITLE
chore: remove deprecated stages.xml

### DIFF
--- a/data/XML/stages.xml
+++ b/data/XML/stages.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<stages>
-	<config enabled="0" />
-	<stage minlevel="1" maxlevel="8" multiplier="7" />
-	<stage minlevel="9" maxlevel="20" multiplier="6" />
-	<stage minlevel="21" maxlevel="50" multiplier="5" />
-	<stage minlevel="51" maxlevel="100" multiplier="4" />
-	<stage minlevel="101" multiplier="5" />
-</stages>

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -113,44 +113,6 @@ ExperienceStages loadLuaStages(lua_State* L)
 	return stages;
 }
 
-ExperienceStages loadXMLStages()
-{
-	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file("data/XML/stages.xml");
-	if (!result) {
-		printXMLError("Error - loadXMLStages", "data/XML/stages.xml", result);
-		return {};
-	}
-
-	ExperienceStages stages;
-	for (auto stageNode : doc.child("stages").children()) {
-		if (boost::iequals(stageNode.name(), "config")) {
-			if (!stageNode.attribute("enabled").as_bool()) {
-				return {};
-			}
-		} else {
-			uint32_t minLevel = 1, maxLevel = std::numeric_limits<uint32_t>::max(), multiplier = 1;
-
-			if (auto minLevelAttribute = stageNode.attribute("minlevel")) {
-				minLevel = pugi::cast<uint32_t>(minLevelAttribute.value());
-			}
-
-			if (auto maxLevelAttribute = stageNode.attribute("maxlevel")) {
-				maxLevel = pugi::cast<uint32_t>(maxLevelAttribute.value());
-			}
-
-			if (auto multiplierAttribute = stageNode.attribute("multiplier")) {
-				multiplier = pugi::cast<uint32_t>(multiplierAttribute.value());
-			}
-
-			stages.emplace_back(minLevel, maxLevel, multiplier);
-		}
-	}
-
-	std::sort(stages.begin(), stages.end());
-	return stages;
-}
-
 } // namespace
 
 bool ConfigManager::load()
@@ -287,14 +249,7 @@ bool ConfigManager::load()
 	integer[STAMINA_REGEN_PREMIUM] = getGlobalNumber(L, "timeToRegenMinutePremiumStamina", 6 * 60);
 	integer[FOLLOW_PATH_CHECK_INTERVAL] = getGlobalNumber(L, "followPathCheckInterval", 200);
 
-	expStages = loadXMLStages();
-	if (expStages.empty()) {
-		expStages = loadLuaStages(L);
-	} else {
-		std::cout << "[Warning - ConfigManager::load] XML stages are deprecated, "
-		             "consider moving to config.lua."
-		          << std::endl;
-	}
+	expStages = loadLuaStages(L);
 	expStages.shrink_to_fit();
 
 	loaded = true;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->
Removed the deprecated `stages.xml` file and its associated XML parsing logic from the engine (`ConfigManager::loadXMLStages()`). Experience stages are now exclusively configured and loaded via Lua configuration.

**Issues addressed:** <!-- Write here the issue number, if any. -->
N/A

**How to test:** <!-- Write here how to test changes. -->
1. Compile the engine and run it.
2. Verify that there are no warnings or errors regarding `stages.xml` during the boot process.
3. Ensure that experience stages from `config.lua` (or equivalent Lua configuration) are correctly applied to players in the game.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Experience stage configuration is now loaded exclusively from `config.lua`.
  * Removed support for the legacy XML-based stage configuration.
  * Deleted the outdated stage configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->