### PR TITLE
perf(tile): limit item spectator queries to players

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -334,7 +334,7 @@ void Tile::onAddTileItem(const std::shared_ptr<Item>& item)
 	setTileFlags(item);
 
 	SpectatorVec spectators;
-	g_game.map.getSpectators(spectators, tilePos, true);
+	g_game.map.getSpectators(spectators, tilePos, true, true);
 
 	// send to client
 	for (const auto& spectator : spectators) {
@@ -373,7 +373,7 @@ void Tile::onUpdateTileItem(const std::shared_ptr<Item>& oldItem, const ItemType
 	}
 
 	SpectatorVec spectators;
-	g_game.map.getSpectators(spectators, tilePos, true);
+	g_game.map.getSpectators(spectators, tilePos, true, true);
 
 	// send to client
 	for (const auto& spectator : spectators) {
@@ -1018,7 +1018,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 		ground = nullptr;
 
 		SpectatorVec spectators;
-		g_game.map.getSpectators(spectators, getPosition(), true);
+		g_game.map.getSpectators(spectators, getPosition(), true, true);
 		onRemoveTileItem(spectators, std::vector<int32_t>(spectators.size(), 0), item);
 		return;
 	}
@@ -1036,7 +1036,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 		}
 
 		SpectatorVec spectators;
-		g_game.map.getSpectators(spectators, getPosition(), true);
+		g_game.map.getSpectators(spectators, getPosition(), true, true);
 
 		std::vector<int32_t> oldStackPosVector;
 		oldStackPosVector.reserve(spectators.size());
@@ -1058,7 +1058,7 @@ void Tile::removeThing(const std::shared_ptr<Thing>& thing, uint32_t count)
 			onUpdateTileItem(item, itemType, item, itemType);
 		} else {
 			SpectatorVec spectators;
-			g_game.map.getSpectators(spectators, getPosition(), true);
+			g_game.map.getSpectators(spectators, getPosition(), true, true);
 
 			std::vector<int32_t> oldStackPosVector;
 			oldStackPosVector.reserve(spectators.size());


### PR DESCRIPTION
### Changes Proposed

Tile item add/update/remove paths were still querying all nearby creatures even though only Players need these notifications.

This is leftover behavior from the old Creature map cache. Upstream TFS PR #4825 removed `localMapCache`, `updateTileCache`, `getWalkCache`, and made the related Creature tile callbacks no-ops, but the broad spectator queries in `src/tile.cpp` remained unchanged.

This PR changes the 5 relevant calls from:

```cpp
g_game.map.getSpectators(spectators, ..., true);
````

to:

```cpp
g_game.map.getSpectators(spectators, ..., true, true);
```

enabling `onlyPlayers = true`.

Affected paths:

* `Tile::onAddTileItem`
* `Tile::onUpdateTileItem`
* `Tile::removeThing` — ground
* `Tile::removeThing` — `alwaysOnTop`
* `Tile::removeThing` — normal/down items

Player packet delivery and Player callbacks are fully preserved. Monster/NPC movement, pathfinding, and `Map::moveCreature` are unchanged.

Upstream context:
[https://github.com/otland/forgottenserver/pull/4825](https://github.com/otland/forgottenserver/pull/4825)

**Issues addressed:** Removes redundant Monster/NPC spectator collection during tile item operations.

**How to test:**

1. Add, update, move, and remove items with multiple Players nearby.
2. Test ground, `alwaysOnTop`, and normal/down items.
3. Verify trade callbacks still work.
4. Repeat in dense Monster/NPC areas and confirm no client desync or missing updates.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
