### PR TITLE
fix(tile): keep rejected duplicate ground detached

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1322,9 +1322,8 @@ void Tile::postRemoveNotification(const std::shared_ptr<Thing>& thing, const std
 
 void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 {
-	thing->setParent(asTile());
-
 	if (const auto& creature = thing->asCreature()) {
+		thing->setParent(asTile());
 		g_game.map.clearSpectatorCache();
 		if (creature->asPlayer()) {
 			g_game.map.clearPlayersSpectatorCache();
@@ -1335,13 +1334,17 @@ void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 	} else if (const auto& item = thing->asItem()) {
 		const ItemType& itemType = Item::items[item->getID()];
 		if (itemType.isGroundTile()) {
-			if (!ground) {
-				ground = item;
-				setTileFlags(item);
+			if (ground) {
+				return;
 			}
+
+			thing->setParent(asTile());
+			ground = item;
+			setTileFlags(item);
 			return;
 		}
 
+		thing->setParent(asTile());
 		TileItemVector* items = makeItemList();
 		if (items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
@@ -1366,6 +1369,8 @@ void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing>& thing)
 		}
 
 		setTileFlags(item);
+	} else {
+		thing->setParent(asTile());
 	}
 }
 


### PR DESCRIPTION
### Pull Request Prelude

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

`Tile::internalAddThing()` assigned the tile as parent before checking whether a ground item could actually be inserted. When a tile already had ground, the rejected item therefore remained associated with that tile despite not being stored by it.

This PR:

- Rejects a duplicate ground item before assigning its parent.
- Preserves the existing first-ground-wins behavior.
- Keeps parent assignment unchanged for accepted creatures, ground items, regular items, and the generic fallback path.
- Does not change ground replacement behavior in `Tile::addThing()`.

> [!NOTE]
> This PR and #425 both touch `Tile::internalAddThing()` for independent correctness issues.
> - #425 handles regular-item capacity rejection.
> - #427 handles rejected duplicate ground items.
>
> If both changes are accepted, the final combined implementation must preserve both invariants.

**Issue addressed:** Closes #426

### How to test

1. Create a tile with an existing ground item.
2. Pass a second ground item to `Tile::internalAddThing()`.
3. Verify the original ground remains installed.
4. Verify the rejected ground remains detached and `getThingIndex()` returns `-1` for it.
5. Verify first-ground insertion and ordinary internal item insertion remain unchanged.

### Validation

- `git diff --check` passed.
- The production diff contains only `src/tile.cpp`.
- No build was run as part of this focused change.

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide