### PR TITLE
feat(pathfinding): introduce reusable deterministic pathfinder

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,7 @@ else ()
 endif ()
 
 add_library(tfslib ${tfs_SRC})
+target_include_directories(tfslib PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_compile_definitions(tfslib PRIVATE SPDLOG_HEADER_ONLY)
 target_link_libraries(tfslib PRIVATE
 	Boost::iostreams

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -184,7 +184,10 @@ target_sources(tfslib PRIVATE $<TARGET_OBJECTS:luascript>)
 add_subdirectory(events)
 target_sources(tfslib PRIVATE $<TARGET_OBJECTS:events>)
 
-add_custom_target(format COMMAND /usr/bin/clang-format -style=file -i ${tfs_HDR} ${tfs_SRC} ${tfs_MAIN} ${events_HDR})
+add_subdirectory(pathfinding)
+target_sources(tfslib PRIVATE $<TARGET_OBJECTS:pathfinding>)
+
+add_custom_target(format COMMAND /usr/bin/clang-format -style=file -i ${tfs_HDR} ${tfs_SRC} ${tfs_MAIN} ${events_HDR} ${pathfinding_HDR} ${pathfinding_SRC})
 
 set(tfs_RC "")
 if (WIN32)

--- a/src/benchs/CMakeLists.txt
+++ b/src/benchs/CMakeLists.txt
@@ -2,11 +2,13 @@ set(benchs_SRC
     ${CMAKE_CURRENT_LIST_DIR}/bench_base64.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bench_rsa.cpp
     ${CMAKE_CURRENT_LIST_DIR}/bench_xtea.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/bench_pathfinding.cpp
     )
 
 foreach(bench_src ${benchs_SRC})
     get_filename_component(bench_name ${bench_src} NAME_WE)
     add_executable(${bench_name} ${bench_src})
+    target_include_directories(${bench_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
     target_link_libraries(${bench_name} PRIVATE tfslib benchmark::benchmark)
 
     add_test(NAME ${bench_name} COMMAND ${bench_name})

--- a/src/benchs/bench_pathfinding.cpp
+++ b/src/benchs/bench_pathfinding.cpp
@@ -1,0 +1,296 @@
+#include "../otpch.h"
+
+#include "../pathfinding/pathfinder.h"
+
+#include <benchmark/benchmark.h>
+
+#include <utility>
+
+namespace
+{
+
+PathRequest makeRequest(const Position& start, const Position& target)
+{
+	return PathRequest::to(target)
+	    .from(start)
+	    .distance(0, 0)
+	    .requiringSight(false)
+	    .withLineOfSight(false);
+}
+
+template <typename TileCostFactory>
+void runPathBenchmark(benchmark::State& state, const PathRequest& request, TileCostFactory tileCostFactory)
+{
+	std::vector<Direction> directions;
+	for (auto&& _ : state) {
+		const auto status = PathFinder::find(request, tileCostFactory(), directions);
+		benchmark::DoNotOptimize(status);
+		benchmark::DoNotOptimize(directions.data());
+		benchmark::ClobberMemory();
+	}
+	state.SetItemsProcessed(state.iterations());
+}
+
+template <typename TileCostFactory, typename SightCheckFactory>
+void runPathBenchmarkWithSight(benchmark::State& state, const PathRequest& request,
+                               TileCostFactory tileCostFactory, SightCheckFactory sightCheckFactory)
+{
+	std::vector<Direction> directions;
+	for (auto&& _ : state) {
+		const auto status = PathFinder::find(request, tileCostFactory(), directions, sightCheckFactory());
+		benchmark::DoNotOptimize(status);
+		benchmark::DoNotOptimize(directions.data());
+		benchmark::ClobberMemory();
+	}
+	state.SetItemsProcessed(state.iterations());
+}
+
+template <typename TileCostFactory>
+void runPathBenchmarkSearchOnly(benchmark::State& state, const PathRequest& request, TileCostFactory tileCostFactory)
+{
+	std::vector<Direction> directions;
+	for (auto&& _ : state) {
+		state.PauseTiming();
+		{
+			auto tileCost = tileCostFactory();
+			state.ResumeTiming();
+			const auto status = PathFinder::find(request, std::move(tileCost), directions);
+			benchmark::DoNotOptimize(status);
+			benchmark::DoNotOptimize(directions.data());
+			benchmark::ClobberMemory();
+			state.PauseTiming();
+		}
+		state.ResumeTiming();
+	}
+	state.SetItemsProcessed(state.iterations());
+}
+
+template <typename TileCostFactory, typename SightCheckFactory>
+void runPathBenchmarkWithSightSearchOnly(benchmark::State& state, const PathRequest& request,
+                                         TileCostFactory tileCostFactory, SightCheckFactory sightCheckFactory)
+{
+	std::vector<Direction> directions;
+	for (auto&& _ : state) {
+		state.PauseTiming();
+		{
+			auto tileCost = tileCostFactory();
+			auto sightCheck = sightCheckFactory();
+			state.ResumeTiming();
+			const auto status = PathFinder::find(request, std::move(tileCost), directions, std::move(sightCheck));
+			benchmark::DoNotOptimize(status);
+			benchmark::DoNotOptimize(directions.data());
+			benchmark::ClobberMemory();
+			state.PauseTiming();
+		}
+		state.ResumeTiming();
+	}
+	state.SetItemsProcessed(state.iterations());
+}
+
+} // namespace
+
+static void bench_pathfinding_same_position(benchmark::State& state)
+{
+	const auto request = makeRequest(Position(0, 0, 7), Position(0, 0, 7));
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 0; };
+	});
+}
+BENCHMARK(bench_pathfinding_same_position);
+
+static void bench_pathfinding_adjacent_shortcut(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(1, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, 1)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 0; };
+	});
+}
+BENCHMARK(bench_pathfinding_adjacent_shortcut);
+
+static void bench_pathfinding_short_open(benchmark::State& state)
+{
+	const auto request = makeRequest(Position(0, 0, 7), Position(5, 0, 7));
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 10; };
+	});
+}
+BENCHMARK(bench_pathfinding_short_open);
+
+static void bench_pathfinding_viewport_edge(benchmark::State& state)
+{
+	const auto request = makeRequest(Position(0, 0, 7), Position(12, 0, 7));
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 10; };
+	});
+}
+BENCHMARK(bench_pathfinding_viewport_edge);
+
+static void bench_pathfinding_large_search(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(20, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, 0)
+	                         .maxDistance(64)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 10; };
+	});
+}
+BENCHMARK(bench_pathfinding_large_search);
+
+static void bench_pathfinding_obstacle_detour(benchmark::State& state)
+{
+	const auto request = makeRequest(Position(0, 0, 7), Position(6, 0, 7));
+	runPathBenchmark(state, request, [] {
+		return [](int32_t x, int32_t y) -> uint16_t {
+			if (x == 2 && y >= -2 && y <= 2) {
+				return 0;
+			}
+			return 10;
+		};
+	});
+}
+BENCHMARK(bench_pathfinding_obstacle_detour);
+
+static void bench_pathfinding_approach_range(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .mode(SearchMode::Approach)
+	                         .distance(1, 3)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 10; };
+	});
+}
+BENCHMARK(bench_pathfinding_approach_range);
+
+static void bench_pathfinding_flee_range(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7))
+	                         .from(Position(4, 0, 7))
+	                         .mode(SearchMode::Flee)
+	                         .distance(1, 3)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 10; };
+	});
+}
+BENCHMARK(bench_pathfinding_flee_range);
+
+static void bench_pathfinding_required_sight(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, 0)
+	                         .requiringSight(true)
+	                         .withLineOfSight(false);
+	runPathBenchmarkWithSight(
+	    state, request,
+	    [] { return [](int32_t, int32_t) -> uint16_t { return 10; }; },
+	    [] { return [](const Position&, const Position&) { return true; }; });
+}
+BENCHMARK(bench_pathfinding_required_sight);
+
+static void bench_pathfinding_budget_exhaustion(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(4, 0, 7))
+	                         .from(Position(0, 2, 7))
+	                         .mode(SearchMode::Approach)
+	                         .distance(0, 2)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	runPathBenchmark(state, request, [] {
+		return [](int32_t x, int32_t y) -> uint16_t {
+			if (x == 2 && y >= 0 && y <= 2) {
+				return 0;
+			}
+			if (y == 2 && x >= 2 && x <= 4) {
+				return 0;
+			}
+			return 10;
+		};
+	});
+}
+BENCHMARK(bench_pathfinding_budget_exhaustion);
+
+static void bench_pathfinding_no_path(benchmark::State& state)
+{
+	const auto request = makeRequest(Position(0, 0, 7), Position(5, 0, 7));
+	runPathBenchmark(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 0; };
+	});
+}
+BENCHMARK(bench_pathfinding_no_path);
+
+static void bench_pathfinding_short_open_search_only(benchmark::State& state)
+{
+	const auto request = makeRequest(Position(0, 0, 7), Position(5, 0, 7));
+	runPathBenchmarkSearchOnly(state, request, [] {
+		return [](int32_t, int32_t) -> uint16_t { return 10; };
+	});
+}
+BENCHMARK(bench_pathfinding_short_open_search_only);
+
+static void bench_pathfinding_required_sight_search_only(benchmark::State& state)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, 0)
+	                         .requiringSight(true)
+	                         .withLineOfSight(false);
+	runPathBenchmarkWithSightSearchOnly(
+	    state, request,
+	    [] { return [](int32_t, int32_t) -> uint16_t { return 10; }; },
+	    [] { return [](const Position&, const Position&) { return true; }; });
+}
+BENCHMARK(bench_pathfinding_required_sight_search_only);
+
+static void bench_pathfinding_tile_cost_callback_construction(benchmark::State& state)
+{
+	for (auto&& _ : state) {
+		TileCost callback = [](int32_t, int32_t) -> uint16_t { return 10; };
+		benchmark::DoNotOptimize(callback);
+	}
+}
+BENCHMARK(bench_pathfinding_tile_cost_callback_construction);
+
+static void bench_pathfinding_tile_cost_callback_invocation(benchmark::State& state)
+{
+	TileCost callback = [](int32_t, int32_t) -> uint16_t { return 10; };
+	for (auto&& _ : state) {
+		const auto value = callback(1, 2);
+		benchmark::DoNotOptimize(value);
+	}
+}
+BENCHMARK(bench_pathfinding_tile_cost_callback_invocation);
+
+static void bench_pathfinding_sight_callback_construction(benchmark::State& state)
+{
+	for (auto&& _ : state) {
+		SightCheck callback = [](const Position&, const Position&) { return true; };
+		benchmark::DoNotOptimize(callback);
+	}
+}
+BENCHMARK(bench_pathfinding_sight_callback_construction);
+
+static void bench_pathfinding_sight_callback_invocation(benchmark::State& state)
+{
+	SightCheck callback = [](const Position&, const Position&) { return true; };
+	const Position from(1, 2, 7);
+	const Position to(3, 4, 7);
+	for (auto&& _ : state) {
+		const auto visible = callback(from, to);
+		benchmark::DoNotOptimize(visible);
+	}
+}
+BENCHMARK(bench_pathfinding_sight_callback_invocation);
+
+BENCHMARK_MAIN();

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -10,6 +10,8 @@
 #include "events/creature.h"
 #include "game.h"
 #include "party.h"
+#include "pathfinding/path_request.h"
+#include "pathfinding/search_mode.h"
 #include "scheduler.h"
 
 double Creature::speedA = 857.36;
@@ -323,12 +325,12 @@ void Creature::onRemoveCreature(const std::shared_ptr<Creature>& creature, bool)
 	}
 }
 
-void Creature::updateFollowCreaturePath(FindPathParams& fpp)
+void Creature::updateFollowCreaturePath(PathRequest& request)
 {
 	listWalkDir.clear();
 
 	if (const auto& followCreature = getFollowCreature();
-	    followCreature && getPathTo(followCreature->getPosition(), listWalkDir, fpp)) {
+	    followCreature && getPathTo(followCreature->getPosition(), listWalkDir, request)) {
 		hasFollowPath = true;
 		startAutoWalk();
 	} else {
@@ -806,13 +808,12 @@ void Creature::setAttackedCreature(const std::shared_ptr<Creature>& creature)
 	}
 }
 
-void Creature::getPathSearchParams(const std::shared_ptr<const Creature>&, FindPathParams& fpp) const
+void Creature::getPathSearchParams(const std::shared_ptr<const Creature>&, PathRequest& request) const
 {
-	fpp.fullPathSearch = !hasFollowPath;
-	fpp.clearSight = true;
-	fpp.maxSearchDist = Map::maxViewportX + Map::maxViewportY;
-	fpp.minTargetDist = 1;
-	fpp.maxTargetDist = 1;
+	request.mode(!hasFollowPath ? SearchMode::Reach : SearchMode::Approach);
+	request.requiringSight(true);
+	request.maxDistance(Map::maxViewportX + Map::maxViewportY);
+	request.distance(1, 1);
 }
 
 void Creature::setFollowCreature(const std::shared_ptr<Creature>& creature)
@@ -1341,88 +1342,6 @@ void Creature::setCreatureLight(LightInfo lightInfo) { internalLight = std::move
 
 void Creature::setNormalCreatureLight() { internalLight = {}; }
 
-bool FrozenPathingConditionCall::isInRange(const Position& startPos, const Position& testPos,
-                                           const FindPathParams& fpp) const
-{
-	if (fpp.fullPathSearch) {
-		if (testPos.x > targetPos.x + fpp.maxTargetDist) {
-			return false;
-		}
-
-		if (testPos.x < targetPos.x - fpp.maxTargetDist) {
-			return false;
-		}
-
-		if (testPos.y > targetPos.y + fpp.maxTargetDist) {
-			return false;
-		}
-
-		if (testPos.y < targetPos.y - fpp.maxTargetDist) {
-			return false;
-		}
-	} else {
-		int32_t dx = startPos.getOffsetX(targetPos);
-
-		int32_t dxMax = (dx >= 0 ? fpp.maxTargetDist : 0);
-		if (testPos.x > targetPos.x + dxMax) {
-			return false;
-		}
-
-		int32_t dxMin = (dx <= 0 ? fpp.maxTargetDist : 0);
-		if (testPos.x < targetPos.x - dxMin) {
-			return false;
-		}
-
-		int32_t dy = startPos.getOffsetY(targetPos);
-
-		int32_t dyMax = (dy >= 0 ? fpp.maxTargetDist : 0);
-		if (testPos.y > targetPos.y + dyMax) {
-			return false;
-		}
-
-		int32_t dyMin = (dy <= 0 ? fpp.maxTargetDist : 0);
-		if (testPos.y < targetPos.y - dyMin) {
-			return false;
-		}
-	}
-	return true;
-}
-
-bool FrozenPathingConditionCall::operator()(const Position& startPos, const Position& testPos,
-                                            const FindPathParams& fpp, int32_t& bestMatchDist) const
-{
-	if (!isInRange(startPos, testPos, fpp)) {
-		return false;
-	}
-
-	if (fpp.clearSight && !g_game.isSightClear(testPos, targetPos, true)) {
-		return false;
-	}
-
-	int32_t testDist = std::max(targetPos.getDistanceX(testPos), targetPos.getDistanceY(testPos));
-	if (fpp.maxTargetDist == 1) {
-		if (testDist < fpp.minTargetDist || testDist > fpp.maxTargetDist) {
-			return false;
-		}
-
-		return true;
-	} else if (testDist <= fpp.maxTargetDist) {
-		if (testDist < fpp.minTargetDist) {
-			return false;
-		}
-
-		if (testDist == fpp.maxTargetDist) {
-			bestMatchDist = 0;
-			return true;
-		} else if (testDist > bestMatchDist) {
-			// not quite what we want, but the best so far
-			bestMatchDist = testDist;
-			return true;
-		}
-	}
-	return false;
-}
-
 bool Creature::isInvisible() const
 {
 	return std::find_if(conditions.begin(), conditions.end(), [](const std::unique_ptr<Condition>& condition) {
@@ -1430,22 +1349,21 @@ bool Creature::isInvisible() const
 	       }) != conditions.end();
 }
 
-bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const FindPathParams& fpp) const
+bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const PathRequest& request) const
 {
-	return g_game.map.getPathMatching(asCreature(), targetPos, dirList, FrozenPathingConditionCall(targetPos), fpp);
+	return g_game.map.getPathMatching(asCreature(), dirList, request);
 }
 
 bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirList, int32_t minTargetDist,
                          int32_t maxTargetDist, bool fullPathSearch /*= true*/, bool clearSight /*= true*/,
                          int32_t maxSearchDist /*= 0*/) const
 {
-	FindPathParams fpp;
-	fpp.fullPathSearch = fullPathSearch;
-	fpp.maxSearchDist = maxSearchDist;
-	fpp.clearSight = clearSight;
-	fpp.minTargetDist = minTargetDist;
-	fpp.maxTargetDist = maxTargetDist;
-	return getPathTo(targetPos, dirList, fpp);
+	auto request = PathRequest::to(targetPos).from(getPosition()).distance(minTargetDist, maxTargetDist)
+	                   .maxDistance(maxSearchDist).requiringSight(clearSight);
+	if (!fullPathSearch) {
+		request.mode(SearchMode::Approach);
+	}
+	return getPathTo(targetPos, dirList, request);
 }
 
 void Creature::setStorageValue(uint32_t key, std::optional<int32_t> value, bool isSpawn)

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1349,7 +1349,7 @@ bool Creature::isInvisible() const
 	       }) != conditions.end();
 }
 
-bool Creature::getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const PathRequest& request) const
+bool Creature::getPathTo(const Position& /*targetPos*/, std::vector<Direction>& dirList, const PathRequest& request) const
 {
 	return g_game.map.getPathMatching(asCreature(), dirList, request);
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -7,6 +7,7 @@
 #include "condition.h"
 #include "const.h"
 #include "enums.h"
+#include "pathfinding/path_request.h"
 #include "position.h"
 #include "tile.h"
 
@@ -37,18 +38,6 @@ enum slots_t : uint8_t
 	CONST_SLOT_LAST = CONST_SLOT_AMMO,
 };
 
-struct FindPathParams
-{
-	bool fullPathSearch = true;
-	bool clearSight = true;
-	bool allowDiagonal = true;
-	bool keepDistance = false;
-	bool summonTargetMaster = false;
-	int32_t maxSearchDist = 0;
-	int32_t minTargetDist = -1;
-	int32_t maxTargetDist = -1;
-};
-
 inline constexpr int32_t EVENT_CREATURECOUNT = 10;
 inline constexpr auto EVENT_CREATURE_THINK_INTERVAL = 1000ms;
 inline constexpr auto EVENT_CHECK_CREATURE_INTERVAL = EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT;
@@ -56,20 +45,6 @@ inline constexpr auto FOLLOW_EVENT_INTERVAL = 100ms;
 
 static constexpr uint32_t CREATURE_ID_MIN = 0x10000000;
 static constexpr uint32_t CREATURE_ID_MAX = std::numeric_limits<uint32_t>::max();
-
-class FrozenPathingConditionCall
-{
-public:
-	explicit FrozenPathingConditionCall(Position targetPos) : targetPos(std::move(targetPos)) {}
-
-	bool operator()(const Position& startPos, const Position& testPos, const FindPathParams& fpp,
-	                int32_t& bestMatchDist) const;
-
-	bool isInRange(const Position& startPos, const Position& testPos, const FindPathParams& fpp) const;
-
-private:
-	Position targetPos;
-};
 
 //////////////////////////////////////////////////////////////////////
 // Defines the Base class for all creatures and base functions which
@@ -198,7 +173,7 @@ public:
 	void addEventWalk(bool firstStep = false);
 	void stopEventWalk();
 	virtual void goToFollowCreature() = 0;
-	void updateFollowCreaturePath(FindPathParams& fpp);
+	void updateFollowCreaturePath(PathRequest& request);
 
 	// walk events
 	virtual void onWalk(Direction& dir);
@@ -350,7 +325,7 @@ public:
 
 	double getDamageRatio(const std::shared_ptr<Creature>& attacker) const;
 
-	bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const FindPathParams& fpp) const;
+	bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const PathRequest& request) const;
 	bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, int32_t minTargetDist,
 	               int32_t maxTargetDist, bool fullPathSearch = true, bool clearSight = true,
 	               int32_t maxSearchDist = 0) const;
@@ -410,7 +385,7 @@ protected:
 	virtual uint64_t getLostExperience() const { return 0; }
 	virtual void dropLoot(const std::shared_ptr<Container>&, const std::shared_ptr<Creature>&) {}
 	virtual uint16_t getLookCorpse() const { return 0; }
-	virtual void getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const;
+	virtual void getPathSearchParams(const std::shared_ptr<const Creature>& creature, PathRequest& request) const;
 	virtual void death(const std::shared_ptr<Creature>&) {}
 	virtual bool dropCorpse(const std::shared_ptr<Creature>& lastHitCreature,
 	                        const std::shared_ptr<Creature>& mostDamageCreature, bool lastHitUnjustified,

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -21,6 +21,7 @@ set(http_HDR
 	)
 
 add_library(http OBJECT ${http_SRC})
+target_include_directories(http PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(http PRIVATE Boost::json)
 
 if(NOT MSVC)

--- a/src/lua/modules/creature.cpp
+++ b/src/lua/modules/creature.cpp
@@ -5,6 +5,8 @@
 #include "../../condition.h"
 #include "../../events/events.h"
 #include "../../game.h"
+#include "../../pathfinding/path_request.h"
+#include "../../pathfinding/search_mode.h"
 #include "../api.h"
 #include "../env.h"
 #include "../meta.h"
@@ -884,17 +886,18 @@ int luaCreatureGetPathTo(lua_State* L)
 		return 1;
 	}
 
-	const Position& position = tfs::lua::getPosition(L, 2);
+	Position position = tfs::lua::getPosition(L, 2);
 
-	FindPathParams fpp;
-	fpp.minTargetDist = tfs::lua::getNumber<int32_t>(L, 3, 0);
-	fpp.maxTargetDist = tfs::lua::getNumber<int32_t>(L, 4, 1);
-	fpp.fullPathSearch = tfs::lua::getBoolean(L, 5, fpp.fullPathSearch);
-	fpp.clearSight = tfs::lua::getBoolean(L, 6, fpp.clearSight);
-	fpp.maxSearchDist = tfs::lua::getNumber<int32_t>(L, 7, fpp.maxSearchDist);
+	auto request = PathRequest::to(position).from(creature->getPosition())
+	                   .distance(tfs::lua::getNumber<int32_t>(L, 3, 0), tfs::lua::getNumber<int32_t>(L, 4, 1))
+	                   .maxDistance(tfs::lua::getNumber<int32_t>(L, 7, 0));
+	request.requiringSight(tfs::lua::getBoolean(L, 6, true));
+	if (!tfs::lua::getBoolean(L, 5, true)) {
+		request.mode(SearchMode::Approach);
+	}
 
 	std::vector<Direction> dirList;
-	if (creature->getPathTo(position, dirList, fpp)) {
+	if (creature->getPathTo(position, dirList, request)) {
 		lua_newtable(L);
 
 		int index = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -768,7 +768,7 @@ bool Map::getPathMatching(const std::shared_ptr<const Creature>& creature, std::
 			}
 		}
 
-		uint16_t cost = 0;
+		uint16_t cost = 1;
 		if (tile->getTopVisibleCreature(creature)) {
 			cost += PATHFIND_NORMAL_COST * 3;
 		}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10,11 +10,37 @@
 #include "game.h"
 #include "iomap.h"
 #include "iomapserialize.h"
+#include "pathfinding/constants.h"
+#include "pathfinding/pathfinder.h"
 #include "pugicast.h"
 
 extern Game g_game;
 
 namespace {
+
+constexpr ConditionType_t DamageToConditionType(CombatType_t type)
+{
+	switch (type) {
+		case COMBAT_FIREDAMAGE:
+			return CONDITION_FIRE;
+		case COMBAT_ENERGYDAMAGE:
+			return CONDITION_ENERGY;
+		case COMBAT_DROWNDAMAGE:
+			return CONDITION_DROWN;
+		case COMBAT_EARTHDAMAGE:
+			return CONDITION_POISON;
+		case COMBAT_ICEDAMAGE:
+			return CONDITION_FREEZING;
+		case COMBAT_HOLYDAMAGE:
+			return CONDITION_DAZZLED;
+		case COMBAT_DEATHDAMAGE:
+			return CONDITION_CURSED;
+		case COMBAT_PHYSICALDAMAGE:
+			return CONDITION_BLEEDING;
+		default:
+			return CONDITION_NONE;
+	}
+}
 
 bool loadHousesXML(const std::filesystem::path& filename)
 {
@@ -561,9 +587,7 @@ bool Map::isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor /*= fal
 	return !tile->hasProperty(CONST_PROP_BLOCKPROJECTILE);
 }
 
-namespace {
-
-bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding /*= false*/)
+bool Map::checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding) const
 {
 	float dx = x1 - x0;
 	float slope = (dx == 0) ? 1 : (y1 - y0) / dx;
@@ -571,7 +595,7 @@ bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t 
 
 	for (uint16_t x = x0 + 1; x < x1; ++x) {
 		// 0.1 is necessary to avoid loss of precision during calculation
-		if (!g_game.map.isTileClear(std::floor(yi + 0.1), x, z, false, pathfinding)) {
+		if (!isTileClear(std::floor(yi + 0.1), x, z, false, pathfinding)) {
 			return false;
 		}
 		yi += slope;
@@ -580,7 +604,7 @@ bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t 
 	return true;
 }
 
-bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding /*= false*/)
+bool Map::checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding) const
 {
 	float dx = x1 - x0;
 	float slope = (dx == 0) ? 1 : (y1 - y0) / dx;
@@ -588,7 +612,7 @@ bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t
 
 	for (uint16_t x = x0 + 1; x < x1; ++x) {
 		// 0.1 is necessary to avoid loss of precision during calculation
-		if (!g_game.map.isTileClear(x, std::floor(yi + 0.1), z, false, pathfinding)) {
+		if (!isTileClear(x, std::floor(yi + 0.1), z, false, pathfinding)) {
 			return false;
 		}
 		yi += slope;
@@ -596,8 +620,6 @@ bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t
 
 	return true;
 }
-
-} // namespace
 
 bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z,
                          bool pathfinding /*= false*/) const
@@ -620,19 +642,13 @@ bool Map::checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uin
 	return checkSlightLine(x0, y0, x1, y1, z, pathfinding);
 }
 
-bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor /*= false*/,
-                       bool pathfinding /*= false*/) const
+bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor /*= false*/) const
 {
 	// target is on the same floor
 	if (fromPos.z == toPos.z) {
 		// skip checks if toPos is next to us
 		if (fromPos.getDistanceX(toPos) < 2 && fromPos.getDistanceY(toPos) < 2) {
 			return true;
-		}
-
-		// Check for additional tile properties when pathfinding
-		if (pathfinding) {
-			return checkSightLine(fromPos.x, fromPos.y, toPos.x, toPos.y, fromPos.z, true);
 		}
 
 		// sight is clear or sameFloor is enabled
@@ -685,6 +701,16 @@ bool Map::isSightClear(const Position& fromPos, const Position& toPos, bool same
 	return checkSightLine(fromPos.x, fromPos.y, toPos.x, toPos.y, fromPos.z);
 }
 
+bool Map::isSightClearPathfinding(const Position& fromPos, const Position& toPos) const
+{
+	// Pathfinding sight also checks BLOCK_PATHFINDING tile properties. This is
+	// used only to decide whether PathFinder may apply straight-line pruning.
+	if (fromPos.getDistanceX(toPos) <= 1 && fromPos.getDistanceY(toPos) <= 1) {
+		return true;
+	}
+	return checkSightLine(fromPos.x, fromPos.y, toPos.x, toPos.y, fromPos.z, true);
+}
+
 const std::shared_ptr<Tile> Map::canWalkTo(const std::shared_ptr<const Creature>& creature, const Position& pos) const
 {
 	const auto& tile = getTile(pos.x, pos.y, pos.z);
@@ -705,307 +731,69 @@ const std::shared_ptr<Tile> Map::canWalkTo(const std::shared_ptr<const Creature>
 	return tile;
 }
 
-static uint16_t calculateHeuristic(const Position& p1, const Position& p2)
+bool Map::getPathMatching(const std::shared_ptr<const Creature>& creature, std::vector<Direction>& dirList,
+                          const PathRequest& request) const
 {
-	uint16_t dx = std::abs(p1.getX() - p2.getX());
-	uint16_t dy = std::abs(p1.getY() - p2.getY());
-	return dx * dx + dy * dy;
-}
-
-bool Map::getPathMatching(const std::shared_ptr<const Creature>& creature, const Position& targetPos,
-                          std::vector<Direction>& dirList, const FrozenPathingConditionCall& pathCondition,
-                          const FindPathParams& fpp) const
-{
-	Position pos = creature->getPosition();
-	const Position startPos = pos;
-
 	// We can't walk, no need to create path.
 	if (creature->getSpeed() <= 0) {
 		return false;
 	}
 
-	// We can't get paths up or down floors.
-	if (startPos.getZ() != targetPos.getZ()) {
-		return false;
-	}
+	// PathFinder::find handles the remaining pre-flight rules: different floors,
+	// targets within dance-step reach, and targets beyond the search distance.
+	// Pruning uses the pathfinding-specific sight check; candidate sight checks
+	// below use the regular sight callback.
+	const auto& position = creature->getPosition();
+	uint8_t z = position.getZ();
+	const auto& targetPos = request.goal().target;
 
-	int32_t distanceX = startPos.getDistanceX(targetPos);
-	int32_t distanceY = startPos.getDistanceY(targetPos);
-	// We are next to our target. Let dance step decide.
-	if (fpp.maxTargetDist <= 1 && distanceX <= 1 && distanceY <= 1) {
-		return true;
-	}
+	auto pathRequest = request;
+	pathRequest.from(position).withLineOfSight(isSightClearPathfinding(position, targetPos));
 
-	// Don't update path. The target is too far away.
-	int32_t maxDistanceX = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxViewportX + 1;
-	int32_t maxDistanceY = fpp.maxSearchDist ? fpp.maxSearchDist : Map::maxViewportY + 1;
-	if (distanceX > maxDistanceX || distanceY > maxDistanceY) {
-		return false;
-	}
-
-	static constexpr std::array<std::pair<int, int>, 8> allNeighbors = {
-	    {{-1, 0}, {0, 1}, {1, 0}, {0, -1}, {-1, -1}, {1, -1}, {1, 1}, {-1, 1}}};
-
-	bool sightClear = isSightClear(startPos, targetPos, true, true);
-
-	Position endPos;
-	AStarNodes nodes(pos.x, pos.y);
-
-	AStarNode* found = nullptr;
-	int32_t bestMatch = 0;
-	uint16_t iterations = 0;
-	AStarNode* n = nodes.getBestNode();
-	while (n) {
-		iterations++;
-
-		if (iterations >= Map::maxViewportX * Map::maxViewportY) {
-			return false;
+	auto getTileCost = [this, &creature, z](int32_t x, int32_t y) -> uint16_t
+	{
+		auto tile = getTile(static_cast<uint16_t>(x), static_cast<uint16_t>(y), z);
+		if (!tile) {
+			return 0;
 		}
 
-		const int32_t x = n->x;
-		const int32_t y = n->y;
-		pos.x = x;
-		pos.y = y;
-		if (pathCondition(startPos, pos, fpp, bestMatch)) {
-			found = n;
-			endPos = pos;
-			if (bestMatch == 0) {
-				break;
+		if (creature->getTile() != tile) {
+			uint32_t flags = FLAG_PATHFINDING;
+			if (!creature->asPlayer()) {
+				flags |= FLAG_IGNOREFIELDDAMAGE;
+			}
+
+			if (tile->queryAdd(0, creature, 1, flags) != RETURNVALUE_NOERROR) {
+				return 0;
 			}
 		}
 
-		for (uint8_t i = 0; i < 8; ++i) {
-			pos.x = x + allNeighbors[i].first;
-			pos.y = y + allNeighbors[i].second;
+		uint16_t cost = 0;
+		if (tile->getTopVisibleCreature(creature)) {
+			cost += PATHFIND_NORMAL_COST * 3;
+		}
 
-			int32_t startDistanceToNode = startPos.getDistanceX(pos) + startPos.getDistanceY(pos);
-			if (fpp.maxSearchDist != 0 && startDistanceToNode > fpp.maxSearchDist) {
-				continue;
-			} else if (fpp.maxSearchDist == 0 && (startDistanceToNode > (Map::maxViewportX + Map::maxViewportY))) {
-				continue;
-			}
-
-			if (fpp.keepDistance && !pathCondition.isInRange(startPos, pos, fpp)) {
-				continue;
-			}
-
-			// If sight is clear we can ignore a lot of nodes.
-			if (sightClear && !fpp.keepDistance && !fpp.summonTargetMaster && fpp.minTargetDist <= 1) {
-				int32_t startX = startPos.getX();
-				int32_t startY = startPos.getY();
-				int32_t targetX = targetPos.getX();
-				int32_t targetY = targetPos.getY();
-
-				// We don't need nodes behind us.
-				// We also do not need nodes on a different x or y if target and start is same x/y.
-				if (startX > targetX && pos.x > startX) {
-					continue;
-				} else if (startX == targetX && pos.x != startX) {
-					continue;
-				} else if (startX < targetX && pos.x < startX) {
-					continue;
-				}
-				if (startY > targetY && pos.y > startY) {
-					continue;
-				} else if (startY == targetY && pos.y != startY) {
-					continue;
-				} else if (startY < targetY && pos.y < startY) {
-					continue;
-				}
-
-				// We don't need nodes past the targetPos
-				if (startX > targetX && pos.x < targetX) {
-					continue;
-				} else if (startX < targetX && pos.x > targetX) {
-					continue;
-				}
-				if (startY > targetY && pos.y < targetY) {
-					continue;
-				} else if (startY < targetY && pos.y > targetY) {
-					continue;
-				}
-			}
-
-			std::shared_ptr<const Tile> tile;
-			AStarNode* neighborNode = nodes.getNodeByPosition(pos.x, pos.y);
-			if (neighborNode) {
-				tile = getTile(pos.x, pos.y, pos.z);
-			} else {
-				tile = canWalkTo(creature, pos);
-				if (!tile) {
-					continue;
-				}
-			}
-
-			// The cost to walk to this neighbor
-			const uint16_t g = n->g + AStarNodes::getMapWalkCost(n, pos) + AStarNodes::getTileWalkCost(creature, tile);
-			const uint16_t h = calculateHeuristic(pos, targetPos);
-			const uint16_t newf = h + g;
-
-			if (neighborNode) {
-				if (neighborNode->f <= newf) {
-					// The node on the closed/open list is cheaper than this one
-					continue;
-				}
-
-				neighborNode->g = g;
-				neighborNode->f = newf;
-				neighborNode->parent = n;
-			} else {
-				// Does not exist in the open/closed list, create a new node
-				if (!nodes.createNode(n, pos.x, pos.y, g, newf)) {
-					// Limit of nodes reached
-					return false;
-				}
+		if (const auto& field = tile->getFieldItem()) {
+			CombatType_t combatType = field->getCombatType();
+			const auto& monster = creature->asMonster();
+			if (!creature->isImmune(combatType) && !creature->hasCondition(DamageToConditionType(combatType)) &&
+			    (monster && !monster->canWalkOnFieldType(combatType))) {
+				cost += PATHFIND_NORMAL_COST * 18;
 			}
 		}
 
-		n = nodes.getBestNode();
+		return cost;
+	};
+
+	SightCheck sightCheck;
+	if (pathRequest.goal().requireSight) {
+		sightCheck = [this](const Position& fromPos, const Position& toPos) {
+			return isSightClear(fromPos, toPos, true);
+		};
 	}
 
-	if (!found) {
-		return false;
-	}
-
-	int32_t prevx = endPos.getX();
-	int32_t prevy = endPos.getY();
-
-	found = found->parent;
-	while (found) {
-		pos.x = found->x;
-		pos.y = found->y;
-
-		int32_t dx = pos.getX() - prevx;
-		int32_t dy = pos.getY() - prevy;
-
-		prevx = pos.x;
-		prevy = pos.y;
-
-		if (dx == 1 && dy == 1) {
-			dirList.push_back(DIRECTION_NORTHWEST);
-		} else if (dx == -1 && dy == 1) {
-			dirList.push_back(DIRECTION_NORTHEAST);
-		} else if (dx == 1 && dy == -1) {
-			dirList.push_back(DIRECTION_SOUTHWEST);
-		} else if (dx == -1 && dy == -1) {
-			dirList.push_back(DIRECTION_SOUTHEAST);
-		} else if (dx == 1) {
-			dirList.push_back(DIRECTION_WEST);
-		} else if (dx == -1) {
-			dirList.push_back(DIRECTION_EAST);
-		} else if (dy == 1) {
-			dirList.push_back(DIRECTION_NORTH);
-		} else if (dy == -1) {
-			dirList.push_back(DIRECTION_SOUTH);
-		}
-
-		found = found->parent;
-	}
-
-	return true;
-}
-
-// AStarNodes
-AStarNodes::AStarNodes(uint16_t x, uint16_t y)
-{
-	nodes.reserve(Map::nodeReserveSize);
-	nodeMap.reserve(Map::nodeReserveSize);
-	visited.reserve(Map::nodeReserveSize);
-	createNode(nullptr, x, y, 0, 0);
-}
-
-AStarNode* AStarNodes::createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f)
-{
-	if (nodes.size() == Map::nodeReserveSize) {
-		return nullptr;
-	}
-
-	uint32_t key = hashCoord(x, y);
-	nodes.emplace_back(AStarNode{parent, x, y, g, f});
-	AStarNode* node = &nodes.back();
-	nodeMap[key] = node;
-	openSet.push(node);
-	return node;
-}
-
-AStarNode* AStarNodes::getBestNode()
-{
-	while (!openSet.empty()) {
-		AStarNode* node = openSet.top();
-		openSet.pop();
-		uint32_t key = hashCoord(node->x, node->y);
-		if (visited.find(key) == visited.end()) {
-			visited.insert(key);
-			return node;
-		}
-	}
-	return nullptr;
-}
-
-AStarNode* AStarNodes::getNodeByPosition(uint16_t x, uint16_t y)
-{
-	auto it = nodeMap.find(hashCoord(x, y));
-	return (it != nodeMap.end()) ? it->second : nullptr;
-}
-
-uint16_t AStarNodes::getMapWalkCost(AStarNode* node, const Position& neighborPos)
-{
-	if (std::abs(node->x - neighborPos.x) == std::abs(node->y - neighborPos.y)) {
-		// diagonal movement extra cost
-		return MAP_DIAGONALWALKCOST;
-	}
-	return MAP_NORMALWALKCOST;
-}
-
-constexpr ConditionType_t DamageToConditionType(CombatType_t type)
-{
-	switch (type) {
-		case COMBAT_FIREDAMAGE:
-			return CONDITION_FIRE;
-
-		case COMBAT_ENERGYDAMAGE:
-			return CONDITION_ENERGY;
-
-		case COMBAT_DROWNDAMAGE:
-			return CONDITION_DROWN;
-
-		case COMBAT_EARTHDAMAGE:
-			return CONDITION_POISON;
-
-		case COMBAT_ICEDAMAGE:
-			return CONDITION_FREEZING;
-
-		case COMBAT_HOLYDAMAGE:
-			return CONDITION_DAZZLED;
-
-		case COMBAT_DEATHDAMAGE:
-			return CONDITION_CURSED;
-
-		case COMBAT_PHYSICALDAMAGE:
-			return CONDITION_BLEEDING;
-
-		default:
-			return CONDITION_NONE;
-	}
-}
-
-uint16_t AStarNodes::getTileWalkCost(const std::shared_ptr<const Creature>& creature,
-                                     const std::shared_ptr<const Tile>& tile)
-{
-	uint16_t cost = 0;
-	if (tile->getTopVisibleCreature(creature)) {
-		cost += MAP_NORMALWALKCOST * 3;
-	}
-
-	if (const auto& field = tile->getFieldItem()) {
-		CombatType_t combatType = field->getCombatType();
-		const auto& monster = creature->asMonster();
-		if (!creature->isImmune(combatType) && !creature->hasCondition(DamageToConditionType(combatType)) &&
-		    (monster && !monster->canWalkOnFieldType(combatType))) {
-			cost += MAP_NORMALWALKCOST * 18;
-		}
-	}
-	return cost;
+	const auto status = PathFinder::find(pathRequest, std::move(getTileCost), dirList, std::move(sightCheck));
+	return status != PathStatus::NoPath;
 }
 
 // QTreeNode

--- a/src/map.h
+++ b/src/map.h
@@ -5,6 +5,7 @@
 #define FS_MAP_H
 
 #include "house.h"
+#include "pathfinding/path_request.h"
 #include "position.h"
 #include "spawn.h"
 #include "town.h"
@@ -15,9 +16,6 @@ class Creature;
 class Tile;
 
 static constexpr int32_t MAP_MAX_LAYERS = 16;
-
-static constexpr uint16_t MAP_NORMALWALKCOST = 10;
-static constexpr uint16_t MAP_DIAGONALWALKCOST = 25;
 
 using SpectatorVec = boost::container::flat_set<std::shared_ptr<Creature>, std::owner_less<std::shared_ptr<Creature>>>;
 
@@ -31,45 +29,6 @@ struct PositionHash
 		boost::hash_combine(seed, position.z);
 		return seed;
 	}
-};
-
-struct FindPathParams;
-struct AStarNode
-{
-	AStarNode* parent;
-	uint16_t x, y;
-	uint16_t g, f;
-};
-
-inline uint32_t hashCoord(uint16_t x, uint16_t y) { return (static_cast<uint32_t>(x) << 16) | y; }
-
-class AStarNodes
-{
-public:
-	AStarNodes(uint16_t x, uint16_t y);
-
-	AStarNode* createNode(AStarNode* parent, uint16_t x, uint16_t y, uint16_t g, uint16_t f);
-	AStarNode* getBestNode();
-	AStarNode* getNodeByPosition(uint16_t x, uint16_t y);
-
-	static uint16_t getMapWalkCost(AStarNode* node, const Position& neighborPos);
-	static uint16_t getTileWalkCost(const std::shared_ptr<const Creature>& creature,
-	                                const std::shared_ptr<const Tile>& tile);
-
-private:
-	std::vector<AStarNode> nodes = {};
-	std::unordered_map<uint32_t, AStarNode*> nodeMap = {};
-	std::unordered_set<uint32_t> visited = {};
-
-	struct NodeCompare
-	{
-		bool operator()(AStarNode* a, AStarNode* b) const
-		{
-			return a->f > b->f; // Min-heap based on f score
-		}
-	};
-
-	std::priority_queue<AStarNode*, std::vector<AStarNode*>, NodeCompare> openSet;
 };
 
 using SpectatorCache = std::unordered_map<Position, SpectatorVec, PositionHash>;
@@ -89,7 +48,6 @@ struct Floor
 	std::shared_ptr<Tile> tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
 };
 
-class FrozenPathingConditionCall;
 class QTreeLeafNode;
 
 class QTreeNode
@@ -175,7 +133,6 @@ public:
 	static constexpr int32_t maxViewportY = 11; // min value: maxClientViewportY + 1
 	static constexpr int32_t maxClientViewportX = 8;
 	static constexpr int32_t maxClientViewportY = 6;
-	static constexpr int16_t nodeReserveSize = static_cast<int16_t>((maxViewportX * maxViewportY * 3) / 2);
 
 	uint32_t clean() const;
 
@@ -245,28 +202,15 @@ public:
 	                      int32_t rangey = Map::maxClientViewportY) const;
 
 	/**
-	 * Checks if there are no obstacles on that position
-	 *	\param blockFloor counts the ground tile as an obstacle
-	 *	\returns The result if there is an obstacle or not
+	 * Checks if path is clear from fromPos to toPos.
+	 * This only checks a straight line; for pathfinding use getPathMatching.
 	 */
-	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false, bool pathfinding = false) const;
-
-	/**
-	 * Checks if path is clear from fromPos to toPos
-	 * Notice: This only checks a straight line if the path is clear, for path
-	 *finding use getPathTo. \param fromPos from Source point \param toPos
-	 *Destination point \param sameFloor checks if the destination is on same
-	 *floor \returns The result if there is no obstacles
-	 */
-	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false,
-	                  bool pathfinding = false) const;
-	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding = false) const;
+	bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false) const;
 
 	const std::shared_ptr<Tile> canWalkTo(const std::shared_ptr<const Creature>& creature, const Position& pos) const;
 
-	bool getPathMatching(const std::shared_ptr<const Creature>& creature, const Position& targetPos,
-	                     std::vector<Direction>& dirList, const FrozenPathingConditionCall& pathCondition,
-	                     const FindPathParams& fpp) const;
+	bool getPathMatching(const std::shared_ptr<const Creature>& creature, std::vector<Direction>& dirList,
+	                     const PathRequest& request) const;
 
 	std::map<std::string, Position> waypoints;
 
@@ -277,6 +221,14 @@ public:
 
 	Spawns spawns;
 	Towns towns;
+
+private:
+	// Line-of-sight helpers (used internally by isSightClear and getPathMatching)
+	bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false, bool pathfinding = false) const;
+	bool checkSteepLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding) const;
+	bool checkSlightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding) const;
+	bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z, bool pathfinding = false) const;
+	bool isSightClearPathfinding(const Position& fromPos, const Position& toPos) const;
 
 private:
 	SpectatorCache spectatorCache;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -522,10 +522,10 @@ void Monster::goToFollowCreature()
 		return;
 	}
 
-	FindPathParams fpp;
-	getPathSearchParams(followCreature, fpp);
+	PathRequest request = PathRequest::to(followCreature->getPosition());
+	getPathSearchParams(followCreature, request);
 
-	const auto simpleStep = !isSummon() && (isFleeing() || fpp.maxTargetDist > 1);
+	const auto simpleStep = !isSummon() && (isFleeing() || request.goal().distance.max > 1);
 	if (simpleStep) {
 		auto direction = DIRECTION_NONE;
 		if (getDistanceStep(followCreature->getPosition(), direction, isFleeing())) {
@@ -540,7 +540,7 @@ void Monster::goToFollowCreature()
 		}
 	}
 
-	updateFollowCreaturePath(fpp);
+	updateFollowCreaturePath(request);
 	onFollowCreatureComplete();
 }
 
@@ -1952,35 +1952,33 @@ bool Monster::challengeCreature(const std::shared_ptr<Creature>& creature, bool 
 	return result;
 }
 
-void Monster::getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const
+void Monster::getPathSearchParams(const std::shared_ptr<const Creature>& creature, PathRequest& request) const
 {
-	Creature::getPathSearchParams(creature, fpp);
+	Creature::getPathSearchParams(creature, request);
 
-	fpp.minTargetDist = 1;
-	fpp.maxTargetDist = mType->info.targetDistance;
+	request.distance(1, mType->info.targetDistance);
 
 	if (isSummon()) {
 		if (const auto& followCreature = getFollowCreature(); followCreature && followCreature == getMaster()) {
-			fpp.summonTargetMaster = true;
+			request.summonTargetMaster();
 		}
 		if (getMaster() == creature) {
-			fpp.maxTargetDist = 2;
-			fpp.fullPathSearch = true;
+			request.distance(1, 2);
+			request.mode(SearchMode::Reach);
 		} else if (mType->info.targetDistance <= 1) {
-			fpp.fullPathSearch = true;
+			request.mode(SearchMode::Reach);
 		} else {
-			fpp.fullPathSearch = !canUseAttack(getPosition(), creature);
+			request.mode(canUseAttack(getPosition(), creature) ? SearchMode::Approach : SearchMode::Reach);
 		}
 	} else if (isFleeing()) {
-		// Distance should be higher than the client view range (Map::maxClientViewportX/Map::maxClientViewportY)
-		fpp.maxTargetDist = Map::maxViewportX;
-		fpp.clearSight = false;
-		fpp.keepDistance = true;
-		fpp.fullPathSearch = false;
+		// Keep the flee distance within the client viewport range.
+		request.distance(1, Map::maxViewportX);
+		request.requiringSight(false);
+		request.mode(SearchMode::Flee);
 	} else if (mType->info.targetDistance <= 1) {
-		fpp.fullPathSearch = true;
+		request.mode(SearchMode::Reach);
 	} else {
-		fpp.fullPathSearch = !canUseAttack(getPosition(), creature);
+		request.mode(canUseAttack(getPosition(), creature) ? SearchMode::Approach : SearchMode::Reach);
 	}
 }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -222,7 +222,7 @@ private:
 	void dropLoot(const std::shared_ptr<Container>& corpse, const std::shared_ptr<Creature>& lastHitCreature) override;
 	uint32_t getDamageImmunities() const override { return mType->info.damageImmunities; }
 	uint32_t getConditionImmunities() const override { return mType->info.conditionImmunities; }
-	void getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const override;
+	void getPathSearchParams(const std::shared_ptr<const Creature>& creature, PathRequest& request) const override;
 
 	friend class LuaScriptInterface;
 };

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -222,9 +222,9 @@ std::string Npc::getDescription(int32_t) const
 void Npc::goToFollowCreature()
 {
 	if (const auto& followCreature = getFollowCreature()) {
-		FindPathParams fpp;
-		getPathSearchParams(followCreature, fpp);
-		updateFollowCreaturePath(fpp);
+		PathRequest request = PathRequest::to(followCreature->getPosition());
+		getPathSearchParams(followCreature, request);
+		updateFollowCreaturePath(request);
 	}
 }
 

--- a/src/pathfinding/CMakeLists.txt
+++ b/src/pathfinding/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(pathfinding_SRC
+	${CMAKE_CURRENT_LIST_DIR}/path_goal.cpp
+	${CMAKE_CURRENT_LIST_DIR}/path_request.cpp
+	${CMAKE_CURRENT_LIST_DIR}/pathfinder.cpp
+	)
+
+set(pathfinding_HDR
+	${CMAKE_CURRENT_LIST_DIR}/constants.h
+	${CMAKE_CURRENT_LIST_DIR}/distance.h
+	${CMAKE_CURRENT_LIST_DIR}/path_goal.h
+	${CMAKE_CURRENT_LIST_DIR}/path_request.h
+	${CMAKE_CURRENT_LIST_DIR}/path_result.h
+	${CMAKE_CURRENT_LIST_DIR}/path_world.h
+	${CMAKE_CURRENT_LIST_DIR}/pathfinder.h
+	${CMAKE_CURRENT_LIST_DIR}/search_mode.h
+	)
+
+set(pathfinding_HDR ${pathfinding_HDR} PARENT_SCOPE)
+set(pathfinding_SRC ${pathfinding_SRC} PARENT_SCOPE)
+
+add_library(pathfinding OBJECT ${pathfinding_SRC})
+target_include_directories(pathfinding PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/pathfinding/constants.h
+++ b/src/pathfinding/constants.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Movement costs are added to the TileCost value for each newly claimed cell.
+static constexpr uint16_t PATHFIND_NORMAL_COST = 10;
+static constexpr uint16_t PATHFIND_DIAGONAL_COST = 25;
+
+// Iteration and node limits are hard failures: the search returns NoPath instead
+// of reconstructing a retained non-exact match when either limit is exhausted.
+inline constexpr size_t PATHFIND_ITERATION_BUDGET = 121;
+inline constexpr size_t PATHFIND_NODE_BUDGET = 181;

--- a/src/pathfinding/distance.h
+++ b/src/pathfinding/distance.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstdint>
+
+/**
+ * Minimum and maximum Chebyshev distances accepted by a PathGoal.
+ */
+struct DistanceRange
+{
+	int32_t min = 0;
+	int32_t max = 1;
+};
+
+/**
+ * Returns the Manhattan distance between two coordinates.
+ */
+[[nodiscard]] inline int32_t manhattanDistance(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+{
+	return std::abs(x1 - x2) + std::abs(y1 - y2);
+}
+
+/**
+ * Returns the Chebyshev distance between two coordinates.
+ */
+[[nodiscard]] inline int32_t chebyshevDistance(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+{
+	return std::max(std::abs(x1 - x2), std::abs(y1 - y2));
+}
+
+/**
+ * Returns the squared Euclidean distance between two coordinates.
+ */
+[[nodiscard]] inline int32_t squaredDistance(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
+{
+	const auto dx = x1 - x2;
+	const auto dy = y1 - y2;
+	return dx * dx + dy * dy;
+}

--- a/src/pathfinding/path_goal.cpp
+++ b/src/pathfinding/path_goal.cpp
@@ -1,0 +1,91 @@
+#include "otpch.h"
+
+#include "pathfinding/path_goal.h"
+
+bool PathGoal::isInRange(int32_t startX, int32_t startY, int32_t testX, int32_t testY) const
+{
+	const auto targetX = static_cast<int32_t>(target.x);
+	const auto targetY = static_cast<int32_t>(target.y);
+
+	if (mode == SearchMode::Reach) {
+		if (testX > targetX + distance.max || testX < targetX - distance.max) {
+			return false;
+		}
+		
+		if (testY > targetY + distance.max || testY < targetY - distance.max) {
+			return false;
+		}
+		return true;
+	}
+
+	// Approach and Flee keep the target-relative bounds on the side containing the
+	// start; an axis aligned with the target keeps both sides available.
+	const auto offsetX = startX - targetX;
+	const auto offsetY = startY - targetY;
+
+	const auto limitHighX = offsetX >= 0 ? distance.max : 0;
+	if (testX > targetX + limitHighX) {
+		return false;
+	}
+
+	const auto limitLowX = offsetX <= 0 ? distance.max : 0;
+	if (testX < targetX - limitLowX) {
+		return false;
+	}
+
+	const auto limitHighY = offsetY >= 0 ? distance.max : 0;
+	if (testY > targetY + limitHighY) {
+		return false;
+	}
+
+	const auto limitLowY = offsetY <= 0 ? distance.max : 0;
+	if (testY < targetY - limitLowY) {
+		return false;
+	}
+	return true;
+}
+
+GoalMatch PathGoal::evaluate(int32_t startX, int32_t startY, int32_t testX, int32_t testY, int32_t& bestMatch,
+                             SightCheck& sightCheck) const
+{
+	// A candidate must pass the mode-dependent bounds, optional sight check, and
+	// distance range. Candidates at the outer distance bound are terminal;
+	// other accepted candidates update bestMatch only when they improve it.
+	if (!isInRange(startX, startY, testX, testY)) {
+		return GoalMatch::None;
+	}
+
+	if (requireSight) {
+		if (!sightCheck) {
+			return GoalMatch::None;
+		}
+
+		const Position testPosition(testX, testY, target.z);
+		if (!sightCheck(testPosition, target)) {
+			return GoalMatch::None;
+		}
+	}
+
+	const auto testDistance = chebyshevDistance(testX, testY, target.x, target.y);
+	if (distance.max == 1) {
+		if (testDistance < distance.min || testDistance > distance.max) {
+			return GoalMatch::None;
+		}
+		return GoalMatch::Exact;
+	}
+
+	if (testDistance > distance.max || testDistance < distance.min) {
+		return GoalMatch::None;
+	}
+
+	if (testDistance == distance.max) {
+		bestMatch = 0;
+		return GoalMatch::Exact;
+	}
+
+	if (testDistance > bestMatch) {
+		bestMatch = testDistance;
+		return GoalMatch::Better;
+	}
+	return GoalMatch::None;
+}

--- a/src/pathfinding/path_goal.h
+++ b/src/pathfinding/path_goal.h
@@ -2,7 +2,7 @@
 
 #include "distance.h"
 #include "path_world.h"
-#include "position.h"
+#include "../position.h"
 #include "search_mode.h"
 
 #include <cstdint>

--- a/src/pathfinding/path_goal.h
+++ b/src/pathfinding/path_goal.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "distance.h"
+#include "path_world.h"
+#include "position.h"
+#include "search_mode.h"
+
+#include <cstdint>
+
+/**
+ * Result of evaluating a node against a PathGoal.
+ */
+enum class GoalMatch : uint8_t
+{
+	None, // The node does not satisfy the goal.
+	Better, // A better in-range match was found; keep searching for Exact.
+	Exact, // An accepted match that terminates the search.
+};
+
+/**
+ * Describes the stopping condition of a search without knowing the game world.
+ * When requireSight is true, a non-empty SightCheck must accept the candidate.
+ */
+struct PathGoal
+{
+	Position target;
+	SearchMode mode = SearchMode::Reach;
+	DistanceRange distance;
+	bool requireSight = true;
+
+	[[nodiscard]] bool isInRange(int32_t startX, int32_t startY, int32_t testX, int32_t testY) const;
+	[[nodiscard]] GoalMatch evaluate(int32_t startX, int32_t startY, int32_t testX, int32_t testY,
+	                                 int32_t& bestMatch, SightCheck& sightCheck) const;
+};

--- a/src/pathfinding/path_request.cpp
+++ b/src/pathfinding/path_request.cpp
@@ -1,0 +1,53 @@
+#include "otpch.h"
+
+#include "pathfinding/path_request.h"
+
+PathRequest PathRequest::to(const Position& target)
+{
+	PathRequest request;
+	request.start_ = target;
+	request.goal_.target = target;
+	return request;
+}
+
+PathRequest& PathRequest::from(const Position& position)
+{
+	start_ = position;
+	return *this;
+}
+
+PathRequest& PathRequest::mode(SearchMode mode)
+{
+	goal_.mode = mode;
+	return *this;
+}
+
+PathRequest& PathRequest::distance(int32_t minTargetDist, int32_t maxTargetDist)
+{
+	goal_.distance = { minTargetDist, maxTargetDist };
+	return *this;
+}
+
+PathRequest& PathRequest::maxDistance(int32_t maxSearchDist)
+{
+	maxDistance_ = maxSearchDist;
+	return *this;
+}
+
+PathRequest& PathRequest::requiringSight(bool require)
+{
+	goal_.requireSight = require;
+	return *this;
+}
+
+PathRequest& PathRequest::withLineOfSight(bool clearSight)
+{
+	lineOfSightClear_ = clearSight;
+	return *this;
+}
+
+PathRequest& PathRequest::summonTargetMaster()
+{
+	summoningTargetMaster_ = true;
+	return *this;
+}

--- a/src/pathfinding/path_request.h
+++ b/src/pathfinding/path_request.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "path_goal.h"
-#include "position.h"
+#include "../position.h"
 #include "search_mode.h"
 
 #include <cstdint>

--- a/src/pathfinding/path_request.h
+++ b/src/pathfinding/path_request.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "path_goal.h"
+#include "position.h"
+#include "search_mode.h"
+
+#include <cstdint>
+
+/**
+ * Describes a pathfinding request assembled through a builder.
+ * The goal target is also used as the search target for pruning and heuristics.
+ */
+class PathRequest
+{
+public:
+	/**
+	 * Creates a request for a target. The start defaults to the target until from() is called.
+	 */
+	[[nodiscard]] static PathRequest to(const Position& target);
+
+	[[nodiscard]] const Position& start() const { return start_; }
+	[[nodiscard]] const PathGoal& goal() const { return goal_; }
+	[[nodiscard]] int32_t maxDistance() const { return maxDistance_; }
+	[[nodiscard]] bool lineOfSightClear() const { return lineOfSightClear_; }
+	[[nodiscard]] bool summoningTargetMaster() const { return summoningTargetMaster_; }
+
+	PathRequest& from(const Position& position);
+
+	PathRequest& mode(SearchMode mode);
+
+	/**
+	 * Sets the minimum and maximum accepted Chebyshev distances from the target.
+	 */
+	PathRequest& distance(int32_t minTargetDist, int32_t maxTargetDist);
+
+	/**
+	 * Sets the maximum search distance. Zero selects the default pre-flight and
+	 * expansion limits.
+	 */
+	PathRequest& maxDistance(int32_t maxSearchDist);
+
+	/**
+	 * Enables or disables sight validation for goal candidates.
+	 */
+	PathRequest& requiringSight(bool require);
+
+	/**
+	 * Sets whether line-of-sight pruning is allowed.
+	 */
+	PathRequest& withLineOfSight(bool clearSight);
+
+	/**
+	 * Disables line-of-sight pruning when searching for the target's master.
+	 */
+	PathRequest& summonTargetMaster();
+
+private:
+	PathRequest() = default;
+
+	PathGoal goal_;
+	Position start_;
+	int32_t maxDistance_ = 0;
+	bool lineOfSightClear_ = true;
+	bool summoningTargetMaster_ = false;
+};

--- a/src/pathfinding/path_result.h
+++ b/src/pathfinding/path_result.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Outcome of a pathfinding search.
+ */
+enum class PathStatus : uint8_t
+{
+	NoPath, // No acceptable route was found, or a pre-flight or search limit rejected it.
+	Found, // An exact goal match was found, or the melee shortcut was accepted.
+	Partial, // Natural open-list exhaustion retained an in-range non-exact match.
+};

--- a/src/pathfinding/path_world.h
+++ b/src/pathfinding/path_world.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "position.h"
+
+#include <cstdint>
+#include <functional>
+
+/**
+ * Returns the additional cost of entering a tile. A cost of zero means blocked.
+ */
+using TileCost = std::move_only_function<uint16_t(int32_t, int32_t)>;
+
+/**
+ * Returns whether a straight line between two positions is clear of obstacles.
+ */
+using SightCheck = std::move_only_function<bool(const Position&, const Position&)>;

--- a/src/pathfinding/path_world.h
+++ b/src/pathfinding/path_world.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "position.h"
+#include "../position.h"
 
 #include <cstdint>
 #include <functional>

--- a/src/pathfinding/pathfinder.cpp
+++ b/src/pathfinding/pathfinder.cpp
@@ -281,11 +281,9 @@ public:
 						continue;
 					}
 
-					if (createdNodes >= PATHFIND_NODE_BUDGET) {
+					if (!reserveNode()) {
 						return PathStatus::NoPath;
 					}
-
-					++createdNodes;
 
 					const auto heuristicValue = squaredDistance(neighbourX, neighbourY, targetX, targetY);
 					const auto exactG = currentNode->g + movementCost + tileCost;
@@ -319,9 +317,21 @@ public:
 	}
 
 private:
+	bool reserveNode()
+	{
+		if (createdNodes >= PATHFIND_NODE_BUDGET) {
+			return false;
+		}
+		++createdNodes;
+		return true;
+	}
+
 	void seedStart()
 	{
 		if (Cell* cell = getCell(startX, startY)) {
+			if (!reserveNode()) {
+				return;
+			}
 			cell->epoch = epoch;
 			cell->node.parent = nullptr;
 			cell->node.x = startX;
@@ -329,7 +339,6 @@ private:
 			cell->node.g = 0;
 			cell->node.f = 0;
 			cell->node.order = nextOrder++;
-			++createdNodes;
 			pushOpenNode(cell);
 		}
 	}
@@ -489,9 +498,12 @@ PathStatus PathFinder::find(const PathRequest& request, TileCost getTileCost, st
 	const auto distanceX = std::abs(startX - targetX);
 	const auto distanceY = std::abs(startY - targetY);
 
-	// If max target distance is at most one tile and the target is at most one tile
-	// away on each axis, return the empty path for the caller's dance-step logic.
-	if (goal.distance.max <= 1 && distanceX <= 1 && distanceY <= 1) {
+	const auto targetDistance = std::max(distanceX, distanceY);
+
+	// Reach requests at one-tile range can defer to the caller's dance-step logic
+	// when the current position already satisfies the requested distance range.
+	if (goal.mode == SearchMode::Reach && goal.distance.max == 1 &&
+	    targetDistance >= goal.distance.min && targetDistance <= goal.distance.max) {
 		return PathStatus::Found;
 	}
 

--- a/src/pathfinding/pathfinder.cpp
+++ b/src/pathfinding/pathfinder.cpp
@@ -1,0 +1,521 @@
+#include "otpch.h"
+
+#include "pathfinding/pathfinder.h"
+
+#include "pathfinding/constants.h"
+#include "pathfinding/distance.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <vector>
+
+namespace
+{
+
+// The grid is centered on the start tile. Its radius is the requested Manhattan
+// limit capped by kMaxGridRadius; getCell rejects positions outside that grid.
+constexpr int32_t kMaxGridRadius = 64;
+constexpr int32_t kDefaultManhattanLimit = 22;
+// With maxDistance == 0, targets more than 12 tiles away on either axis are
+// rejected before the search starts.
+constexpr int32_t kDefaultAxisReach = 12;
+
+struct NeighbourOffset
+{
+	int8_t x;
+	int8_t y;
+	uint16_t movementCost;
+};
+
+constexpr NeighbourOffset neighbourOffsets[8] = {
+	{-1, 0, PATHFIND_NORMAL_COST},  {0, 1, PATHFIND_NORMAL_COST},  {1, 0, PATHFIND_NORMAL_COST},
+	{0, -1, PATHFIND_NORMAL_COST}, {-1, -1, PATHFIND_DIAGONAL_COST}, {1, -1, PATHFIND_DIAGONAL_COST},
+	{1, 1, PATHFIND_DIAGONAL_COST}, {-1, 1, PATHFIND_DIAGONAL_COST}};
+
+constexpr uint16_t kNoHeapIndex = std::numeric_limits<uint16_t>::max();
+
+struct Node
+{
+	// Parent pointers refer to nodes in the current thread's grid storage and
+	// remain valid for the duration of the search.
+	Node* parent = nullptr;
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t g = 0;
+	int32_t f = 0;
+	uint32_t order = 0; // Insertion order used for deterministic tie-breaking.
+	uint16_t heapIndex = kNoHeapIndex; // kNoHeapIndex means the node is not open.
+};
+
+struct Cell
+{
+	// A cell reuses its node and tile cost across searches. The epoch identifies
+	// whether those values belong to the current search.
+	Node node;
+	uint32_t epoch = 0; // A mismatched stamp means the cell may be reclaimed.
+	uint16_t tileCost = 0;
+};
+
+// Precomputes the target-relative bounds used by each candidate evaluation.
+// Reach keeps the full target-centered rectangle; Approach and Flee keep the
+// target-relative side containing the start on each axis.
+struct PreparedGoal
+{
+	PreparedGoal(const PathGoal& goal, int32_t startX, int32_t startY)
+	    : goal(goal), targetX(static_cast<int32_t>(goal.target.x)), targetY(static_cast<int32_t>(goal.target.y)),
+	      distanceMin(goal.distance.min), distanceMax(goal.distance.max)
+	{
+		if (goal.mode == SearchMode::Reach) {
+			rangeMinX = targetX - distanceMax;
+			rangeMaxX = targetX + distanceMax;
+			rangeMinY = targetY - distanceMax;
+			rangeMaxY = targetY + distanceMax;
+			return;
+		}
+
+		const auto offsetX = startX - targetX;
+		const auto offsetY = startY - targetY;
+		rangeMaxX = targetX + (offsetX >= 0 ? distanceMax : 0);
+		rangeMinX = targetX - (offsetX <= 0 ? distanceMax : 0);
+		rangeMaxY = targetY + (offsetY >= 0 ? distanceMax : 0);
+		rangeMinY = targetY - (offsetY <= 0 ? distanceMax : 0);
+	}
+
+	[[nodiscard]] bool isInRange(int32_t testX, int32_t testY) const
+	{
+		if (testX > rangeMaxX || testX < rangeMinX) {
+			return false;
+		}
+		if (testY > rangeMaxY || testY < rangeMinY) {
+			return false;
+		}
+		return true;
+	}
+
+	GoalMatch evaluate(int32_t testX, int32_t testY, int32_t& bestMatch, SightCheck& sightCheck) const
+	{
+		// A candidate must pass the mode-dependent bounds, optional sight check, and
+		// distance range. Candidates at the outer distance bound are terminal;
+		// other accepted candidates update bestMatch only when they improve it.
+		if (!isInRange(testX, testY)) {
+			return GoalMatch::None;
+		}
+
+		if (goal.requireSight) {
+			if (!sightCheck) {
+				return GoalMatch::None;
+			}
+			const Position testPosition(testX, testY, goal.target.z);
+			if (!sightCheck(testPosition, goal.target)) {
+				return GoalMatch::None;
+			}
+		}
+
+		const auto testDistance = chebyshevDistance(testX, testY, targetX, targetY);
+		if (distanceMax == 1) {
+			if (testDistance < distanceMin || testDistance > distanceMax) {
+				return GoalMatch::None;
+			}
+			return GoalMatch::Exact;
+		}
+
+		if (testDistance > distanceMax || testDistance < distanceMin) {
+			return GoalMatch::None;
+		}
+		if (testDistance == distanceMax) {
+			bestMatch = 0;
+			return GoalMatch::Exact;
+		}
+		if (testDistance > bestMatch) {
+			bestMatch = testDistance;
+			return GoalMatch::Better;
+		}
+		return GoalMatch::None;
+	}
+
+	const PathGoal& goal;
+	const int32_t targetX;
+	const int32_t targetY;
+	const int32_t distanceMin;
+	const int32_t distanceMax;
+	int32_t rangeMinX = 0;
+	int32_t rangeMaxX = 0;
+	int32_t rangeMinY = 0;
+	int32_t rangeMaxY = 0;
+};
+
+// Each thread owns scratch storage for the grid, open heap, and search epoch.
+// Capacities are retained between searches and grow only when a larger search needs them.
+thread_local std::vector<Cell> gridStorage;
+thread_local std::vector<Node*> openList;
+thread_local uint32_t searchEpoch = 0;
+
+class PathSearcher
+{
+public:
+	PathSearcher(int32_t startX, int32_t startY, int32_t gridRadius)
+	    : startX(startX), startY(startY), gridWidth(gridRadius * 2 + 1), gridHeight(gridRadius * 2 + 1),
+	      gridCenterX(gridWidth / 2), gridCenterY(gridHeight / 2),
+	      cellCount(static_cast<size_t>(gridWidth) * static_cast<size_t>(gridHeight)), epoch(++searchEpoch)
+	{
+		// On epoch wrap, clear all existing stamps before starting a new non-zero generation.
+		if (epoch == 0) {
+			std::fill(gridStorage.begin(), gridStorage.end(), Cell{});
+			epoch = ++searchEpoch;
+		}
+
+		if (gridStorage.size() < cellCount) {
+			gridStorage.resize(cellCount);
+		}
+
+		if (openList.capacity() < PATHFIND_NODE_BUDGET) {
+			openList.reserve(PATHFIND_NODE_BUDGET);
+		}
+
+		openList.clear();
+	}
+
+	PathStatus search(const PathGoal& goal, const PathRequest& request, TileCost& getTileCost,
+	                  std::vector<Direction>& directionList, SightCheck& sightCheck)
+	{
+		const PreparedGoal preparedGoal(goal, startX, startY);
+		const auto targetX = preparedGoal.targetX;
+		const auto targetY = preparedGoal.targetY;
+
+		Node* found = nullptr;
+		bool exactMatch = false;
+		int32_t bestMatch = 0;
+		size_t iterations = 0;
+		int32_t endX = targetX;
+		int32_t endY = targetY;
+
+		const auto keepDistance = goal.mode == SearchMode::Flee;
+		const auto pruningActive =
+		    request.lineOfSightClear() && !keepDistance && !request.summoningTargetMaster() && goal.distance.min <= 1;
+		const auto pruningMinX = std::min(startX, targetX);
+		const auto pruningMaxX = std::max(startX, targetX);
+		const auto pruningMinY = std::min(startY, targetY);
+		const auto pruningMaxY = std::max(startY, targetY);
+
+		// A clear direct line permits rectangle pruning for ordinary reach/approach
+		// searches. Flee, target-master searches, and ranges with min > 1 retain
+		// their broader exploration behavior.
+		// When active, discard neighbours outside the rectangle spanning start and target.
+		const auto maxDistance = request.maxDistance();
+		const auto manhattanLimit = maxDistance ? maxDistance : kDefaultManhattanLimit;
+
+		seedStart();
+
+		Node* currentNode = popBestNode();
+		while (currentNode) {
+			// Iteration and node limits are hard failures: return NoPath rather than
+			// reconstructing a retained non-exact match.
+			if (++iterations >= PATHFIND_ITERATION_BUDGET) {
+				return PathStatus::NoPath;
+			}
+
+			const auto match = preparedGoal.evaluate(currentNode->x, currentNode->y, bestMatch, sightCheck);
+			if (match != GoalMatch::None) {
+				found = currentNode;
+				endX = currentNode->x;
+				endY = currentNode->y;
+				if (match == GoalMatch::Exact) {
+					exactMatch = true;
+					break;
+				}
+			}
+
+			for (const auto& neighbour : neighbourOffsets) {
+				const auto offsetX = neighbour.x;
+				const auto offsetY = neighbour.y;
+				const auto neighbourX = currentNode->x + offsetX;
+				const auto neighbourY = currentNode->y + offsetY;
+
+				if (manhattanDistance(neighbourX, neighbourY, startX, startY) > manhattanLimit) {
+					continue;
+				}
+
+				if (keepDistance && !preparedGoal.isInRange(neighbourX, neighbourY)) {
+					continue;
+				}
+
+				if (pruningActive &&
+				    (neighbourX < pruningMinX || neighbourX > pruningMaxX || neighbourY < pruningMinY ||
+				     neighbourY > pruningMaxY)) {
+					continue;
+				}
+
+				Cell* cell = getCell(neighbourX, neighbourY);
+				if (!cell) {
+					continue;
+				}
+
+				const auto movementCost = neighbour.movementCost;
+
+				// TileCost is queried only when a cell is first claimed; later relaxations
+				// reuse the stored value and update the heap only while the node is open.
+				if (cell->epoch == epoch) {
+					const auto heuristicValue = squaredDistance(neighbourX, neighbourY, targetX, targetY);
+					const auto minimumG = currentNode->g + movementCost;
+
+					if (cell->node.f <= heuristicValue + minimumG) {
+						continue;
+					}
+
+					const auto exactG = minimumG + cell->tileCost;
+					const auto totalF = heuristicValue + exactG;
+
+					if (cell->node.f > totalF) {
+						cell->node.g = exactG;
+						cell->node.f = totalF;
+						cell->node.parent = currentNode;
+						if (cell->node.heapIndex != kNoHeapIndex) {
+							siftUp(&cell->node);
+						}
+					}
+				} else {
+					const auto tileCost = getTileCost(neighbourX, neighbourY);
+					if (tileCost == 0) {
+						continue;
+					}
+
+					if (createdNodes >= PATHFIND_NODE_BUDGET) {
+						return PathStatus::NoPath;
+					}
+
+					++createdNodes;
+
+					const auto heuristicValue = squaredDistance(neighbourX, neighbourY, targetX, targetY);
+					const auto exactG = currentNode->g + movementCost + tileCost;
+					const auto totalF = heuristicValue + exactG;
+
+					cell->epoch = epoch;
+					cell->node.parent = currentNode;
+					cell->node.x = neighbourX;
+					cell->node.y = neighbourY;
+					cell->node.g = exactG;
+					cell->node.f = totalF;
+					cell->node.order = nextOrder++;
+					cell->tileCost = tileCost;
+
+					pushOpenNode(cell);
+				}
+			}
+
+			currentNode = popBestNode();
+		}
+
+		if (!found) {
+			return PathStatus::NoPath;
+		}
+
+		reconstructPath(found, endX, endY, directionList);
+		// A terminal Exact match returns Found. If the open list is exhausted normally
+		// after retaining only a Better match, reconstruct that route as Partial; the
+		// route may be empty when the retained node is the start.
+		return exactMatch ? PathStatus::Found : PathStatus::Partial;
+	}
+
+private:
+	void seedStart()
+	{
+		if (Cell* cell = getCell(startX, startY)) {
+			cell->epoch = epoch;
+			cell->node.parent = nullptr;
+			cell->node.x = startX;
+			cell->node.y = startY;
+			cell->node.g = 0;
+			cell->node.f = 0;
+			cell->node.order = nextOrder++;
+			++createdNodes;
+			pushOpenNode(cell);
+		}
+	}
+
+	Cell* getCell(int32_t x, int32_t y)
+	{
+		const auto gridX = x - startX + gridCenterX;
+		const auto gridY = y - startY + gridCenterY;
+		if (gridX >= 0 && gridX < gridWidth && gridY >= 0 && gridY < gridHeight) {
+			return &gridStorage[static_cast<size_t>(gridY) * gridWidth + gridX];
+		}
+		return nullptr;
+	}
+
+	// Open nodes are ordered by lowest f; equal f values use insertion order so
+	// tie-breaking remains deterministic.
+	static bool comesBefore(const Node* lhs, const Node* rhs)
+	{
+		return lhs->f < rhs->f || (lhs->f == rhs->f && lhs->order < rhs->order);
+	}
+
+	void swapHeapEntries(size_t firstIndex, size_t secondIndex)
+	{
+		std::swap(openList[firstIndex], openList[secondIndex]);
+		openList[firstIndex]->heapIndex = static_cast<uint16_t>(firstIndex);
+		openList[secondIndex]->heapIndex = static_cast<uint16_t>(secondIndex);
+	}
+
+	void siftUp(Node* node)
+	{
+		size_t index = node->heapIndex;
+		while (index > 0) {
+			const size_t parentIndex = (index - 1) / 2;
+			if (!comesBefore(openList[index], openList[parentIndex])) {
+				break;
+			}
+
+			swapHeapEntries(index, parentIndex);
+			index = parentIndex;
+		}
+	}
+
+	void siftDown(size_t index)
+	{
+		while (true) {
+			const size_t leftIndex = index * 2 + 1;
+			if (leftIndex >= openList.size()) {
+				break;
+			}
+
+			const size_t rightIndex = leftIndex + 1;
+			size_t bestChildIndex = leftIndex;
+			if (rightIndex < openList.size() && comesBefore(openList[rightIndex], openList[leftIndex])) {
+				bestChildIndex = rightIndex;
+			}
+
+			if (!comesBefore(openList[bestChildIndex], openList[index])) {
+				break;
+			}
+
+			swapHeapEntries(index, bestChildIndex);
+			index = bestChildIndex;
+		}
+	}
+
+	void pushOpenNode(Cell* cell)
+	{
+		Node* node = &cell->node;
+		node->heapIndex = static_cast<uint16_t>(openList.size());
+		openList.push_back(node);
+		siftUp(node);
+	}
+
+	Node* popBestNode()
+	{
+		if (openList.empty()) {
+			return nullptr;
+		}
+
+		Node* bestNode = openList.front();
+		const size_t lastIndex = openList.size() - 1;
+		if (lastIndex != 0) {
+			openList.front() = openList.back();
+			openList.front()->heapIndex = 0;
+		}
+
+		openList.pop_back();
+
+		bestNode->heapIndex = kNoHeapIndex;
+
+		if (!openList.empty()) {
+			siftDown(0);
+		}
+
+		return bestNode;
+	}
+
+	void reconstructPath(Node* node, int32_t endX, int32_t endY, std::vector<Direction>& directionList) const
+	{
+		// Follow parents from the selected end node toward the start. Directions are
+		// appended end-to-start because Creature consumes listWalkDir from back().
+		Node* currentNode = node->parent;
+
+		auto previousX = endX;
+		auto previousY = endY;
+
+		while (currentNode) {
+			const auto deltaX = currentNode->x - previousX;
+			const auto deltaY = currentNode->y - previousY;
+
+			previousX = currentNode->x;
+			previousY = currentNode->y;
+
+			if (deltaX == 1 && deltaY == 1) { directionList.push_back(DIRECTION_NORTHWEST); }
+			else if (deltaX == -1 && deltaY == 1) { directionList.push_back(DIRECTION_NORTHEAST); }
+			else if (deltaX == 1 && deltaY == -1) { directionList.push_back(DIRECTION_SOUTHWEST); }
+			else if (deltaX == -1 && deltaY == -1) { directionList.push_back(DIRECTION_SOUTHEAST); }
+			else if (deltaX == 1) { directionList.push_back(DIRECTION_WEST); }
+			else if (deltaX == -1) { directionList.push_back(DIRECTION_EAST); }
+			else if (deltaY == 1) { directionList.push_back(DIRECTION_NORTH); }
+			else if (deltaY == -1) { directionList.push_back(DIRECTION_SOUTH); }
+
+			currentNode = currentNode->parent;
+		}
+	}
+
+	const int32_t startX;
+	const int32_t startY;
+	const int32_t gridWidth;
+	const int32_t gridHeight;
+	const int32_t gridCenterX;
+	const int32_t gridCenterY;
+	const size_t cellCount;
+	uint32_t epoch = 0;
+	size_t createdNodes = 0;
+	uint32_t nextOrder = 0;
+};
+
+} // namespace
+
+PathStatus PathFinder::find(const PathRequest& request, TileCost getTileCost, std::vector<Direction>& directionList,
+                            SightCheck sightCheck)
+{
+	const auto& goal = request.goal();
+	const auto startX = static_cast<int32_t>(request.start().x);
+	const auto startY = static_cast<int32_t>(request.start().y);
+
+	directionList.clear();
+
+	// Different start and target floors are rejected before searching.
+	if (request.start().z != goal.target.z) {
+		return PathStatus::NoPath;
+	}
+
+	const auto targetX = static_cast<int32_t>(goal.target.x);
+	const auto targetY = static_cast<int32_t>(goal.target.y);
+	const auto distanceX = std::abs(startX - targetX);
+	const auto distanceY = std::abs(startY - targetY);
+
+	// If max target distance is at most one tile and the target is at most one tile
+	// away on each axis, return the empty path for the caller's dance-step logic.
+	if (goal.distance.max <= 1 && distanceX <= 1 && distanceY <= 1) {
+		return PathStatus::Found;
+	}
+
+	// Reject targets beyond the configured axis reach before allocating the search grid.
+	const auto maxDistance = request.maxDistance();
+	const auto axisReach = maxDistance ? maxDistance : kDefaultAxisReach;
+	if (distanceX > axisReach || distanceY > axisReach) {
+		return PathStatus::NoPath;
+	}
+
+	const auto manhattanLimit = maxDistance ? maxDistance : kDefaultManhattanLimit;
+	const auto gridRadius = std::min(manhattanLimit, kMaxGridRadius);
+
+	PathSearcher searcher(startX, startY, gridRadius);
+	return searcher.search(goal, request, getTileCost, directionList, sightCheck);
+}
+
+std::expected<std::vector<Direction>, PathStatus> PathFinder::find(const PathRequest& request, TileCost getTileCost,
+                                                                   SightCheck sightCheck)
+{
+	std::vector<Direction> directionList;
+	const auto status = find(request, std::move(getTileCost), directionList, std::move(sightCheck));
+	if (status == PathStatus::NoPath) {
+		return std::unexpected(status);
+	}
+	return directionList;
+}

--- a/src/pathfinding/pathfinder.h
+++ b/src/pathfinding/pathfinder.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "path_request.h"
+#include "path_result.h"
+#include "path_world.h"
+#include "position.h"
+
+#include <expected>
+#include <vector>
+
+/**
+ * Cache-friendly A* search that reuses per-thread scratch storage after its
+ * initial allocation. Instances are intentionally not constructible.
+ *
+ * find() applies the request pre-flight rules before searching:
+ * - a start and target on different floors yield NoPath;
+ * - a target within melee reach yields Found with an empty path, leaving the
+ *   caller's dance-step to decide;
+ * - a target beyond the configured search distance yields NoPath.
+ *
+ * directionList is cleared before any pre-flight rejection. A required sight
+ * check must be supplied and accept the candidate.
+ *
+ * Obstacle and cost queries are supplied through TileCost and SightCheck.
+ */
+class PathFinder
+{
+public:
+	PathFinder() = delete;
+
+	/**
+	 * Searches for a route and writes its directions to directionList.
+	 * Directions are stored from the selected end node toward the start node so
+	 * callers can consume the last element as the next step.
+	 */
+	[[nodiscard]] static PathStatus find(const PathRequest& request, TileCost getTileCost,
+	                                     std::vector<Direction>& directionList, SightCheck sightCheck = {});
+
+	/**
+	 * Searches for a route and returns NoPath as an unexpected value. Partial
+	 * results are returned together with their directions.
+	 */
+	[[nodiscard]] static std::expected<std::vector<Direction>, PathStatus> find(const PathRequest& request,
+	                                                                             TileCost getTileCost,
+	                                                                             SightCheck sightCheck = {});
+};

--- a/src/pathfinding/pathfinder.h
+++ b/src/pathfinding/pathfinder.h
@@ -3,7 +3,7 @@
 #include "path_request.h"
 #include "path_result.h"
 #include "path_world.h"
-#include "position.h"
+#include "../position.h"
 
 #include <expected>
 #include <vector>

--- a/src/pathfinding/search_mode.h
+++ b/src/pathfinding/search_mode.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Describes the target behavior of a pathfinding search.
+ */
+enum class SearchMode : uint8_t
+{
+	Reach, // Search for an accepted position in the target range.
+	Approach, // Search while retaining the target-relative approach bounds.
+	Flee, // Keep expansion inside the target-relative bounds and seek their far edge.
+};

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3209,19 +3209,19 @@ void Player::goToFollowCreature()
 		return;
 	}
 
-	FindPathParams fpp;
-	getPathSearchParams(followCreature, fpp);
-	updateFollowCreaturePath(fpp);
+	PathRequest request = PathRequest::to(followCreature->getPosition());
+	getPathSearchParams(followCreature, request);
+	updateFollowCreaturePath(request);
 
 	if (!hasFollowPath) {
 		lastFailedFollow = std::chrono::steady_clock::now();
 	}
 }
 
-void Player::getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const
+void Player::getPathSearchParams(const std::shared_ptr<const Creature>& creature, PathRequest& request) const
 {
-	Creature::getPathSearchParams(creature, fpp);
-	fpp.fullPathSearch = true;
+	Creature::getPathSearchParams(creature, request);
+	request.mode(SearchMode::Reach);
 }
 
 uint64_t Player::getGainedExperience(const std::shared_ptr<Creature>& attacker) const

--- a/src/player.h
+++ b/src/player.h
@@ -1450,7 +1450,7 @@ private:
 	uint32_t getConditionImmunities() const override { return conditionImmunities; }
 	uint32_t getConditionSuppressions() const override { return conditionSuppressions; }
 	uint16_t getLookCorpse() const override;
-	void getPathSearchParams(const std::shared_ptr<const Creature>& creature, FindPathParams& fpp) const override;
+	void getPathSearchParams(const std::shared_ptr<const Creature>& creature, PathRequest& request) const override;
 
 	friend class IOLoginData;
 	friend class ProtocolGame;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -17,3 +17,16 @@ foreach(test_src ${tests_SRC})
 
     add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()
+
+set(pathfinding_tests_SRC
+    ${CMAKE_CURRENT_LIST_DIR}/test_pathfinding.cpp
+    )
+
+foreach(test_src ${pathfinding_tests_SRC})
+    get_filename_component(test_name ${test_src} NAME_WE)
+    add_executable(${test_name} ${test_src})
+    target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+    target_link_libraries(${test_name} PRIVATE pathfinding tfslib Boost::unit_test_framework)
+
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/src/tests/test_pathfinding.cpp
+++ b/src/tests/test_pathfinding.cpp
@@ -1,0 +1,609 @@
+#define BOOST_TEST_MODULE pathfinding
+
+#include "../otpch.h"
+
+#include "../pathfinding/path_goal.h"
+#include "../pathfinding/pathfinder.h"
+#include "../pathfinding/search_mode.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <limits>
+
+namespace
+{
+
+uint16_t alwaysWalkable(int32_t, int32_t)
+{
+	return 10;
+}
+
+uint16_t alwaysBlocked(int32_t, int32_t)
+{
+	return 0;
+}
+
+uint16_t walkable(int32_t, int32_t)
+{
+	return 10;
+}
+
+uint16_t blocked(int32_t, int32_t)
+{
+	return 0;
+}
+
+Position walkPath(Position position, const std::vector<Direction>& directions)
+{
+	for (auto it = directions.rbegin(); it != directions.rend(); ++it) {
+		switch (*it) {
+			case DIRECTION_NORTH: --position.y; break;
+			case DIRECTION_EAST: ++position.x; break;
+			case DIRECTION_SOUTH: ++position.y; break;
+			case DIRECTION_WEST: --position.x; break;
+			case DIRECTION_NORTHWEST: --position.x; --position.y; break;
+			case DIRECTION_NORTHEAST: ++position.x; --position.y; break;
+			case DIRECTION_SOUTHWEST: --position.x; ++position.y; break;
+			case DIRECTION_SOUTHEAST: ++position.x; ++position.y; break;
+			default: break;
+		}
+	}
+	return position;
+}
+
+int32_t chebyshevDistance(const Position& lhs, const Position& rhs)
+{
+	return std::max(lhs.getDistanceX(rhs), lhs.getDistanceY(rhs));
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_CASE(test_same_position)
+{
+	const auto request = PathRequest::to(Position(3, 3, 7)).from(Position(3, 3, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysBlocked, dirList) == PathStatus::Found);
+	BOOST_CHECK(dirList.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_unreachable)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysBlocked, dirList) == PathStatus::NoPath);
+	BOOST_CHECK(dirList.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_single_cardinal_step)
+{
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(dirList.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_single_diagonal_step)
+{
+	const auto request = PathRequest::to(Position(2, 2, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(dirList.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_linear_path_three_steps)
+{
+	const auto request = PathRequest::to(Position(3, 0, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::Found);
+	BOOST_CHECK_GE(dirList.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_cost_avoidance_chooses_cheaper_path)
+{
+	auto expensiveStraight = [](int32_t x, int32_t y) -> uint16_t {
+		if (x == 1 && y == 0) return 200;
+		if (x == 1 && y == -1) return 0;
+		return 10;
+	};
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0)
+	                         .maxDistance(5).requiringSight(false).withLineOfSight(false);
+	std::vector<Direction> dirList;
+	BOOST_REQUIRE(PathFinder::find(request, expensiveStraight, dirList) == PathStatus::Found);
+	BOOST_REQUIRE_EQUAL(dirList.size(), 2);
+	BOOST_CHECK_EQUAL(dirList[0], DIRECTION_NORTHEAST);
+	BOOST_CHECK_EQUAL(dirList[1], DIRECTION_SOUTHEAST);
+}
+
+BOOST_AUTO_TEST_CASE(test_zero_cost_blocked)
+{
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysBlocked, dirList) == PathStatus::NoPath);
+	BOOST_CHECK(dirList.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_minimal_cost_leads_to_shortest_path)
+{
+	auto expensiveDiagonal = [](int32_t x, int32_t y) -> uint16_t {
+		if (x == 1 && y == 1) return 200;
+		return 10;
+	};
+	const auto request = PathRequest::to(Position(2, 2, 7)).from(Position(0, 0, 7)).distance(0, 1)
+	                         .requiringSight(false).withLineOfSight(true);
+	std::vector<Direction> dirList;
+	BOOST_REQUIRE(PathFinder::find(request, expensiveDiagonal, dirList) == PathStatus::Found);
+	BOOST_REQUIRE_EQUAL(dirList.size(), 2);
+	BOOST_CHECK_EQUAL(dirList[0], DIRECTION_SOUTHEAST);
+	BOOST_CHECK_EQUAL(dirList[1], DIRECTION_SOUTH);
+}
+
+BOOST_AUTO_TEST_CASE(test_max_search_dist_limits_exploration)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7)).from(Position(0, 0, 7)).distance(0, 1)
+	                         .maxDistance(2).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::NoPath);
+	BOOST_CHECK(dirList.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_goal_is_in_range)
+{
+	PathGoal goal;
+	goal.target = Position(5, 3, 7);
+	goal.mode = SearchMode::Reach;
+	goal.distance = { 1, 3 };
+
+	BOOST_CHECK(!goal.isInRange(0, 0, 0, 0));
+	BOOST_CHECK(goal.isInRange(0, 0, 4, 2));
+	BOOST_CHECK(goal.isInRange(0, 0, 2, 1));
+	BOOST_CHECK(!goal.isInRange(0, 0, 9, 3));
+}
+
+BOOST_AUTO_TEST_CASE(test_ipathmap_custom_costs)
+{
+	auto customCost = [](int32_t x, int32_t y) -> uint16_t {
+		if (x == 0 && y == 1) return 0;
+		if (x == 1 && y == 1) return 50;
+		return 10;
+	};
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, customCost, dirList) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(dirList.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_ipathmap_all_blocked_except_one)
+{
+	auto narrowPath = [](int32_t x, int32_t y) -> uint16_t {
+		if (x == 0 && y == 1) return 10;
+		return 0;
+	};
+	const auto request = PathRequest::to(Position(0, 2, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, narrowPath, dirList) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(dirList.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_long_path_within_limits)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7)).from(Position(0, 0, 7)).distance(0, 1)
+	                         .maxDistance(10).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::Found);
+	BOOST_CHECK_GT(dirList.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_goal_at_start_position)
+{
+	const auto request = PathRequest::to(Position(7, 8, 7)).from(Position(7, 8, 7)).distance(0, 0).requiringSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, alwaysBlocked, dirList) == PathStatus::Found);
+	BOOST_CHECK(dirList.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_pruned_path_to_exact_target)
+{
+	const auto request = PathRequest::to(Position(5, 5, 7)).from(Position(0, 0, 7)).distance(0, 0)
+	                         .requiringSight(false).withLineOfSight(true);
+	std::vector<Direction> dirList;
+	BOOST_REQUIRE(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::Found);
+	BOOST_REQUIRE(!dirList.empty());
+	const auto end = walkPath(Position(0, 0, 7), dirList);
+	BOOST_CHECK_EQUAL(end.x, 5);
+	BOOST_CHECK_EQUAL(end.y, 5);
+}
+
+BOOST_AUTO_TEST_CASE(test_no_path_when_search_budget_exhausted)
+{
+	auto blockedExactEdge = [](int32_t x, int32_t y) -> uint16_t {
+		if (x == 2 && y >= 0 && y <= 2) return 0;
+		if (y == 2 && x >= 2 && x <= 4) return 0;
+		return 10;
+	};
+	const auto request = PathRequest::to(Position(4, 0, 7)).from(Position(0, 2, 7)).mode(SearchMode::Approach)
+	                         .distance(0, 2).requiringSight(false).withLineOfSight(false);
+	std::vector<Direction> dirList;
+	BOOST_CHECK(PathFinder::find(request, blockedExactEdge, dirList) == PathStatus::NoPath);
+	BOOST_CHECK(dirList.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_reaches_twelve_tile_edge)
+{
+	const auto request = PathRequest::to(Position(12, 0, 7)).from(Position(0, 0, 7)).distance(0, 0)
+	                         .requiringSight(false).withLineOfSight(false);
+	std::vector<Direction> dirList;
+	BOOST_REQUIRE(PathFinder::find(request, alwaysWalkable, dirList) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(dirList.size(), 12);
+	const auto end = walkPath(Position(0, 0, 7), dirList);
+	BOOST_CHECK_EQUAL(end.x, 12);
+	BOOST_CHECK_EQUAL(end.y, 0);
+}
+
+BOOST_AUTO_TEST_CASE(different_floors_return_no_path_and_clear_output)
+{
+	std::vector<Direction> directions{DIRECTION_EAST};
+	const auto request = PathRequest::to(Position(2, 0, 8)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(default_axis_limit_rejects_distant_target)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(13, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(explicit_search_limit_rejects_target_before_search)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(5, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).maxDistance(2).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(negative_search_limit_does_not_search)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(5, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).maxDistance(-1).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(inverted_distance_range_returns_no_path)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(5, 0, 7)).from(Position(0, 0, 7)).distance(3, 1).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(required_sight_without_callback_returns_no_path)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0);
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(rejected_sight_returns_no_path)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0);
+	auto sightBlocked = [](const Position&, const Position&) { return false; };
+	BOOST_CHECK(PathFinder::find(request, walkable, directions, std::move(sightBlocked)) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(disabled_sight_does_not_invoke_callback)
+{
+	std::vector<Direction> directions;
+	int sightCalls = 0;
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	auto sight = [&sightCalls](const Position&, const Position&) {
+		++sightCalls;
+		return false;
+	};
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions, std::move(sight)) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(sightCalls, 0);
+}
+
+BOOST_AUTO_TEST_CASE(blocked_target_returns_no_path)
+{
+	std::vector<Direction> directions;
+	auto targetBlocked = [](int32_t x, int32_t y) -> uint16_t { return x == 2 && y == 0 ? 0 : 10; };
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, targetBlocked, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(start_tile_is_not_required_to_have_positive_cost)
+{
+	std::vector<Direction> directions;
+	auto blockedStart = [](int32_t x, int32_t y) -> uint16_t { return x == 0 && y == 0 ? 0 : 10; };
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, blockedStart, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(adjacent_target_uses_dance_step_shortcut)
+{
+	std::vector<Direction> directions;
+	const auto request = PathRequest::to(Position(1, 0, 7)).from(Position(0, 0, 7)).distance(0, 1).requiringSight(false);
+	BOOST_CHECK(PathFinder::find(request, blocked, directions) == PathStatus::Found);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(expected_overload_returns_value_or_error)
+{
+	const auto foundRequest = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	const auto noPathRequest = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	auto found = PathFinder::find(foundRequest, walkable);
+	auto noPath = PathFinder::find(noPathRequest, blocked);
+	BOOST_REQUIRE(found.has_value());
+	BOOST_CHECK_EQUAL(found->size(), 2);
+	BOOST_REQUIRE(!noPath.has_value());
+	BOOST_CHECK(noPath.error() == PathStatus::NoPath);
+}
+
+BOOST_AUTO_TEST_CASE(reach_mode_finds_exact_target)
+{
+	const Position start(0, 0, 7);
+	const Position target(4, 0, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Reach).distance(0, 0).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	const auto end = walkPath(start, directions);
+	BOOST_CHECK_EQUAL(end.x, target.x);
+	BOOST_CHECK_EQUAL(end.y, target.y);
+	BOOST_CHECK_EQUAL(end.z, target.z);
+}
+
+BOOST_AUTO_TEST_CASE(reach_mode_stops_at_requested_maximum_distance)
+{
+	const Position start(0, 0, 7);
+	const Position target(5, 0, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Reach).distance(1, 3).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(chebyshevDistance(walkPath(start, directions), target), 3);
+}
+
+BOOST_AUTO_TEST_CASE(approach_mode_reaches_near_side_of_target)
+{
+	const Position start(0, 0, 7);
+	const Position target(5, 0, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Approach).distance(1, 3).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(chebyshevDistance(walkPath(start, directions), target), 3);
+}
+
+BOOST_AUTO_TEST_CASE(approach_mode_respects_direction_from_right_side)
+{
+	const Position start(10, 0, 7);
+	const Position target(5, 0, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Approach).distance(1, 3).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(chebyshevDistance(walkPath(start, directions), target), 3);
+}
+
+BOOST_AUTO_TEST_CASE(flee_mode_moves_to_the_far_edge_of_range)
+{
+	const Position start(4, 0, 7);
+	const Position target(5, 0, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Flee).distance(1, 3).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	const auto end = walkPath(start, directions);
+	BOOST_CHECK_EQUAL(chebyshevDistance(end, target), 3);
+	BOOST_CHECK_LT(end.x, start.x);
+}
+
+BOOST_AUTO_TEST_CASE(minimum_distance_is_enforced)
+{
+	const Position start(0, 0, 7);
+	const Position target(4, 0, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Reach).distance(2, 3).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	const auto distance = chebyshevDistance(walkPath(start, directions), target);
+	BOOST_CHECK_GE(distance, 2);
+	BOOST_CHECK_LE(distance, 3);
+}
+
+BOOST_AUTO_TEST_CASE(line_of_sight_pruning_still_reaches_diagonal_target)
+{
+	const Position start(0, 0, 7);
+	const Position target(5, 5, 7);
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Reach).distance(0, 0).requiringSight(false).withLineOfSight(true);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	const auto end = walkPath(start, directions);
+	BOOST_CHECK_EQUAL(end.x, target.x);
+	BOOST_CHECK_EQUAL(end.y, target.y);
+	BOOST_CHECK_EQUAL(end.z, target.z);
+}
+
+BOOST_AUTO_TEST_CASE(no_path_is_returned_when_fleeing_has_no_reachable_edge)
+{
+	const Position start(0, 0, 7);
+	const Position target(10, 0, 7);
+	auto onlyStart = [start](int32_t x, int32_t y) -> uint16_t { return x == start.x && y == start.y ? 10 : 0; };
+	const auto request = PathRequest::to(target).from(start).mode(SearchMode::Flee).distance(1, 3).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_CHECK(PathFinder::find(request, onlyStart, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(storage_is_reusable_after_a_large_search)
+{
+	const auto largeRequest = PathRequest::to(Position(20, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).maxDistance(64).requiringSight(false);
+	std::vector<Direction> largePath;
+	BOOST_REQUIRE(PathFinder::find(largeRequest, walkable, largePath) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(largePath.size(), 20);
+	auto shortCorridor = [](int32_t x, int32_t y) -> uint16_t { return y == 0 && x >= 1 && x <= 2 ? 10 : 0; };
+	const auto shortRequest = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).maxDistance(2).requiringSight(false);
+	std::vector<Direction> shortPath;
+	BOOST_REQUIRE(PathFinder::find(shortRequest, shortCorridor, shortPath) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(shortPath.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(failed_search_does_not_poison_the_next_search)
+{
+	const auto request = PathRequest::to(Position(3, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_CHECK(PathFinder::find(request, [](int32_t, int32_t) -> uint16_t { return 0; }, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(output_is_replaced_on_success_after_previous_path)
+{
+	const auto firstRequest = PathRequest::to(Position(3, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	const auto secondRequest = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(firstRequest, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 3);
+	BOOST_REQUIRE(PathFinder::find(secondRequest, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(tile_cost_zero_is_the_only_blocked_value)
+{
+	auto positiveCost = [](int32_t x, int32_t y) -> uint16_t {
+		if (x == 1 && y == 0) return 1;
+		return x == 2 && y == 0 ? 1 : 0;
+	};
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_REQUIRE(PathFinder::find(request, positiveCost, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(maximum_tile_cost_does_not_overflow_path_cost)
+{
+	auto expensive = [](int32_t, int32_t) -> uint16_t { return std::numeric_limits<uint16_t>::max(); };
+	const auto request = PathRequest::to(Position(2, 0, 7)).from(Position(0, 0, 7)).distance(0, 0).requiringSight(false);
+	std::vector<Direction> directions;
+	BOOST_CHECK(PathFinder::find(request, expensive, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(explicit_search_limit_allows_target_beyond_default_viewport)
+{
+	const auto request = PathRequest::to(Position(13, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, 0)
+	                         .maxDistance(13)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	std::vector<Direction> directions;
+
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions) == PathStatus::Found);
+	BOOST_CHECK_EQUAL(directions.size(), 13);
+	const auto end = walkPath(Position(0, 0, 7), directions);
+	BOOST_CHECK_EQUAL(end.x, 13);
+	BOOST_CHECK_EQUAL(end.y, 0);
+}
+
+BOOST_AUTO_TEST_CASE(negative_maximum_target_distance_returns_no_path)
+{
+	const auto request = PathRequest::to(Position(5, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, -1)
+	                         .requiringSight(false);
+	std::vector<Direction> directions;
+
+	BOOST_CHECK(PathFinder::find(request, walkable, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(accepted_sight_callback_is_called_with_target)
+{
+	int sightCalls = 0;
+	int32_t lastFromX = -1;
+	int32_t lastFromY = -1;
+	int32_t lastToX = -1;
+	int32_t lastToY = -1;
+	auto sight = [&](const Position& from, const Position& to) {
+		++sightCalls;
+		lastFromX = from.x;
+		lastFromY = from.y;
+		lastToX = to.x;
+		lastToY = to.y;
+		return true;
+	};
+	const auto request = PathRequest::to(Position(2, 0, 7))
+	                         .from(Position(0, 0, 7))
+	                         .distance(0, 0)
+	                         .requiringSight(true)
+	                         .withLineOfSight(false);
+	std::vector<Direction> directions;
+
+	BOOST_REQUIRE(PathFinder::find(request, walkable, directions, std::move(sight)) == PathStatus::Found);
+	BOOST_CHECK_GT(sightCalls, 0);
+	BOOST_CHECK_EQUAL(lastFromX, 2);
+	BOOST_CHECK_EQUAL(lastFromY, 0);
+	BOOST_CHECK_EQUAL(lastToX, 2);
+	BOOST_CHECK_EQUAL(lastToY, 0);
+}
+
+BOOST_AUTO_TEST_CASE(best_effort_match_returns_partial_when_exact_ring_is_blocked)
+{
+	const Position start(3, 0, 7);
+	const Position target(5, 0, 7);
+	auto blockExactRing = [target](int32_t x, int32_t y) -> uint16_t {
+		return std::max(std::abs(x - static_cast<int32_t>(target.x)), std::abs(y - static_cast<int32_t>(target.y))) == 3 ? 0 : 10;
+	};
+	const auto request = PathRequest::to(target)
+	                         .from(start)
+	                         .mode(SearchMode::Reach)
+	                         .distance(1, 3)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+	std::vector<Direction> directions;
+
+	BOOST_CHECK(PathFinder::find(request, blockExactRing, directions) == PathStatus::Partial);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(failed_search_clears_previous_successful_output)
+{
+	const auto successRequest = PathRequest::to(Position(2, 0, 7))
+	                                  .from(Position(0, 0, 7))
+	                                  .distance(0, 0)
+	                                  .requiringSight(false);
+	const auto failureRequest = PathRequest::to(Position(5, 0, 7))
+	                                  .from(Position(0, 0, 7))
+	                                  .distance(0, 0)
+	                                  .requiringSight(false);
+	std::vector<Direction> directions;
+
+	BOOST_REQUIRE(PathFinder::find(successRequest, walkable, directions) == PathStatus::Found);
+	BOOST_REQUIRE(!directions.empty());
+	BOOST_CHECK(PathFinder::find(failureRequest, blocked, directions) == PathStatus::NoPath);
+	BOOST_CHECK(directions.empty());
+}
+
+BOOST_AUTO_TEST_CASE(expected_overload_accepts_partial_path)
+{
+	const Position start(3, 0, 7);
+	const Position target(5, 0, 7);
+	auto blockExactRing = [target](int32_t x, int32_t y) -> uint16_t {
+		return std::max(std::abs(x - static_cast<int32_t>(target.x)), std::abs(y - static_cast<int32_t>(target.y))) == 3 ? 0 : 10;
+	};
+	const auto request = PathRequest::to(target)
+	                         .from(start)
+	                         .mode(SearchMode::Reach)
+	                         .distance(1, 3)
+	                         .requiringSight(false)
+	                         .withLineOfSight(false);
+
+	auto result = PathFinder::find(request, std::move(blockExactRing));
+	BOOST_REQUIRE(result.has_value());
+	BOOST_CHECK(result->empty());
+}


### PR DESCRIPTION
### Pull Request Prelude
- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Introduces a dedicated deterministic pathfinding module with bounded A* search. Supports Reach, Approach, and Flee modes with distance and sight constraints

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated pathfinding system supporting Reach, Approach, and Flee behaviors.
  * Added configurable distance limits, movement costs, line-of-sight checks, and partial-path results.
  * Creature, monster, NPC, player, and Lua pathfinding now use the new request-based options.
  * Added safeguards for unreachable targets, excessive search limits, and different-floor destinations.

* **Tests**
  * Added comprehensive pathfinding tests and performance benchmarks covering movement, obstacles, visibility, costs, and search limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->