### PR TITLE
Fix viewport desync

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2757,7 +2757,8 @@ void ProtocolGame::sendMoveCreature(const std::shared_ptr<const Creature>& creat
                                     int32_t newStackPos, const Position& oldPos, int32_t oldStackPos, bool teleport)
 {
 	if (creature == player) {
-		if (teleport) {
+		const int32_t zDiff = std::abs(newPos.z - oldPos.z);
+		if (teleport || zDiff > 1) {
 			sendRemoveTileCreature(creature, oldPos, oldStackPos);
 			sendMapDescription(newPos);
 		} else {


### PR DESCRIPTION
Viewport gets desynced when z changes > 1 and can crash the client.

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->

**How to test:** <!-- Write here how to test changes. -->

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature movement updates when moving across multiple floors.
  * Such movements now display as teleports with refreshed map information, preventing incomplete or inaccurate movement visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->