### PR TITLE
fix(player): remove redundant walkthrough broadcast during login

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1065,10 +1065,6 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature>& creature, bool is
 	sendEnterWorld();
 	sendMapDescription();
 
-	if (isLogin) {
-		g_game.updateCreatureWalkthrough(asPlayer());
-	}
-
 	if (magicEffect != CONST_ME_NONE) {
 		sendMagicEffect(magicEffect);
 	}


### PR DESCRIPTION
## Summary

- Remove the redundant `updateCreatureWalkthrough()` broadcast during player login.
- Initial `AddCreature` serialization already includes the creature walkthrough/passability state.
- Prevent `0x92` walkthrough updates from reaching spectators before their corresponding `AddCreature` notification during mass login.

## Root cause

`Player::onCreatureAppear()` called `updateCreatureWalkthrough()` from inside the login spectator notification flow. Depending on spectator iteration order, this could send a walkthrough update for the newly logging player to spectators that had not yet received that creature's `AddCreature` packet.

The client then failed to resolve the creature ID and logged:

`ERROR: could not get creature`

Fixes #423

## Validation

- Build passes.
- `git diff --check` passes.
- Final diff only removes the redundant login-time walkthrough broadcast.
- Existing non-login walkthrough updates remain unchanged.
