### PR TITLE
fix: expose forced state to player logout callbacks

### DIFF
--- a/data/cpplinter.lua
+++ b/data/cpplinter.lua
@@ -1038,7 +1038,7 @@ Weapon = {}
 ---@field onPlayerSpellCheck fun(player:Player, spell:Spell):boolean
 ---@field onPlayerLogin fun(player:Player):boolean
 ---@field onPlayerJoin fun(player:Player):nil
----@field onPlayerLogout fun(player:Player):boolean
+---@field onPlayerLogout fun(player:Player, forced:boolean):boolean
 ---@field onPlayerReconnect fun(player:Player):nil
 ---@field onPlayerAdvance fun(player:Player, skill:integer, oldLvl:integer, newLvl:integer):nil
 ---@field onPlayerModalWindow fun(player:Player, modalWindowId:integer, buttonId:integer, choiceId:integer):nil

--- a/data/scripts/events/player.lua
+++ b/data/scripts/events/player.lua
@@ -281,9 +281,9 @@ function Player:onJoin()
 	end
 end
 
-function Player:onLogout()
+function Player:onLogout(forced)
 	if Event.onPlayerLogout then
-		return Event.onPlayerLogout(self)
+		return Event.onPlayerLogout(self, forced)
 	end
 	return true
 end

--- a/src/events/player.cpp
+++ b/src/events/player.cpp
@@ -775,9 +775,9 @@ void onJoin(const std::shared_ptr<Player>& player)
 	tfs::events::getScriptInterface().callVoidFunction(1);
 }
 
-bool onLogout(const std::shared_ptr<Player>& player)
+bool onLogout(const std::shared_ptr<Player>& player, bool forced)
 {
-	// Player:onLogout()
+	// Player:onLogout(forced)
 	if (playerHandlers.onLogout == -1) {
 		return true;
 	}
@@ -794,7 +794,8 @@ bool onLogout(const std::shared_ptr<Player>& player)
 	tfs::events::getScriptInterface().pushFunction(playerHandlers.onLogout);
 
 	tfs::lua::pushThing(L, player);
-	return tfs::events::getScriptInterface().callFunction(1);
+	tfs::lua::pushBoolean(L, forced);
+	return tfs::events::getScriptInterface().callFunction(2);
 }
 
 void onReconnect(const std::shared_ptr<Player>& player)

--- a/src/events/player.h
+++ b/src/events/player.h
@@ -55,7 +55,7 @@ void onNetworkMessage(const std::shared_ptr<Player>& player, uint8_t recvByte, s
 bool onSpellCheck(const std::shared_ptr<Player>& player, const Spell* spell);
 bool onLogin(const std::shared_ptr<Player>& player);
 void onJoin(const std::shared_ptr<Player>& player);
-bool onLogout(const std::shared_ptr<Player>& player);
+bool onLogout(const std::shared_ptr<Player>& player, bool forced);
 void onReconnect(const std::shared_ptr<Player>& player);
 void onAdvance(const std::shared_ptr<Player>& player, skills_t skill, uint32_t oldLevel, uint32_t newLevel);
 void onModalWindow(const std::shared_ptr<Player>& player, uint32_t modalWindowId, uint8_t buttonId, uint8_t choiceId);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2180,7 +2180,7 @@ void Player::addInFightTicks(bool pzlock /*= false*/)
 
 void Player::kickPlayer(bool displayEffect)
 {
-	tfs::events::player::onLogout(asPlayer());
+	tfs::events::player::onLogout(asPlayer(), true);
 
 	if (client) {
 		client->forceLogout(displayEffect);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -336,7 +336,7 @@ void ProtocolGame::logout(bool displayEffect)
 			}
 		}
 
-		if (!tfs::events::player::onLogout(player)) {
+		if (!tfs::events::player::onLogout(player, false)) {
 			return;
 		}
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed proper The Forgotten Server code styling.
- [x] I have read and understood the contribution guidelines before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logout events now indicate whether a player was logged out forcibly or normally.
  * Scripts can respond differently based on the logout reason.

* **Bug Fixes**
  * Forced removals and standard logouts now pass the correct logout status to event handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Changes Proposed

`Player::kickPlayer()` executes the cancellable logout callback but cannot
honor its return value because player removal is mandatory.

If an early `onPlayerLogout` callback returns `false`, the event dispatcher
stops executing subsequent callbacks. The forced removal still happens,
but later cleanup callbacks are skipped.

This change passes a `forced` boolean through the C++ and Lua logout
callback layers:

- normal protocol logout passes `false` and continues to honor callback vetoes;
- forced removal through `Player::kickPlayer()` passes `true`;
- logout callbacks can avoid vetoing an unavoidable removal and allow later
  cleanup callbacks to execute;
- existing Lua callbacks accepting only the player argument remain compatible,
  because Lua ignores additional arguments.

This applies to forced removals triggered by `/kick`, `/ban`,
`player:remove()`, server shutdown and closing the game world.

The existing `ProtocolGame::forceLogout()` implementation, logout
restrictions and protocol behavior remain unchanged.

**How to test:**

Register an early callback that vetoes only normal logout:

```lua
local veto = Event()

veto.onPlayerLogout = function(player, forced)
	return forced
end

veto:register(-100)