### PR TITLE
refactor(lua): replace deprecated math.pow calls

### DIFF
--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -149,7 +149,7 @@ function Creature:addDamageCondition(target, type, list, damage, period, rounds)
 	elseif list == DAMAGELIST_LOGARITHMIC_DAMAGE then
 		local n, value = 0, damage
 		while value > 0 do
-			value = math.floor(damage * (2.718281828459 ^ (-0.05 * n)) + 0.5)
+			value = math.floor(damage * math.exp(-0.05 * n) + 0.5)
 			if value ~= 0 then
 				condition:addDamage(1, period or 4000, -value)
 				n = n + 1

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -136,7 +136,7 @@ function Creature:addDamageCondition(target, type, list, damage, period, rounds)
 	if list == DAMAGELIST_EXPONENTIAL_DAMAGE then
 		local exponent, value = -10, 0
 		while value < damage do
-			value = math.floor(10 * math.pow(1.2, exponent) + 0.5)
+			value = math.floor(10 * (1.2 ^ exponent) + 0.5)
 			condition:addDamage(1, period or 4000, -value)
 
 			if value >= damage then
@@ -149,7 +149,7 @@ function Creature:addDamageCondition(target, type, list, damage, period, rounds)
 	elseif list == DAMAGELIST_LOGARITHMIC_DAMAGE then
 		local n, value = 0, damage
 		while value > 0 do
-			value = math.floor(damage * math.pow(2.718281828459, -0.05 * n) + 0.5)
+			value = math.floor(damage * (2.718281828459 ^ (-0.05 * n)) + 0.5)
 			if value ~= 0 then
 				condition:addDamage(1, period or 4000, -value)
 				n = n + 1

--- a/data/scripts/lib/spells.lua
+++ b/data/scripts/lib/spells.lua
@@ -259,7 +259,7 @@ function Player:addPartyCondition(combat, variant, condition, baseMana)
 		return false
 	end
 
-	local mana = math.ceil(#affectedMembers * math.pow(0.9, #affectedMembers - 1) * baseMana)
+	local mana = math.ceil(#affectedMembers * (0.9 ^ (#affectedMembers - 1)) * baseMana)
 	if self:getMana() < mana then
 		self:sendCancelMessage(RETURNVALUE_NOTENOUGHMANA)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

Replaces 3 deprecated `math.pow` calls with the native Lua `^` operator in `spells.lua` and `creature.lua` for Lua 5.4 compatibility.

**Issues addressed:** None

**How to test:** Cast party spells and apply creature exponential/logarithmic damage conditions to verify math functions properly without Lua errors.

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated damage calculations to use consistent Lua exponentiation/math functions for exponential and logarithmic damage scaling.
  * Updated party mana cost calculation to use Lua’s exponentiation operator for the derived mana requirement.
  * Improved reliability and consistency of damage and mana computations without changing overall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->