### PR TITLE
fix(protocol): bound tile creature serialization

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -537,7 +537,7 @@ bool Game::removeCreature(const std::shared_ptr<Creature>& creature, bool isLogo
 	for (const auto& spectator : spectators) {
 		if (const auto& player = spectator->asPlayer()) {
 			oldStackPosVector.push_back(
-			    player->canSeeCreature(creature) ? tile->getClientIndexOfCreature(player, creature) : -1);
+			    player->canSeeCreature(creature) ? tile->getStackposOfCreature(player, creature) : -1);
 		}
 	}
 
@@ -549,7 +549,7 @@ bool Game::removeCreature(const std::shared_ptr<Creature>& creature, bool isLogo
 	size_t i = 0;
 	for (const auto& spectator : spectators) {
 		if (const auto& player = spectator->asPlayer()) {
-			player->sendRemoveTileCreature(creature, tilePosition, oldStackPosVector[i++]);
+			player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
 		}
 	}
 

--- a/src/lua/modules/player.cpp
+++ b/src/lua/modules/player.cpp
@@ -1911,8 +1911,10 @@ int luaPlayerSetGhostMode(lua_State* L)
 		const auto& spectatorPlayer = std::static_pointer_cast<Player>(spectator);
 		if (spectatorPlayer != player && !spectatorPlayer->isAccessPlayer()) {
 			if (enabled) {
-				spectatorPlayer->sendRemoveTileCreature(player, position,
-				                                        tile->getClientIndexOfCreature(spectatorPlayer, player));
+				int32_t stackpos = tile->getStackposOfCreature(spectatorPlayer, player);
+				if (stackpos != -1) {
+					spectatorPlayer->sendRemoveTileThing(position, stackpos);
+				}
 			} else {
 				spectatorPlayer->sendAddCreature(player, position, magicEffect);
 			}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -357,8 +357,8 @@ void Map::moveCreature(const std::shared_ptr<Creature>& creature, const std::sha
 			// Use the correct stackpos
 			int32_t stackpos = oldStackPosVector[i++];
 			if (stackpos != -1) {
-				tmpPlayer->sendCreatureMove(creature, newPos, newTile->getClientIndexOfCreature(tmpPlayer, creature),
-				                            oldPos, stackpos, teleport);
+				// 0xFF is special stackpos that tells client to insert it as new object - exactly what we want
+				tmpPlayer->sendCreatureMove(creature, newPos, 0xFF, oldPos, stackpos, teleport);
 			}
 		}
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -583,14 +583,10 @@ public:
 	void sendUpdateTileCreature(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client) {
-			client->sendUpdateTileCreature(
-			    creature->getPosition(), creature->getTile()->getClientIndexOfCreature(asPlayer(), creature), creature);
-		}
-	}
-	void sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos, int32_t stackpos)
-	{
-		if (client) {
-			client->sendRemoveTileCreature(creature, pos, stackpos);
+			int32_t stackpos = creature->getTile()->getStackposOfCreature(asPlayer(), creature);
+			if (stackpos != -1) {
+				client->sendUpdateTileCreature(creature->getPosition(), stackpos, creature);
+			}
 		}
 	}
 	void sendUpdateTile(const std::shared_ptr<const Tile>& tile, const Position& pos)
@@ -623,7 +619,7 @@ public:
 	                     MagicEffectClasses magicEffect = CONST_ME_NONE)
 	{
 		if (client) {
-			client->sendAddCreature(creature, pos, creature->getTile()->getClientIndexOfCreature(asPlayer(), creature),
+			client->sendAddCreature(creature, pos, creature->getTile()->getStackposOfCreature(asPlayer(), creature),
 			                        magicEffect);
 		}
 	}
@@ -637,7 +633,7 @@ public:
 	void sendCreatureTurn(const std::shared_ptr<const Creature>& creature)
 	{
 		if (client && canSeeCreature(creature)) {
-			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(asPlayer(), creature);
+			int32_t stackpos = creature->getTile()->getStackposOfCreature(asPlayer(), creature);
 			if (stackpos != -1) {
 				client->sendCreatureTurn(creature, stackpos);
 			}
@@ -684,7 +680,7 @@ public:
 		} else if (canSeeInvisibility()) {
 			client->sendCreatureOutfit(creature, creature->getCurrentOutfit());
 		} else {
-			int32_t stackpos = creature->getTile()->getClientIndexOfCreature(asPlayer(), creature);
+			int32_t stackpos = creature->getTile()->getStackposOfCreature(asPlayer(), creature);
 			if (stackpos == -1) {
 				return;
 			}
@@ -692,7 +688,7 @@ public:
 			if (visible) {
 				client->sendAddCreature(creature, creature->getPosition(), stackpos);
 			} else {
-				client->sendRemoveTileCreature(creature, creature->getPosition(), stackpos);
+				client->sendRemoveTileThing(creature->getPosition(), stackpos);
 			}
 		}
 	}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -826,25 +826,40 @@ void ProtocolGame::GetTileDescription(const std::shared_ptr<const Tile>& tile, N
 		for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 			msg.addItem(*it);
 
-			if (++count == MAX_STACKPOS) {
+			count++;
+			if (count == 9 && tile->getPosition() == player->getPosition()) {
 				break;
+			} else if (count == MAX_STACKPOS) {
+				return;
 			}
 		}
 	}
 
 	const CreatureVector* creatures = tile->getCreatures();
 	if (creatures) {
+		bool playerAdded = false;
 		for (auto it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
-			const auto& creature = *it;
+			auto creature = *it;
 			if (!player->canSeeCreature(creature)) {
 				continue;
+			}
+
+			if (tile->getPosition() == player->getPosition() && count == 9 && !playerAdded) {
+				creature = player;
+			}
+
+			if (creature->getID() == player->getID()) {
+				playerAdded = true;
 			}
 
 			bool known;
 			uint32_t removedKnown;
 			checkCreatureAsKnown(creature->getID(), known, removedKnown);
 			AddCreature(msg, creature, known, removedKnown);
-			++count;
+
+			if (++count == MAX_STACKPOS) {
+				return;
+			}
 		}
 	}
 
@@ -2347,13 +2362,8 @@ void ProtocolGame::sendCreatureTurn(const std::shared_ptr<const Creature>& creat
 
 	NetworkMessage msg;
 	msg.addByte(0x6B);
-	if (stackpos >= MAX_STACKPOS) {
-		msg.add<uint16_t>(0xFFFF);
-		msg.add<uint32_t>(creature->getID());
-	} else {
-		msg.addPosition(creature->getPosition());
-		msg.addByte(stackpos);
-	}
+	msg.addPosition(creature->getPosition());
+	msg.addByte(stackpos);
 
 	msg.add<uint16_t>(0x63);
 	msg.add<uint32_t>(creature->getID());
@@ -2597,27 +2607,6 @@ void ProtocolGame::sendUpdateTileCreature(const Position& pos, uint32_t stackpos
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
-                                          uint32_t stackpos)
-{
-	if (stackpos < MAX_STACKPOS) {
-		if (!canSee(pos)) {
-			return;
-		}
-
-		NetworkMessage msg;
-		RemoveTileThing(msg, pos, stackpos);
-		writeToOutputBuffer(msg);
-		return;
-	}
-
-	NetworkMessage msg;
-	msg.addByte(0x6C);
-	msg.add<uint16_t>(0xFFFF);
-	msg.add<uint32_t>(creature->getID());
-	writeToOutputBuffer(msg);
-}
-
 void ProtocolGame::sendUpdateTile(const std::shared_ptr<const Tile>& tile, const Position& pos)
 {
 	if (!canSee(pos)) {
@@ -2681,7 +2670,7 @@ void ProtocolGame::sendFightModes()
 }
 
 void ProtocolGame::sendAddCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
-                                   int32_t stackpos, MagicEffectClasses magicEffect /*= CONST_ME_NONE*/)
+                                   int32_t stackpos, MagicEffectClasses magicEffect)
 {
 	assert(creature != player);
 
@@ -2689,19 +2678,7 @@ void ProtocolGame::sendAddCreature(const std::shared_ptr<const Creature>& creatu
 		return;
 	}
 
-	// stack pos is always real index now, so it can exceed the limit if stack pos exceeds the limit, we need to
-	// refresh the tile instead
-	// 1. this is a rare case, and is only triggered by forcing summon in a position
-	// 2. since no stackpos will be send to the client about that creature, removing it must be done with its id if
-	// its stackpos remains >= MAX_STACKPOS. this is done to add creatures to battle list instead of rendering on
-	// screen
-	if (stackpos >= MAX_STACKPOS) {
-		// @todo: should we avoid this check?
-		if (const auto& tile = creature->getTile()) {
-			sendUpdateTile(tile, pos);
-		}
-	} else {
-		// if stackpos is -1, the client will automatically detect it
+	if (stackpos != -1) {
 		NetworkMessage msg;
 		msg.addByte(0x6A);
 		msg.addPosition(pos);
@@ -2723,22 +2700,19 @@ void ProtocolGame::sendMoveCreature(const std::shared_ptr<const Creature>& creat
                                     int32_t newStackPos, const Position& oldPos, int32_t oldStackPos, bool teleport)
 {
 	if (creature == player) {
-		if (teleport) {
-			sendRemoveTileCreature(creature, oldPos, oldStackPos);
+		if (oldStackPos >= MAX_STACKPOS) {
+			sendMapDescription(newPos);
+		} else if (teleport) {
+			sendRemoveTileThing(oldPos, oldStackPos);
 			sendMapDescription(newPos);
 		} else {
 			NetworkMessage msg;
 			if (oldPos.z == 7 && newPos.z >= 8) {
-				RemoveTileCreature(msg, creature, oldPos, oldStackPos);
+				RemoveTileThing(msg, oldPos, oldStackPos);
 			} else {
 				msg.addByte(0x6D);
-				if (oldStackPos < MAX_STACKPOS) {
-					msg.addPosition(oldPos);
-					msg.addByte(oldStackPos);
-				} else {
-					msg.add<uint16_t>(0xFFFF);
-					msg.add<uint32_t>(creature->getID());
-				}
+				msg.addPosition(oldPos);
+				msg.addByte(oldStackPos);
 				msg.addPosition(newPos);
 			}
 
@@ -2784,24 +2758,19 @@ void ProtocolGame::sendMoveCreature(const std::shared_ptr<const Creature>& creat
 			writeToOutputBuffer(msg);
 		}
 	} else if (canSee(oldPos) && canSee(creature->getPosition())) {
-		if (teleport || (oldPos.z == 7 && newPos.z >= 8)) {
-			sendRemoveTileCreature(creature, oldPos, oldStackPos);
+		if (teleport || (oldPos.z == 7 && newPos.z >= 8) || oldStackPos >= MAX_STACKPOS) {
+			sendRemoveTileThing(oldPos, oldStackPos);
 			sendAddCreature(creature, newPos, newStackPos);
 		} else {
 			NetworkMessage msg;
 			msg.addByte(0x6D);
-			if (oldStackPos < MAX_STACKPOS) {
-				msg.addPosition(oldPos);
-				msg.addByte(oldStackPos);
-			} else {
-				msg.add<uint16_t>(0xFFFF);
-				msg.add<uint32_t>(creature->getID());
-			}
+			msg.addPosition(oldPos);
+			msg.addByte(oldStackPos);
 			msg.addPosition(creature->getPosition());
 			writeToOutputBuffer(msg);
 		}
 	} else if (canSee(oldPos)) {
-		sendRemoveTileCreature(creature, oldPos, oldStackPos);
+		sendRemoveTileThing(oldPos, oldStackPos);
 	} else if (canSee(creature->getPosition())) {
 		sendAddCreature(creature, newPos, newStackPos);
 	}
@@ -3360,19 +3329,6 @@ void ProtocolGame::RemoveTileThing(NetworkMessage& msg, const Position& pos, uin
 	msg.addByte(0x6C);
 	msg.addPosition(pos);
 	msg.addByte(stackpos);
-}
-
-void ProtocolGame::RemoveTileCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,
-                                      const Position& pos, uint32_t stackpos)
-{
-	if (stackpos < MAX_STACKPOS) {
-		RemoveTileThing(msg, pos, stackpos);
-		return;
-	}
-
-	msg.addByte(0x6C);
-	msg.add<uint16_t>(0xFFFF);
-	msg.add<uint32_t>(creature->getID());
 }
 
 void ProtocolGame::MoveUpCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -274,8 +274,6 @@ private:
 	void sendRemoveTileThing(const Position& pos, uint32_t stackpos);
 	void sendUpdateTileCreature(const Position& pos, uint32_t stackpos,
 	                            const std::shared_ptr<const Creature>& creature);
-	void sendRemoveTileCreature(const std::shared_ptr<const Creature>& creature, const Position& pos,
-	                            uint32_t stackpos);
 	void sendUpdateTile(const std::shared_ptr<const Tile>& tile, const Position& pos);
 
 	void sendUpdateCreatureIcons(const std::shared_ptr<const Creature>& creature);
@@ -324,8 +322,6 @@ private:
 
 	// tiles
 	static void RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos);
-	static void RemoveTileCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature,
-	                               const Position& pos, uint32_t stackpos);
 
 	void MoveUpCreature(NetworkMessage& msg, const std::shared_ptr<const Creature>& creature, const Position& newPos,
 	                    const Position& oldPos);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1163,6 +1163,62 @@ int32_t Tile::getClientIndexOfCreature(const std::shared_ptr<const Player>& play
 	return -1;
 }
 
+int32_t Tile::getStackposOfCreature(const std::shared_ptr<const Player>& player,
+                                    const std::shared_ptr<const Creature>& creature) const
+{
+	const bool isOwnTile = (getPosition() == player->getPosition());
+	int32_t n = ground ? 1 : 0;
+
+	if (const TileItemVector* items = getItemList()) {
+		int32_t topItemCount = items->getTopItemCount();
+		if (isOwnTile) {
+			// GetTileDescription caps top items at count == MAX_STACKPOS - 1 on the
+			// viewer's own tile to reserve the final visible slot for the player.
+			n += std::min(topItemCount, (MAX_STACKPOS - 1) - n);
+		} else {
+			n += topItemCount;
+			if (n >= MAX_STACKPOS) {
+				return -1;
+			}
+		}
+	}
+
+	if (const CreatureVector* creatures = getCreatures()) {
+		bool playerAdded = false;
+		for (const auto& tileCreature : *creatures | std::views::reverse) {
+			// GetTileDescription forces the player into the final visible slot
+			// when it hasn't been serialized naturally by count == MAX_STACKPOS - 1.
+			if (isOwnTile && n == (MAX_STACKPOS - 1) && !playerAdded) {
+				if (creature->getID() == player->getID()) {
+					return n;
+				}
+				// This creature and all subsequent ones are displaced.
+				return -1;
+			}
+
+			// Match the target creature at its physical position regardless of
+			// current visibility. Callers such as ghost-mode removal need the
+			// stackpos of a creature that has just become invisible.
+			if (tileCreature == creature) {
+				return n;
+			}
+
+			if (!player->canSeeCreature(tileCreature)) {
+				continue;
+			}
+
+			if (tileCreature->getID() == player->getID()) {
+				playerAdded = true;
+			}
+
+			if (++n >= MAX_STACKPOS) {
+				return -1;
+			}
+		}
+	}
+	return -1;
+}
+
 int32_t Tile::getStackposOfItem(const std::shared_ptr<const Player>& player,
                                 const std::shared_ptr<const Item>& item) const
 {

--- a/src/tile.h
+++ b/src/tile.h
@@ -204,6 +204,8 @@ public:
 
 	int32_t getClientIndexOfCreature(const std::shared_ptr<const Player>& player,
 	                                 const std::shared_ptr<const Creature>& creature) const;
+	int32_t getStackposOfCreature(const std::shared_ptr<const Player>& player,
+	                              const std::shared_ptr<const Creature>& creature) const;
 	int32_t getStackposOfItem(const std::shared_ptr<const Player>& player,
 	                          const std::shared_ptr<const Item>& item) const;
 


### PR DESCRIPTION
Fixes #428

## Summary

Restores bounded client tile stack semantics and removes obsolete deep-stack protocol behavior inherited from TFS #2673.

TFS #2673 introduced support for sending creatures beyond the normal tile stack limit, mainly to expose them in the battle list outside normal on-tile rendering. For Atlas' current bounded client tile semantics, the additional deep-stack serialization and special packet handling create unnecessary CPU/network work and protocol complexity.

This PR restores the bounded model used by the reference implementations while preserving Atlas' current architecture and `MAX_STACKPOS`.

Changes:

- Bound `GetTileDescription()` creature loop to `MAX_STACKPOS`
- Preserve own-player visibility on crowded tiles (slot 9 override)
- Restore separate bounded `getStackposOfCreature()`
- Retain `getClientIndexOfCreature()` only for deep-aware movement bookkeeping
- Stop sending tile operations for creatures outside the client-visible stack
- Remove `0xFFFF + creatureId` deep-stack move/turn/remove handling
- Remove `sendRemoveTileCreature()` and `RemoveTileCreature()`
- Restore canonical add/remove/move semantics using `sendRemoveTileThing()`
- Update ghost/invisibility paths accordingly

## Performance

Hotspot reductions under a crowded-tile movement workload:

| Hotspot | Before | After |
| --- | ---: | ---: |
| `Map::moveCreature` | 40.27% | 25.14% |
| `GetTileDescription` | 21.95% | 11.78% |
| `checkCreatureAsKnown` | 12.58% | 6.20% |
| `AddCreature` | 7.50% | 4.10% |
| `Protocol::onSendMessage` | 12.87% | 8.67% |

Measured with Linux `perf` while running a stress workload with **500 walking player bots** in crowded areas, exercising creature movement, tile refreshes, map serialization and network output.

The final capture contained **61K samples with 0 lost samples**.

These percentages represent hotspot reductions within the sampled workload, not whole-server speedup.

## Validation

- `git diff --check` clean
- Tested with a 500-player walking stress workload
- Crowded tile / deep creature movement tested
- No `unable to remove creature` client errors observed
- Tile serialization remains bounded to `MAX_STACKPOS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved creature positioning and visibility updates when creatures are moved, removed, hidden, or revealed.
  * Fixed tile rendering at maximum stack capacity.
  * Improved handling of player movement and creature updates in crowded tiles.
  * Prevented invalid or duplicate creature notifications from being sent to the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->