### PR TITLE
fix(events): remove duplicate player turn packet broadcast

### DIFF
--- a/data/scripts/events/player/default_onTurn.lua
+++ b/data/scripts/events/player/default_onTurn.lua
@@ -1,86 +1,12 @@
 local event = Event()
 
-local function getClientIndexOfCreature(player, creature)
-    local tile = creature:getTile()
-    local n = 0
-
-    if tile:getGround() ~= nil then
-        n = n + 1
-    end
-
-    n = n + tile:getTopItemCount()
-
-    local tileCreatures = tile:getCreatures()
-    for i = #tileCreatures, 1, -1 do
-        local tileCreature = tileCreatures[i]
-        if tileCreature == creature then
-            return n
-        end
-
-        if player:canSeeCreature(tileCreature) then
-            n = n + 1
-        end
-    end
-
-    return -1
-end
-
-local function canWalkthroughEx(player, creature)
-    if player:getGroup():getAccess() then
-        return true
-    end
-
-    if creature:isPlayer() and not configManager.getBoolean(configKeys.ALLOW_WALKTHROUGH) then
-        return false
-    end
-
-    local tile = creature:getTile()
-    if not tile then
-        return false
-    end
-
-    return tile:hasFlag(TILESTATE_PROTECTIONZONE) or player:getLevel() <=
-               configManager.getNumber(configKeys.PROTECTION_LEVEL)
-end
-
-local function sendCreatureTurn(player, creature, stackpos, direction)
-    if not player:canSeeCreature(creature) then
-        return
-    end
-
-    local msg = NetworkMessage()
-    msg:addByte(0x6B)
-    if stackpos >= MAX_STACKPOS then
-        msg:addU16(0xFFFF)
-        msg:addU32(creature:getId())
-    else
-        msg:addPosition(creature:getPosition())
-        msg:addByte(stackpos)
-    end
-
-    msg:addU16(0x63)
-    msg:addU32(creature:getId())
-    msg:addByte(direction)
-    msg:addBool(not canWalkthroughEx(player, creature))
-    return msg:sendToPlayer(player)
-end
-
 function event.onPlayerTurn(player, direction)
-    if player:getDirection() == direction then
-        return false
-    end
+	if player:getDirection() == direction then
+		return false
+	end
 
-    player:resetIdleTime()
-
-    local spectators = Game.getSpectators(player:getPosition(), true, true)
-    for _, spectator in ipairs(spectators) do
-        local stackpos = getClientIndexOfCreature(spectator, player)
-        if stackpos ~= -1 then
-            sendCreatureTurn(spectator, player, stackpos, direction)
-        end
-    end
-
-    return true
+	player:resetIdleTime()
+	return true
 end
 
 event:register()


### PR DESCRIPTION
The turn pipeline previously sent duplicate 0x6B (Update Tile / Creature Turn) packets on every player turn:

1. `default_onTurn.lua` manually queried spectators, computed stack positions, and sent 0x6B packets through Lua.
2. `player_turn.lua` then called `player:setDirection(direction)`, which invokes `Game::internalCreatureTurn` in C++, performs another spectator query, and broadcasts the same turn packet again.

In addition, the Lua implementation of `canWalkthroughEx` checked the spectator's level instead of the turning creature's level, which could produce conflicting walkthrough flags between the Lua and C++ turn packets.

This PR removes the redundant Lua turn broadcasting logic and leaves `Game::internalCreatureTurn` as the single authoritative turn broadcaster.

### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

- Removed the manual `Game.getSpectators` call from `default_onTurn.lua`.
- Removed the Lua-side stack position calculation.
- Removed the manual `NetworkMessage` construction and 0x6B turn packet broadcast.
- Removed the duplicated Lua `canWalkthroughEx` implementation.
- Preserved the `onPlayerTurn` validation hook.
- Preserved `player:resetIdleTime()`.
- Kept `player:setDirection(direction)` / `Game::internalCreatureTurn` as the single path responsible for:
  - updating the creature direction,
  - querying spectators,
  - calculating stack positions,
  - sending the turn packet.

**Issues addressed:** Duplicate player turn packet broadcasting and redundant spectator queries.

**How to test:**

1. Log in with two clients and place both players within visible range.
2. Turn one player in all four directions without moving.
3. Verify the turning player and nearby observer receive the direction update normally.
4. Verify each turn produces only one turn update instead of two.
5. Verify repeated turns do not cause client desync or incorrect direction.
6. Verify idle time is still reset when the player turns.
7. Build and run the server normally and confirm no Lua errors occur.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved player turn handling by removing unnecessary spectator notifications.
  * Player idle timers now reset reliably when the player’s direction changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->